### PR TITLE
Enforce planner non-ownership for executable work beads

### DIFF
--- a/src/atelier/templates/AGENTS.planner.md.tmpl
+++ b/src/atelier/templates/AGENTS.planner.md.tmpl
@@ -43,6 +43,12 @@ record constraints in beads. You do not implement code. You do not commit.
 
 Your work must leave a clear, self-contained plan that a worker can execute.
 
+Planner ownership boundary:
+- Do not claim or keep assignee ownership on executable work beads
+  (`at:epic` / `at:changeset`).
+- If you encounter planner-owned executable work, mark it as a policy violation
+  and route recovery to workers/overseer instead of silently reassigning.
+
 ## Project Architecture
 
 Project root: {{ project_root }}
@@ -132,6 +138,7 @@ Both an agent and a developer should be able to implement from beads alone.
 - Implement code changes.
 - Commit or push code.
 - Treat external tickets as authoritative.
+- Claim or hold assignee ownership of executable epics/changesets.
 
 ## Failure Modes to Avoid
 

--- a/src/atelier/worker/session/startup.py
+++ b/src/atelier/worker/session/startup.py
@@ -618,6 +618,8 @@ def run_startup_contract_service(
                 continue
             if issue_id == hooked_epic:
                 continue
+            if worker_selection.has_planner_executable_assignee(issue):
+                continue
             if is_excluded(issue_id, stage="review-feedback"):
                 continue
             status = str(issue.get("status") or "")

--- a/src/atelier/worker/work_startup_runtime.py
+++ b/src/atelier/worker/work_startup_runtime.py
@@ -152,7 +152,15 @@ def _no_eligible_epics_summary(
     """
     ready = filter_epics(issues, require_unassigned=True)
     assigned = filter_epics(issues, assignee=agent_id)
+    planner_owned = worker_selection.planner_owned_executable_issues(issues)
     timestamp = dt.datetime.now(tz=dt.timezone.utc).isoformat()
+    ownership_detail = ", ".join(
+        sorted(
+            str(issue.get("id") or "")
+            for issue in planner_owned
+            if isinstance(issue.get("id"), str) and issue.get("id")
+        )[:5]
+    )
     return [
         "No eligible epics available.",
         f"- Agent: {agent_id}",
@@ -160,6 +168,12 @@ def _no_eligible_epics_summary(
         f"- Total epics: {len(issues)}",
         f"- Ready epics: {len(ready)}",
         f"- Assigned epics: {len(assigned)}",
+        f"- Planner-owned executable epics: {len(planner_owned)}",
+        (
+            f"- Ownership violations: {ownership_detail}"
+            if ownership_detail
+            else "- Ownership violations: none"
+        ),
         f"- Timestamp: {timestamp}",
     ]
 

--- a/tests/atelier/test_planner_agents_template.py
+++ b/tests/atelier/test_planner_agents_template.py
@@ -24,3 +24,4 @@ def test_planner_agents_template_contains_core_sections() -> None:
     assert "epic_list" in content
     assert "one child changeset" in content
     assert "decomposition rationale" in content
+    assert "Do not claim or keep assignee ownership" in content


### PR DESCRIPTION
# Summary

- enforce a strict planner/worker ownership boundary so planner agents cannot own executable epics or changesets

# Changes

- add worker-side ownership guards that skip planner-owned executable epics during startup selection and review-feedback prioritization
- add claim-time validation to reject attempts to continue execution when an executable epic is assigned to a planner agent
- surface ownership policy violations in `atelier status` JSON/table output and in no-eligible startup summaries
- update the planner AGENTS template to explicitly prohibit planner assignee ownership of executable work and document recovery expectations
- add tests for invalid planner executable ownership and valid planner message ownership behavior

# Testing

- `just format`
- `just lint`
- `env -u ATELIER_AGENT_ID -u ATELIER_AGENT_SESSION just test`

# Tickets

- Fixes #96

# Risks / Rollout

- low risk; behavior changes are bounded to ownership checks, startup selection filtering, and status reporting

# Notes

- no data migration is performed automatically; invalid planner-owned executable beads are now explicitly flagged for correction