### PR TITLE
Fix atelier open editor timing for new workspaces

### DIFF
--- a/src/atelier/cli.py
+++ b/src/atelier/cli.py
@@ -321,6 +321,74 @@ def render_integration_strategy(branch_pr: bool, branch_history: str) -> str:
     return "\n".join(lines)
 
 
+def ensure_workspace_metadata(
+    workspace_dir: Path,
+    agents_path: Path,
+    workspace_config_path: Path,
+    project_root: Path,
+    workspace_name: str,
+    workspace_branch: str,
+    atelier_id: str,
+    branch_pr: bool,
+    branch_history: str,
+) -> None:
+    workspace_config_exists = workspace_config_path.exists()
+    if not workspace_config_exists:
+        workspace_config = {
+            "workspace": {
+                "name": workspace_name,
+                "branch": workspace_branch,
+                "branch_pr": branch_pr,
+                "branch_history": branch_history,
+                "id": f"atelier:{atelier_id}:{workspace_name}",
+            },
+            "atelier": {
+                "version": __version__,
+                "created_at": utc_now(),
+            },
+        }
+        write_json(workspace_config_path, workspace_config)
+
+    if agents_path.exists():
+        return
+
+    if workspace_config_exists:
+        stored_pr, stored_history = read_workspace_branch_settings(workspace_dir)
+        if stored_pr is None or not isinstance(stored_pr, bool):
+            die("workspace missing branch.pr setting")
+        if stored_history is None or not isinstance(stored_history, str):
+            die("workspace missing branch.history setting")
+        stored_history = normalize_branch_history(
+            stored_history, "workspace branch.history"
+        )
+        integration_pr = stored_pr
+        integration_history = stored_history
+    else:
+        integration_pr = branch_pr
+        integration_history = branch_history
+
+    integration_strategy = render_integration_strategy(
+        integration_pr, integration_history
+    )
+    template_override = project_root / "templates" / "AGENTS.md"
+    if template_override.exists():
+        content = template_override.read_text(encoding="utf-8")
+        if "## Integration Strategy" not in content:
+            if content and not content.endswith("\n"):
+                content += "\n"
+            content = content.rstrip() + "\n\n" + integration_strategy + "\n"
+        agents_path.write_text(content, encoding="utf-8")
+    else:
+        agents_path.write_text(
+            WORKSPACE_AGENTS_TEMPLATE.format(
+                atelier_id=atelier_id,
+                workspace_name=workspace_name,
+                integration_strategy=integration_strategy,
+            ),
+            encoding="utf-8",
+        )
+
+
 def read_first_user_message(path: Path) -> str | None:
     try:
         if path.suffix == ".jsonl":
@@ -770,58 +838,17 @@ def open_workspace(args: argparse.Namespace) -> None:
         base_branch = branch_hint or workspace_name
         workspace_branch = branch_override or f"{branch_prefix}{base_branch}"
     ensure_dir(workspace_dir)
-
-    if not workspace_config_exists:
-        workspace_config = {
-            "workspace": {
-                "name": workspace_name,
-                "branch": workspace_branch,
-                "branch_pr": effective_branch_pr,
-                "branch_history": effective_branch_history,
-                "id": f"atelier:{atelier_id}:{workspace_name}",
-            },
-            "atelier": {
-                "version": __version__,
-                "created_at": utc_now(),
-            },
-        }
-        write_json(workspace_config_path, workspace_config)
-
-    if not agents_path.exists():
-        if workspace_config_exists:
-            stored_pr, stored_history = read_workspace_branch_settings(workspace_dir)
-            if stored_pr is None or not isinstance(stored_pr, bool):
-                die("workspace missing branch.pr setting")
-            if stored_history is None or not isinstance(stored_history, str):
-                die("workspace missing branch.history setting")
-            stored_history = normalize_branch_history(
-                stored_history, "workspace branch.history"
-            )
-            integration_pr = stored_pr
-            integration_history = stored_history
-        else:
-            integration_pr = effective_branch_pr
-            integration_history = effective_branch_history
-        integration_strategy = render_integration_strategy(
-            integration_pr, integration_history
-        )
-        template_override = project_root / "templates" / "AGENTS.md"
-        if template_override.exists():
-            content = template_override.read_text(encoding="utf-8")
-            if "## Integration Strategy" not in content:
-                if content and not content.endswith("\n"):
-                    content += "\n"
-                content = content.rstrip() + "\n\n" + integration_strategy + "\n"
-            agents_path.write_text(content, encoding="utf-8")
-        else:
-            agents_path.write_text(
-                WORKSPACE_AGENTS_TEMPLATE.format(
-                    atelier_id=atelier_id,
-                    workspace_name=workspace_name,
-                    integration_strategy=integration_strategy,
-                ),
-                encoding="utf-8",
-            )
+    ensure_workspace_metadata(
+        workspace_dir=workspace_dir,
+        agents_path=agents_path,
+        workspace_config_path=workspace_config_path,
+        project_root=project_root,
+        workspace_name=workspace_name,
+        workspace_branch=workspace_branch,
+        atelier_id=atelier_id,
+        branch_pr=effective_branch_pr,
+        branch_history=effective_branch_history,
+    )
 
     repo_dir = workspace_dir / "repo"
     project_repo_url = config.get("project", {}).get("repo_url")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -54,6 +54,34 @@ def write_project_config(root: Path) -> dict:
     return config
 
 
+def make_open_config(**overrides: object) -> dict:
+    config = {
+        "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
+        "branch": {
+            "default": "main",
+            "prefix": "scott/",
+            "pr": True,
+            "history": "manual",
+        },
+        "agent": {"default": "codex", "options": {"codex": []}},
+        "editor": {"default": "true", "options": {"true": []}},
+        "workspaces": {"root": "workspaces"},
+        "atelier": {
+            "id": "01TEST",
+            "version": "0.2.0",
+            "created_at": "2026-01-01T00:00:00Z",
+        },
+    }
+    config.update(overrides)
+    return config
+
+
+def write_open_config(root: Path, **overrides: object) -> dict:
+    config = make_open_config(**overrides)
+    (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+    return config
+
+
 def init_local_repo(root: Path) -> Path:
     repo = root / "origin"
     repo.mkdir()
@@ -792,19 +820,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_creates_workspace_and_launches(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(root)
 
             original_cwd = Path.cwd()
             os.chdir(root)
@@ -865,19 +881,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_edits_agents_before_clone_when_repo_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(root)
 
             original_cwd = Path.cwd()
             os.chdir(root)
@@ -911,19 +915,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_skips_editor_when_repo_exists(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            config = write_open_config(root)
 
             workspace_dir = root / "workspaces" / "feat-demo"
             repo_dir = workspace_dir / "repo"
@@ -967,24 +959,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_uses_workspace_branch_settings_for_agents(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {
-                    "default": "main",
-                    "prefix": "scott/",
-                    "pr": True,
-                    "history": "manual",
-                },
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(root)
 
             workspace_dir = root / "workspaces" / "feat-demo"
             workspace_dir.mkdir(parents=True)
@@ -1034,19 +1009,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_errors_when_repo_is_not_git_repo(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(root)
 
             workspace_dir = root / "workspaces" / "feat-demo"
             (workspace_dir / "repo").mkdir(parents=True)
@@ -1078,19 +1041,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_errors_when_origin_remote_missing(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(root)
 
             workspace_dir = root / "workspaces" / "feat-demo"
             repo_dir = workspace_dir / "repo"
@@ -1118,19 +1069,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_accepts_workspace_path(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(root)
 
             original_cwd = Path.cwd()
             os.chdir(root)
@@ -1167,19 +1106,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_normalizes_workspace_name_and_preserves_branch_slashes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(root)
 
             original_cwd = Path.cwd()
             os.chdir(root)
@@ -1218,24 +1145,15 @@ class TestOpenWorkspace(TestCase):
     def test_open_renders_direct_integration_strategy(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {
+            write_open_config(
+                root,
+                branch={
                     "default": "main",
                     "prefix": "scott/",
                     "pr": False,
                     "history": "squash",
                 },
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            )
 
             original_cwd = Path.cwd()
             os.chdir(root)
@@ -1271,24 +1189,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_overrides_branch_settings_for_new_workspace(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {
-                    "default": "main",
-                    "prefix": "scott/",
-                    "pr": True,
-                    "history": "manual",
-                },
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(root)
 
             original_cwd = Path.cwd()
             os.chdir(root)
@@ -1340,19 +1241,9 @@ class TestOpenWorkspace(TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             origin_repo = init_local_repo(root)
-            config = {
-                "project": {"name": "demo", "repo_url": str(origin_repo)},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(
+                root, project={"name": "demo", "repo_url": str(origin_repo)}
+            )
 
             original_cwd = Path.cwd()
             os.chdir(root)
@@ -1404,19 +1295,9 @@ class TestOpenWorkspace(TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             origin_repo = init_local_repo_without_feature(root)
-            config = {
-                "project": {"name": "demo", "repo_url": str(origin_repo)},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(
+                root, project={"name": "demo", "repo_url": str(origin_repo)}
+            )
 
             original_cwd = Path.cwd()
             os.chdir(root)
@@ -1449,19 +1330,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_uses_explicit_branch_without_prefix(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(root)
 
             original_cwd = Path.cwd()
             os.chdir(root)
@@ -1512,17 +1381,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_errors_on_branch_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(root)
             workspace_dir = root / "workspaces" / "feat-demo"
             workspace_dir.mkdir(parents=True)
             write_workspace_config(workspace_dir, "feat-demo", "scott/feat-demo")
@@ -1540,17 +1399,7 @@ class TestOpenWorkspace(TestCase):
     def test_open_errors_on_branch_settings_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {"default": "main", "prefix": "scott/"},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(root)
             workspace_dir = root / "workspaces" / "feat-demo"
             workspace_dir.mkdir(parents=True)
             write_workspace_config(workspace_dir, "feat-demo", "scott/feat-demo")
@@ -1573,23 +1422,10 @@ class TestOpenWorkspace(TestCase):
     def test_open_rejects_invalid_branch_history(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
-            config = {
-                "project": {"name": "demo", "repo_url": "git@github.com:org/repo.git"},
-                "branch": {
-                    "default": "main",
-                    "prefix": "scott/",
-                    "history": "sideways",
-                },
-                "agent": {"default": "codex", "options": {"codex": []}},
-                "editor": {"default": "true", "options": {"true": []}},
-                "workspaces": {"root": "workspaces"},
-                "atelier": {
-                    "id": "01TEST",
-                    "version": "0.2.0",
-                    "created_at": "2026-01-01T00:00:00Z",
-                },
-            }
-            (root / ".atelier.json").write_text(json.dumps(config), encoding="utf-8")
+            write_open_config(
+                root,
+                branch={"default": "main", "prefix": "scott/", "history": "sideways"},
+            )
 
             original_cwd = Path.cwd()
             os.chdir(root)


### PR DESCRIPTION
## Summary
- open AGENTS.md before clone only when repo/ is missing
- always create missing workspace metadata files on open
- add tests for editor ordering and skip behavior

## Testing
- just test
- just format
- just lint