### PR TITLE
Allow stacked intra-epic changesets after review handoff

### DIFF
--- a/src/atelier/changeset_fields.py
+++ b/src/atelier/changeset_fields.py
@@ -28,6 +28,10 @@ def root_branch(issue: dict[str, object]) -> str | None:
     return normalized_field(issue_fields(issue), "changeset.root_branch")
 
 
+def parent_branch(issue: dict[str, object]) -> str | None:
+    return normalized_field(issue_fields(issue), "changeset.parent_branch")
+
+
 def pr_url(issue: dict[str, object]) -> str | None:
     return normalized_field(issue_fields(issue), "pr_url")
 

--- a/src/atelier/worker/work_finalization_runtime.py
+++ b/src/atelier/worker/work_finalization_runtime.py
@@ -12,6 +12,7 @@ from .work_finalization_reconcile import (
     reconcile_blocked_merged_changesets,
 )
 from .work_finalization_state import (
+    changeset_has_review_handoff_signal,
     changeset_integration_signal,
     changeset_parent_branch,
     changeset_pr_url,
@@ -34,6 +35,7 @@ from .work_finalization_state import (
 )
 
 __all__ = [
+    "changeset_has_review_handoff_signal",
     "changeset_integration_signal",
     "changeset_parent_branch",
     "changeset_pr_url",

--- a/src/atelier/worker/work_startup_runtime.py
+++ b/src/atelier/worker/work_startup_runtime.py
@@ -16,6 +16,7 @@ from ..worker import selection as worker_selection
 from ..worker.models import StartupContractResult
 from ..worker.session import startup as worker_startup
 from .work_finalization_runtime import (
+    changeset_has_review_handoff_signal,
     changeset_waiting_on_review_or_signals,
     has_open_descendant_changesets,
     is_changeset_in_progress,
@@ -75,6 +76,22 @@ class _NextChangesetService(worker_startup.NextChangesetService):
             repo_root=self._repo_root,
             branch_pr=branch_pr,
             branch_pr_strategy=branch_pr_strategy,
+            git_path=git_path,
+        )
+
+    def changeset_has_review_handoff_signal(
+        self,
+        issue: dict[str, object],
+        *,
+        repo_slug: str | None,
+        branch_pr: bool,
+        git_path: str | None,
+    ) -> bool:
+        return changeset_has_review_handoff_signal(
+            issue,
+            repo_slug=repo_slug,
+            repo_root=self._repo_root,
+            branch_pr=branch_pr,
             git_path=git_path,
         )
 

--- a/tests/atelier/test_changeset_fields.py
+++ b/tests/atelier/test_changeset_fields.py
@@ -6,18 +6,28 @@ def test_changeset_fields_extract_core_values() -> None:
         "description": (
             "changeset.work_branch: feat/work\n"
             "changeset.root_branch: feat/root\n"
+            "changeset.parent_branch: feat/base\n"
             "pr_url: https://example.test/pr/1\n"
             "pr_state: In-Review\n"
         )
     }
     assert changeset_fields.work_branch(issue) == "feat/work"
     assert changeset_fields.root_branch(issue) == "feat/root"
+    assert changeset_fields.parent_branch(issue) == "feat/base"
     assert changeset_fields.pr_url(issue) == "https://example.test/pr/1"
     assert changeset_fields.review_state(issue) == "in-review"
 
 
 def test_changeset_fields_normalizes_empty_and_null_values() -> None:
-    issue = {"description": ("changeset.work_branch: null\nchangeset.root_branch:\npr_url:   \n")}
+    issue = {
+        "description": (
+            "changeset.work_branch: null\n"
+            "changeset.root_branch:\n"
+            "changeset.parent_branch: null\n"
+            "pr_url:   \n"
+        )
+    }
     assert changeset_fields.work_branch(issue) is None
     assert changeset_fields.root_branch(issue) is None
+    assert changeset_fields.parent_branch(issue) is None
     assert changeset_fields.pr_url(issue) is None

--- a/tests/atelier/worker/test_session_next_changeset.py
+++ b/tests/atelier/worker/test_session_next_changeset.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+from atelier.worker.session import startup
+
+
+class FakeNextChangesetService:
+    def __init__(
+        self,
+        *,
+        issues_by_id: dict[str, dict[str, object]],
+        ready_changesets: list[dict[str, object]],
+        descendants: list[dict[str, object]],
+        review_handoff_by_id: dict[str, bool] | None = None,
+        waiting_by_id: dict[str, bool] | None = None,
+    ) -> None:
+        self._issues_by_id = issues_by_id
+        self._ready_changesets = ready_changesets
+        self._descendants = descendants
+        self._review_handoff_by_id = review_handoff_by_id or {}
+        self._waiting_by_id = waiting_by_id or {}
+
+    def show_issue(self, issue_id: str) -> dict[str, object] | None:
+        return self._issues_by_id.get(issue_id)
+
+    def ready_changesets(self, *, epic_id: str) -> list[dict[str, object]]:
+        del epic_id
+        return list(self._ready_changesets)
+
+    def issue_labels(self, issue: dict[str, object]) -> set[str]:
+        labels = issue.get("labels")
+        if not isinstance(labels, list):
+            return set()
+        return {str(label) for label in labels if isinstance(label, str)}
+
+    def is_changeset_ready(self, issue: dict[str, object]) -> bool:
+        labels = self.issue_labels(issue)
+        status = str(issue.get("status") or "").strip().lower()
+        return "at:changeset" in labels and status in {"open", "in_progress"}
+
+    def changeset_waiting_on_review_or_signals(
+        self,
+        issue: dict[str, object],
+        *,
+        repo_slug: str | None,
+        branch_pr: bool,
+        branch_pr_strategy: object,
+        git_path: str | None,
+    ) -> bool:
+        del repo_slug, branch_pr, branch_pr_strategy, git_path
+        issue_id = issue.get("id")
+        if not isinstance(issue_id, str):
+            return False
+        return self._waiting_by_id.get(issue_id, False)
+
+    def is_changeset_recovery_candidate(
+        self,
+        issue: dict[str, object],
+        *,
+        repo_slug: str | None,
+        branch_pr: bool,
+        git_path: str | None,
+    ) -> bool:
+        del issue, repo_slug, branch_pr, git_path
+        return False
+
+    def changeset_has_review_handoff_signal(
+        self,
+        issue: dict[str, object],
+        *,
+        repo_slug: str | None,
+        branch_pr: bool,
+        git_path: str | None,
+    ) -> bool:
+        del repo_slug, branch_pr, git_path
+        issue_id = issue.get("id")
+        if not isinstance(issue_id, str):
+            return False
+        return self._review_handoff_by_id.get(issue_id, False)
+
+    def has_open_descendant_changesets(self, changeset_id: str) -> bool:
+        del changeset_id
+        return False
+
+    def list_descendant_changesets(
+        self,
+        parent_id: str,
+        *,
+        include_closed: bool,
+    ) -> list[dict[str, object]]:
+        del parent_id, include_closed
+        return list(self._descendants)
+
+    def is_changeset_in_progress(self, issue: dict[str, object]) -> bool:
+        return str(issue.get("status") or "").strip().lower() == "in_progress"
+
+
+def _changeset(
+    issue_id: str,
+    *,
+    dependencies: list[str] | None = None,
+    parent_branch: str | None = None,
+    work_branch: str | None = None,
+    status: str = "open",
+) -> dict[str, object]:
+    fields: list[str] = []
+    if parent_branch is not None:
+        fields.append(f"changeset.parent_branch: {parent_branch}")
+    if work_branch is not None:
+        fields.append(f"changeset.work_branch: {work_branch}")
+    description = "\n".join(fields)
+    if description:
+        description = f"{description}\n"
+    payload: dict[str, object] = {
+        "id": issue_id,
+        "status": status,
+        "labels": ["at:changeset"],
+        "description": description,
+    }
+    if dependencies is not None:
+        payload["dependencies"] = list(dependencies)
+    return payload
+
+
+def _context() -> startup.NextChangesetContext:
+    return startup.NextChangesetContext(
+        epic_id="at-epic",
+        repo_slug="org/repo",
+        branch_pr=True,
+        branch_pr_strategy="sequential",
+        git_path="git",
+    )
+
+
+def _epic() -> dict[str, object]:
+    return {"id": "at-epic", "status": "open", "labels": ["at:epic", "at:ready"]}
+
+
+def test_next_changeset_service_allows_stacked_intra_epic_review_handoff() -> None:
+    blocker = _changeset("at-epic.1", work_branch="feat/at-epic.1")
+    downstream = _changeset(
+        "at-epic.2",
+        dependencies=["at-epic.1"],
+        parent_branch="feat/at-epic.1",
+        work_branch="feat/at-epic.2",
+    )
+    service = FakeNextChangesetService(
+        issues_by_id={"at-epic": _epic(), blocker["id"]: blocker, downstream["id"]: downstream},
+        ready_changesets=[],
+        descendants=[blocker, downstream],
+        review_handoff_by_id={"at-epic.1": True},
+        waiting_by_id={"at-epic.1": True},
+    )
+
+    selected = startup.next_changeset_service(context=_context(), service=service)
+
+    assert selected is not None
+    assert selected["id"] == "at-epic.2"
+
+
+def test_next_changeset_service_blocks_when_review_handoff_evidence_missing() -> None:
+    blocker = _changeset("at-epic.1", work_branch="feat/at-epic.1")
+    downstream = _changeset(
+        "at-epic.2",
+        dependencies=["at-epic.1"],
+        parent_branch="feat/at-epic.1",
+        work_branch="feat/at-epic.2",
+    )
+    service = FakeNextChangesetService(
+        issues_by_id={"at-epic": _epic(), blocker["id"]: blocker, downstream["id"]: downstream},
+        ready_changesets=[],
+        descendants=[blocker, downstream],
+        review_handoff_by_id={"at-epic.1": False},
+        waiting_by_id={"at-epic.1": True},
+    )
+
+    selected = startup.next_changeset_service(context=_context(), service=service)
+
+    assert selected is None
+
+
+def test_next_changeset_service_blocks_when_branch_lineage_is_broken() -> None:
+    blocker = _changeset("at-epic.1", work_branch="feat/at-epic.1")
+    downstream = _changeset(
+        "at-epic.2",
+        dependencies=["at-epic.1"],
+        parent_branch="feat/not-the-blocker",
+        work_branch="feat/at-epic.2",
+    )
+    service = FakeNextChangesetService(
+        issues_by_id={"at-epic": _epic(), blocker["id"]: blocker, downstream["id"]: downstream},
+        ready_changesets=[],
+        descendants=[blocker, downstream],
+        review_handoff_by_id={"at-epic.1": True},
+        waiting_by_id={"at-epic.1": True},
+    )
+
+    selected = startup.next_changeset_service(context=_context(), service=service)
+
+    assert selected is None
+
+
+def test_next_changeset_service_keeps_cross_epic_dependencies_blocked() -> None:
+    blocker = _changeset("at-other.1", work_branch="feat/at-other.1")
+    downstream = _changeset(
+        "at-epic.2",
+        dependencies=["at-other.1"],
+        parent_branch="feat/at-other.1",
+        work_branch="feat/at-epic.2",
+    )
+    service = FakeNextChangesetService(
+        issues_by_id={"at-epic": _epic(), blocker["id"]: blocker, downstream["id"]: downstream},
+        ready_changesets=[],
+        descendants=[downstream],
+        review_handoff_by_id={"at-other.1": True},
+    )
+
+    selected = startup.next_changeset_service(context=_context(), service=service)
+
+    assert selected is None


### PR DESCRIPTION
# Summary

- Allow worker startup selection to treat a same-epic dependency as runnable when the blocker has been handed off for review and branch lineage proves stacked ordering.
- Keep strict dependency behavior for cross-epic and non-handoff blockers.

# Changes

- Added startup dependency evaluation that supplements `bd ready` with same-epic stacked eligibility checks.
- Added explicit fail-closed gates for missing dependency metadata, missing review handoff evidence, and broken branch lineage.
- Added a review-handoff signal helper that requires pushed/open PR lifecycle evidence from remote branch + PR state.
- Added `changeset.parent_branch` parsing helper used for lineage validation.
- Added tests covering:
  - eligible stacked intra-epic handoff
  - missing handoff evidence
  - broken lineage
  - cross-epic dependency safety

# Testing

- `just format`
- `just lint`
- `just test` (run with worker session env vars unset to avoid unrelated `test_agent_home` env coupling)

# Tickets

- Fixes #93

# Risks / Rollout

- The new startup fallback now considers additional descendant changesets; behavior remains fail-closed when any required signal is missing.

# Notes

- This change does not alter cross-epic dependency semantics or automate merge orchestration.