### PR TITLE
Enforce epic-as-changeset planning for single-unit work

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -20,8 +20,9 @@ side effects inside the user's repo.
 - **Project**: Identified by the absolute path to a local enlistment. Project
   state lives under the Atelier data directory.
 - **Epic**: Top-level unit of intent that owns a workspace root branch.
-- **Changeset**: Child unit under an epic; each changeset is a branch derived
-  from the root branch.
+- **Changeset**: Executable unit under an epic. It is usually a child bead, but
+  guardrail-sized single-unit work may execute directly on the epic labeled
+  `at:changeset`.
 - **Workspace root branch**: User-facing branch name for the epic. Stored as
   `workspace.root_branch` in epic metadata and labeled
   `workspace:<root_branch>`.

--- a/docs/dogfood.md
+++ b/docs/dogfood.md
@@ -19,7 +19,8 @@ source of truth and that changesets remain reviewable.
 1. Start planner session.
 1. Planner checks messages first and reports any worker requests.
 1. Planner creates a draft epic with acceptance criteria and intent.
-1. Planner creates 1-2 changesets with guardrails.
+1. Planner keeps the epic as the executable changeset when scope fits, or
+   creates child changesets only when decomposition is required.
 1. Planner requests approval to promote the epic from `draft` to `ready`.
 1. Worker session starts on the approved epic.
 1. Worker implements a single changeset and runs required checks.
@@ -36,6 +37,7 @@ source of truth and that changesets remain reviewable.
 
 - Beads contain full intent, constraints, and acceptance criteria.
 - Changesets stay human-sized unless explicitly approved.
+- One-child decomposition is avoided unless rationale is explicitly recorded.
 - Worker never expands scope; ambiguities are surfaced via messages.
 - Planner does not auto-promote epics without user approval.
 

--- a/docs/rethinking-atelier.md
+++ b/docs/rethinking-atelier.md
@@ -181,11 +181,13 @@ Store the worktree path in the epic bead description:
 worktree_path: worktrees/at-abc12
 ```
 
-Changesets should always have a corresponding bead that is a child of the epic.
-In PR-based workflows, each changeset bead maps to its own branch and PR.
-Changesets are still modeled as branches, but parallel work requires separate
-worktrees per changeset session. The epic worktree remains a convenience view
-for the root branch.
+Changesets normally have a corresponding child bead under the epic. For
+single-unit work that fits guardrails, the epic itself may be the executable
+changeset (`at:changeset`) with no children. In PR-based workflows, each
+executable changeset maps to its own branch and PR, except epic-as-changeset
+work that runs on the root branch. Changesets are still modeled as branches, but
+parallel work requires separate worktrees per changeset session. The epic
+worktree remains a convenience view for the root branch.
 
 ## Changeset Branch Naming
 

--- a/src/atelier/skills/plan_changeset_guardrails/SKILL.md
+++ b/src/atelier/skills/plan_changeset_guardrails/SKILL.md
@@ -20,15 +20,23 @@ description: >-
 - If a changeset exceeds the approval threshold (default 800 LOC), notes should
   include an explicit approval record.
 - Guardrails should be recorded in notes or description when exceptions apply.
+- Detect anti-pattern: an epic with exactly one child changeset and no
+  decomposition rationale.
 
 ## Steps
 
+1. Run the deterministic checker script:
+   - `python3 scripts/check_guardrails.py --epic-id <epic_id>`
+   - or
+     `python3 scripts/check_guardrails.py --changeset-id <id> [--changeset-id <id> ...]`
 1. Resolve target changesets:
-   - If `changeset_ids` is provided, use those.
+   - If `changeset_ids` is provided, validate those.
    - Else list children of `epic_id` with `at:changeset`.
 1. For each changeset, inspect description/notes:
    - Look for a LOC estimate (e.g., `loc`, `LOC`, `estimate`).
    - If a large estimate is found (>800), ensure approval is recorded.
+1. If an epic has exactly one child changeset, require explicit decomposition
+   rationale in the epic or child notes/description.
 1. Summarize any violations and send a message to the planner/overseer with
    actionable fixes.
 1. Do not block planning; use messages and bead notes instead.
@@ -36,4 +44,5 @@ description: >-
 ## Verification
 
 - Violations are reported with bead ids and missing guardrail details.
+- One-child anti-pattern warnings are reported when rationale is missing.
 - No beads are blocked or re-labeled automatically.

--- a/src/atelier/skills/plan_changeset_guardrails/scripts/check_guardrails.py
+++ b/src/atelier/skills/plan_changeset_guardrails/scripts/check_guardrails.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Check planner guardrails for epic-as-changeset and decomposition rules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_LOC_TRIGGER = re.compile(r"\b(?:loc|estimate)\b", re.IGNORECASE)
+_NUMBER = re.compile(r"\b\d{2,5}\b")
+_APPROVAL = re.compile(r"\b(?:approve|approved|approval|sign[- ]?off|ok(?:ay)?)\b", re.IGNORECASE)
+_RATIONALE = re.compile(
+    r"\b(?:rationale|split because|split due to|reviewability|dependency|sequencing)\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class _GuardrailReport:
+    path_summary: str | None
+    violations: list[str]
+    checked_ids: list[str]
+
+
+def _run_bd_json(args: list[str], *, beads_dir: str | None) -> list[dict[str, object]]:
+    command = ["bd", *args]
+    env = dict(os.environ)
+    if beads_dir:
+        env["BEADS_DIR"] = beads_dir
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+    except FileNotFoundError:
+        print("error: missing required command: bd", file=sys.stderr)
+        raise SystemExit(1)
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        print(f"error: bd command failed ({' '.join(command)}): {detail}", file=sys.stderr)
+        raise SystemExit(1)
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return []
+    payload = json.loads(raw)
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        return [payload]
+    return []
+
+
+def _issue_id(issue: dict[str, object]) -> str:
+    return str(issue.get("id") or "").strip()
+
+
+def _labels(issue: dict[str, object]) -> set[str]:
+    labels = issue.get("labels")
+    if not isinstance(labels, list):
+        return set()
+    return {str(label) for label in labels if label is not None}
+
+
+def _normalize_text(value: object) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        return "\n".join(str(item) for item in value if item is not None)
+    return ""
+
+
+def _text_blob(issue: dict[str, object]) -> str:
+    fields = (
+        "description",
+        "notes",
+        "acceptance",
+        "acceptance_criteria",
+        "design",
+    )
+    return "\n".join(
+        part for part in (_normalize_text(issue.get(field)) for field in fields) if part.strip()
+    )
+
+
+def _extract_loc_estimate(text: str) -> int | None:
+    values: list[int] = []
+    for line in text.splitlines():
+        if not _LOC_TRIGGER.search(line):
+            continue
+        numbers = [int(value) for value in _NUMBER.findall(line)]
+        if numbers:
+            values.append(max(numbers))
+    if not values:
+        return None
+    return max(values)
+
+
+def _load_issue(issue_id: str, *, beads_dir: str | None) -> dict[str, object] | None:
+    issues = _run_bd_json(["show", issue_id, "--json"], beads_dir=beads_dir)
+    if not issues:
+        return None
+    return issues[0]
+
+
+def _list_child_changesets(epic_id: str, *, beads_dir: str | None) -> list[dict[str, object]]:
+    children = _run_bd_json(
+        ["list", "--parent", epic_id, "--label", "at:changeset", "--json"],
+        beads_dir=beads_dir,
+    )
+    full_children: list[dict[str, object]] = []
+    for item in children:
+        child_id = _issue_id(item)
+        if not child_id:
+            continue
+        child_issue = _load_issue(child_id, beads_dir=beads_dir)
+        if child_issue is not None:
+            full_children.append(child_issue)
+    return full_children
+
+
+def _evaluate_guardrails(
+    *,
+    epic_issue: dict[str, object] | None,
+    child_changesets: list[dict[str, object]],
+    target_changesets: list[dict[str, object]],
+) -> _GuardrailReport:
+    violations: list[str] = []
+    path_summary: str | None = None
+
+    for issue in target_changesets:
+        issue_id = _issue_id(issue) or "(unknown)"
+        text = _text_blob(issue)
+        estimate = _extract_loc_estimate(text)
+        if estimate is None:
+            violations.append(f"{issue_id}: missing LOC estimate in notes/description.")
+            continue
+        if estimate > 800 and not _APPROVAL.search(text):
+            violations.append(
+                f"{issue_id}: LOC estimate {estimate} exceeds 800 without explicit approval note."
+            )
+
+    if epic_issue is not None:
+        epic_id = _issue_id(epic_issue) or "(epic)"
+        if not child_changesets:
+            if "at:changeset" in _labels(epic_issue):
+                path_summary = (
+                    f"{epic_id}: compliant single-unit path (epic is the executable changeset)."
+                )
+            else:
+                path_summary = f"{epic_id}: no child changesets present."
+                violations.append(
+                    f"{epic_id}: no child changesets and epic is not labeled at:changeset."
+                )
+        elif len(child_changesets) == 1:
+            child = child_changesets[0]
+            child_id = _issue_id(child) or "(child)"
+            rationale_text = "\n".join((_text_blob(epic_issue), _text_blob(child)))
+            if _RATIONALE.search(rationale_text):
+                path_summary = (
+                    f"{epic_id}: one child changeset ({child_id}) with explicit rationale."
+                )
+            else:
+                path_summary = f"{epic_id}: one child changeset ({child_id}) without rationale."
+                violations.append(
+                    f"{epic_id}: one-child anti-pattern; add decomposition rationale "
+                    f"for {child_id} or keep the epic as the executable changeset."
+                )
+        else:
+            path_summary = (
+                f"{epic_id}: multi-unit decomposition ({len(child_changesets)} children)."
+            )
+
+    checked_ids = [_issue_id(issue) for issue in target_changesets if _issue_id(issue)]
+    return _GuardrailReport(
+        path_summary=path_summary,
+        violations=violations,
+        checked_ids=checked_ids,
+    )
+
+
+def _render_report(report: _GuardrailReport) -> str:
+    lines = ["Planner changeset guardrails report:"]
+    if report.path_summary:
+        lines.append(f"- Path: {report.path_summary}")
+    lines.append(f"- Checked changesets: {len(report.checked_ids)}")
+    if report.checked_ids:
+        lines.append(f"- IDs: {', '.join(report.checked_ids)}")
+    if report.violations:
+        lines.append("- Violations:")
+        for violation in report.violations:
+            lines.append(f"  - {violation}")
+    else:
+        lines.append("- Violations: none")
+    return "\n".join(lines)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--epic-id", help="Epic id to validate")
+    parser.add_argument(
+        "--changeset-id",
+        action="append",
+        dest="changeset_ids",
+        default=[],
+        help="Changeset id to validate (repeatable)",
+    )
+    parser.add_argument(
+        "--beads-dir",
+        default=os.environ.get("BEADS_DIR", ""),
+        help="Beads directory path (defaults to BEADS_DIR env var)",
+    )
+    args = parser.parse_args()
+
+    epic_id = str(args.epic_id or "").strip()
+    changeset_ids = [str(value).strip() for value in args.changeset_ids if str(value).strip()]
+    beads_dir = str(args.beads_dir or "").strip() or None
+    if beads_dir and not Path(beads_dir).exists():
+        print(f"error: beads dir not found: {beads_dir}", file=sys.stderr)
+        raise SystemExit(1)
+    if not epic_id and not changeset_ids:
+        parser.error("provide --epic-id or at least one --changeset-id")
+
+    epic_issue = _load_issue(epic_id, beads_dir=beads_dir) if epic_id else None
+    child_changesets = _list_child_changesets(epic_id, beads_dir=beads_dir) if epic_id else []
+
+    target_changesets: list[dict[str, object]] = []
+    if changeset_ids:
+        for changeset_id in changeset_ids:
+            issue = _load_issue(changeset_id, beads_dir=beads_dir)
+            if issue is not None:
+                target_changesets.append(issue)
+    elif child_changesets:
+        target_changesets = child_changesets
+    elif epic_issue is not None and "at:changeset" in _labels(epic_issue):
+        target_changesets = [epic_issue]
+
+    report = _evaluate_guardrails(
+        epic_issue=epic_issue,
+        child_changesets=child_changesets,
+        target_changesets=target_changesets,
+    )
+    print(_render_report(report))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/atelier/skills/plan_changesets/SKILL.md
+++ b/src/atelier/skills/plan_changesets/SKILL.md
@@ -22,6 +22,9 @@ children.
 - Separate renames from behavioral changes.
 - Prefer additive-first changesets.
 - Keep changesets reviewable (~200–400 LOC; split when >800 LOC).
+- Avoid one-child decomposition by default. If a split would produce exactly one
+  child changeset, keep the epic as the executable changeset unless you record
+  explicit decomposition rationale.
 - Keep tests with the nearest production change.
 - Ask for an estimated LOC range per changeset and confirm approval when a
   changeset exceeds ~800 LOC (unless purely mechanical).
@@ -33,6 +36,10 @@ children.
 
 1. For each changeset, create a bead:
    - `bd create --parent <epic_id> --type task --label at:changeset --label cs:ready --title <title> --acceptance <acceptance>`
+1. If decomposition would produce exactly one child changeset, stop and either:
+   - keep the epic as the executable changeset, or
+   - record explicit decomposition rationale in epic/changeset notes before
+     creating the child.
 1. If the changeset is not ready, use `cs:planned` instead of `cs:ready`.
 1. Capture an estimated LOC range and record it in notes.
 1. If a changeset violates guardrails (especially >800 LOC), pause and request
@@ -43,3 +50,5 @@ children.
 
 - Changeset beads exist under the epic with `at:changeset` labels.
 - Decomposition happened only when needed for scope/dependency/reviewability.
+- Any one-child decomposition has explicit rationale recorded in notes or
+  description.

--- a/src/atelier/skills/plan_promote_epic/SKILL.md
+++ b/src/atelier/skills/plan_promote_epic/SKILL.md
@@ -22,6 +22,8 @@ description: >-
 - Changeset guardrails have been validated (run `plan_changeset_guardrails`
   first).
 - Do not require child changesets when the epic itself is guardrail-sized.
+- If the epic has exactly one child changeset, explicit decomposition rationale
+  must be recorded before promotion.
 
 ## Steps
 
@@ -30,6 +32,10 @@ description: >-
 1. If there are no child changesets and the epic is single-changeset sized:
    - Add `at:changeset` to the epic.
    - Add `cs:ready` to the epic.
+1. If there is exactly one child changeset:
+   - Verify decomposition rationale is recorded in epic/child notes.
+   - If rationale is missing, keep the epic as executable changeset or add the
+     rationale before promotion.
 1. If the epic is not single-changeset sized, create only the minimum child
    changesets needed for execution and reviewability.
 1. Summarize the executable unit(s) for the user (child changesets or the epic
@@ -48,3 +54,4 @@ description: >-
   `cs:ready`.
 - If the epic has no child changesets, the epic itself is labeled `at:changeset`
   \+ `cs:ready`.
+- Any one-child decomposition has explicit rationale in notes/description.

--- a/src/atelier/skills/plan_split_tasks/SKILL.md
+++ b/src/atelier/skills/plan_split_tasks/SKILL.md
@@ -19,6 +19,11 @@ review-sized unit, keep it as the executable changeset.
 
 ## Steps
 
+1. Confirm decomposition is necessary for scope, dependency sequencing, or
+   reviewability.
+1. If decomposition would create exactly one child changeset, keep the epic as
+   the executable changeset unless explicit decomposition rationale is recorded
+   in notes/description.
 1. Create changeset beads under the epic:
    - `bd create --parent <epic_id> --type task --label at:changeset --label cs:planned --title <title> --acceptance <acceptance>`
 1. Create nested changesets under a parent changeset when needed:
@@ -28,3 +33,4 @@ review-sized unit, keep it as the executable changeset.
 ## Verification
 
 - All executable work items are labeled `at:changeset` (never `at:subtask`).
+- One-child decompositions include explicit rationale.

--- a/src/atelier/templates/AGENTS.planner.md.tmpl
+++ b/src/atelier/templates/AGENTS.planner.md.tmpl
@@ -94,6 +94,8 @@ If code changes are needed, create beads and leave implementation to workers.
   changeset (no child changesets required).
 - Split into child changesets only when scope, dependencies, or reviewability
   require it.
+- Treat "exactly one child changeset" as an anti-pattern unless explicit
+  decomposition rationale is recorded.
 - Use the guardrails in the `plan_changesets` skill.
 - Validate guardrails with `plan_changeset_guardrails`.
 - Keep changesets reviewable and human-sized.

--- a/tests/atelier/skills/test_plan_changeset_guardrails_script.py
+++ b/tests/atelier/skills/test_plan_changeset_guardrails_script.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_script_module():
+    script_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "atelier"
+        / "skills"
+        / "plan_changeset_guardrails"
+        / "scripts"
+        / "check_guardrails.py"
+    )
+    spec = importlib.util.spec_from_file_location("check_guardrails", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_evaluate_guardrails_accepts_single_unit_epic_path() -> None:
+    module = _load_script_module()
+    epic = {
+        "id": "at-epic",
+        "labels": ["at:epic", "at:changeset"],
+        "description": "LOC estimate: 320",
+    }
+
+    report = module._evaluate_guardrails(
+        epic_issue=epic,
+        child_changesets=[],
+        target_changesets=[epic],
+    )
+
+    assert "single-unit path" in str(report.path_summary)
+    assert report.violations == []
+
+
+def test_evaluate_guardrails_flags_one_child_without_rationale() -> None:
+    module = _load_script_module()
+    epic = {"id": "at-epic", "labels": ["at:epic"], "description": "Intent: ship parser update"}
+    child = {"id": "at-epic.1", "labels": ["at:changeset"], "description": "LOC estimate: 210"}
+
+    report = module._evaluate_guardrails(
+        epic_issue=epic,
+        child_changesets=[child],
+        target_changesets=[child],
+    )
+
+    assert any("one-child anti-pattern" in item for item in report.violations)
+
+
+def test_evaluate_guardrails_allows_one_child_with_rationale() -> None:
+    module = _load_script_module()
+    epic = {
+        "id": "at-epic",
+        "labels": ["at:epic"],
+        "notes": "Decomposition rationale: split due to dependency sequencing.",
+    }
+    child = {"id": "at-epic.1", "labels": ["at:changeset"], "description": "LOC estimate: 260"}
+
+    report = module._evaluate_guardrails(
+        epic_issue=epic,
+        child_changesets=[child],
+        target_changesets=[child],
+    )
+
+    assert "with explicit rationale" in str(report.path_summary)
+    assert not any("one-child anti-pattern" in item for item in report.violations)
+
+
+def test_evaluate_guardrails_flags_large_changeset_without_approval() -> None:
+    module = _load_script_module()
+    child = {
+        "id": "at-epic.1",
+        "labels": ["at:changeset"],
+        "description": "LOC estimate: 920\nGuardrails: data migration",
+    }
+
+    report = module._evaluate_guardrails(
+        epic_issue=None,
+        child_changesets=[],
+        target_changesets=[child],
+    )
+
+    assert any("exceeds 800 without explicit approval" in item for item in report.violations)
+
+
+def test_evaluate_guardrails_reports_multi_unit_decomposition() -> None:
+    module = _load_script_module()
+    epic = {"id": "at-epic", "labels": ["at:epic"]}
+    children = [
+        {"id": "at-epic.1", "labels": ["at:changeset"], "description": "LOC estimate: 220"},
+        {"id": "at-epic.2", "labels": ["at:changeset"], "description": "LOC estimate: 240"},
+    ]
+
+    report = module._evaluate_guardrails(
+        epic_issue=epic,
+        child_changesets=children,
+        target_changesets=children,
+    )
+
+    assert "multi-unit decomposition" in str(report.path_summary)
+    assert report.violations == []

--- a/tests/atelier/test_dogfood_doc.py
+++ b/tests/atelier/test_dogfood_doc.py
@@ -7,3 +7,4 @@ def test_dogfood_doc_exists() -> None:
     doc_path = Path(__file__).resolve().parents[2] / "docs" / "dogfood.md"
     content = doc_path.read_text(encoding="utf-8")
     assert "Golden Path" in content
+    assert "keeps the epic as the executable changeset" in content

--- a/tests/atelier/test_planner_agents_template.py
+++ b/tests/atelier/test_planner_agents_template.py
@@ -22,3 +22,5 @@ def test_planner_agents_template_contains_core_sections() -> None:
     assert "plan_promote_epic" in content
     assert "planner_startup_check" in content
     assert "epic_list" in content
+    assert "one child changeset" in content
+    assert "decomposition rationale" in content

--- a/tests/atelier/test_skills.py
+++ b/tests/atelier/test_skills.py
@@ -178,3 +178,25 @@ def test_packaged_skill_docs_include_yaml_frontmatter() -> None:
     for name, definition in definitions.items():
         text = definition.files["SKILL.md"].decode("utf-8").lstrip()
         assert text.startswith("---\n"), f"{name} SKILL.md missing YAML frontmatter"
+
+
+def test_plan_changesets_skill_requires_rationale_for_one_child_split() -> None:
+    skill = skills.load_packaged_skills()["plan_changesets"]
+    text = skill.files["SKILL.md"].decode("utf-8")
+    assert "one child changeset" in text
+    assert "decomposition rationale" in text
+
+
+def test_plan_changeset_guardrails_skill_mentions_checker_script() -> None:
+    skill = skills.load_packaged_skills()["plan_changeset_guardrails"]
+    text = skill.files["SKILL.md"].decode("utf-8")
+    assert "scripts/check_guardrails.py" in text
+    assert "one child changeset" in text
+    assert "decomposition rationale" in text
+
+
+def test_plan_promote_epic_skill_requires_one_child_rationale() -> None:
+    skill = skills.load_packaged_skills()["plan_promote_epic"]
+    text = skill.files["SKILL.md"].decode("utf-8")
+    assert "exactly one child changeset" in text
+    assert "decomposition rationale" in text


### PR DESCRIPTION
## Summary
Enforce planner behavior so single-unit work executes on the epic itself, and decomposition into child changesets only happens when explicitly justified.

## What Changed
- Updated planner skills and planner template guidance to default to epic-as-changeset for review-sized, single-unit work.
- Added deterministic guardrail checks for:
  - missing LOC estimates,
  - LOC estimates above 800 without explicit approval,
  - one-child epic decomposition without a recorded rationale.
- Updated promotion/readiness guidance so epic-level executable changesets remain a first-class path.
- Added tests and docs covering compliant single-unit planning and justified decomposition paths.

## Acceptance Criteria Coverage
- Planner defaults to epic-as-changeset for singular, guardrail-sized work.
- One-child decomposition now requires explicit rationale in planning text.
- Guardrails surface the one-child anti-pattern when rationale is missing.
- Promotion/readiness flow supports epic-level executable changesets.
- Deterministic checks cover compliant and justified planning paths.

## Validation
- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #94
