### PR TITLE
Fix PR base resolution and restack stacked changesets

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -23,6 +23,18 @@ side effects inside the user's repo.
 - **Changeset**: Executable unit under an epic. It is usually a child bead, but
   guardrail-sized single-unit work may execute directly on the epic labeled
   `at:changeset`.
+- **PR base alignment**: Atelier resolves review PR bases from integration
+  lineage rather than raw branch-cut ancestry.
+  - First reviewable changesets target `workspace.parent_branch` (for example
+    `main`) even when branch metadata stores `changeset.parent_branch` equal to
+    the root branch.
+  - Stacked descendants may target predecessor work branches before predecessor
+    integration.
+  - After predecessor integration, Atelier restacks descendants onto updated
+    lineage and retargets PR base as needed.
+- **Terminology**: Use `integrate` for getting changes into the main code line.
+  Use `merge` only for merge-specific states/actions (for example `git merge` or
+  PR merged state).
 - **Workspace root branch**: User-facing branch name for the epic. Stored as
   `workspace.root_branch` in epic metadata and labeled
   `workspace:<root_branch>`.

--- a/src/atelier/worker/work_finalization_pipeline.py
+++ b/src/atelier/worker/work_finalization_pipeline.py
@@ -16,6 +16,7 @@ from .work_finalization_integration import (
     format_publish_diagnostics,
 )
 from .work_finalization_state import (
+    align_existing_pr_base,
     changeset_integration_signal,
     changeset_waiting_on_review_or_signals,
     close_completed_container_changesets,
@@ -207,6 +208,25 @@ class _FinalizePipelineService(worker_finalize_pipeline.FinalizePipelineService)
         self, repo_slug: str | None, branch: str
     ) -> tuple[dict[str, object] | None, str | None]:
         return lookup_pr_payload_diagnostic(repo_slug, branch)
+
+    def align_existing_pr_base(
+        self,
+        *,
+        issue: dict[str, object],
+        pr_payload: dict[str, object],
+        context: worker_finalize_pipeline.FinalizePipelineContext,
+    ) -> tuple[bool, str | None]:
+        if not context.repo_slug:
+            return False, "missing repo slug for PR base alignment"
+        return align_existing_pr_base(
+            issue=issue,
+            changeset_id=context.changeset_id,
+            pr_payload=pr_payload,
+            repo_slug=context.repo_slug,
+            beads_root=self._beads_root,
+            repo_root=self._repo_root,
+            git_path=context.git_path,
+        )
 
     def update_changeset_review_from_pr(
         self,

--- a/tests/atelier/worker/test_models_boundary.py
+++ b/tests/atelier/worker/test_models_boundary.py
@@ -31,6 +31,24 @@ def test_parse_issue_boundary_normalizes_dependency_and_parent_fields() -> None:
     assert boundary.labels == ("at:changeset", "cs:ready")
 
 
+def test_parse_issue_boundary_derives_parent_from_parent_child_dependency() -> None:
+    issue = {
+        "id": "at-123",
+        "status": "open",
+        "labels": ["at:changeset"],
+        "parent": None,
+        "dependencies": [
+            {"relation": "parent-child", "id": "at-1"},
+            {"id": "at-2"},
+        ],
+    }
+
+    boundary = parse_issue_boundary(issue, source="test")
+
+    assert boundary.parent_id == "at-1"
+    assert boundary.dependency_ids == ("at-2",)
+
+
 def test_parse_issue_boundary_rejects_missing_issue_id() -> None:
     with pytest.raises(ValueError, match="invalid beads issue payload"):
         parse_issue_boundary({"status": "open"}, source="test")

--- a/tests/atelier/worker/test_work_finalization_state.py
+++ b/tests/atelier/worker/test_work_finalization_state.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from atelier.worker import work_finalization_state
+
+
+def test_changeset_base_branch_prefers_workspace_parent_for_first_reviewable(monkeypatch) -> None:
+    issue = {
+        "id": "at-epic.1",
+        "description": ("changeset.root_branch: feat/root\nchangeset.parent_branch: feat/root\n"),
+    }
+
+    monkeypatch.setattr(
+        work_finalization_state,
+        "resolve_epic_id_for_changeset",
+        lambda *_args, **_kwargs: "at-epic",
+    )
+    monkeypatch.setattr(
+        work_finalization_state.beads,
+        "run_bd_json",
+        lambda args, **_kwargs: (
+            [{"description": "workspace.parent_branch: main\n"}]
+            if args == ["show", "at-epic"]
+            else []
+        ),
+    )
+
+    base = work_finalization_state.changeset_base_branch(
+        issue,
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+        git_path="git",
+    )
+
+    assert base == "main"
+
+
+def test_changeset_base_branch_keeps_stacked_parent_before_integration(monkeypatch) -> None:
+    issue = {
+        "description": (
+            "changeset.root_branch: feat/root\n"
+            "changeset.parent_branch: feat/parent\n"
+            "workspace.parent_branch: main\n"
+        )
+    }
+
+    monkeypatch.setattr(
+        work_finalization_state,
+        "branch_ref_for_lookup",
+        lambda _repo_root, branch, **_kwargs: branch,
+    )
+    monkeypatch.setattr(
+        work_finalization_state.git,
+        "git_is_ancestor",
+        lambda *_args, **_kwargs: False,
+    )
+    monkeypatch.setattr(
+        work_finalization_state.git,
+        "git_branch_fully_applied",
+        lambda *_args, **_kwargs: False,
+    )
+
+    base = work_finalization_state.changeset_base_branch(
+        issue,
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+        git_path="git",
+    )
+
+    assert base == "feat/parent"
+
+
+def test_changeset_base_branch_promotes_to_workspace_parent_after_integration(monkeypatch) -> None:
+    issue = {
+        "description": (
+            "changeset.root_branch: feat/root\n"
+            "changeset.parent_branch: feat/parent\n"
+            "workspace.parent_branch: main\n"
+        )
+    }
+
+    monkeypatch.setattr(
+        work_finalization_state,
+        "branch_ref_for_lookup",
+        lambda _repo_root, branch, **_kwargs: branch,
+    )
+    monkeypatch.setattr(
+        work_finalization_state.git,
+        "git_is_ancestor",
+        lambda _repo, ancestor, descendant, **_kwargs: (
+            ancestor == "feat/parent" and descendant == "main"
+        ),
+    )
+
+    base = work_finalization_state.changeset_base_branch(
+        issue,
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+        git_path="git",
+    )
+
+    assert base == "main"
+
+
+def test_align_existing_pr_base_rebases_and_retargets(monkeypatch) -> None:
+    issue = {
+        "description": (
+            "changeset.root_branch: feat/root\n"
+            "changeset.parent_branch: feat/parent\n"
+            "changeset.work_branch: feat/work\n"
+            "workspace.parent_branch: main\n"
+        )
+    }
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        work_finalization_state,
+        "changeset_base_branch",
+        lambda *_args, **_kwargs: "main",
+    )
+    monkeypatch.setattr(work_finalization_state.git, "git_is_clean", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        work_finalization_state.git,
+        "git_ref_exists",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        work_finalization_state,
+        "branch_ref_for_lookup",
+        lambda _repo_root, branch, **_kwargs: branch,
+    )
+    monkeypatch.setattr(
+        work_finalization_state.git,
+        "git_current_branch",
+        lambda *_args, **_kwargs: "main",
+    )
+    monkeypatch.setattr(
+        work_finalization_state.git,
+        "git_rev_parse",
+        lambda *_args, **_kwargs: "abc1234",
+    )
+    monkeypatch.setattr(
+        work_finalization_state.beads,
+        "update_changeset_branch_metadata",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        work_finalization_state.beads,
+        "run_bd_command",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def _record_command(cmd: list[str]):
+        commands.append(list(cmd))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(work_finalization_state.exec, "try_run_command", _record_command)
+
+    ok, detail = work_finalization_state.align_existing_pr_base(
+        issue=issue,
+        changeset_id="at-epic.2",
+        pr_payload={"number": 12, "baseRefName": "feat/parent"},
+        repo_slug="org/repo",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+        git_path="git",
+    )
+
+    assert ok is True
+    assert detail is not None
+    assert "expected=main" in detail
+    assert any(
+        command[-5:] == ["rebase", "--onto", "main", "feat/parent", "feat/work"]
+        for command in commands
+    )
+    assert any(
+        command[-4:] == ["push", "--force-with-lease", "origin", "feat/work"]
+        for command in commands
+    )
+    assert any(
+        command[:7] == ["gh", "pr", "edit", "12", "--repo", "org/repo", "--base"]
+        and command[-1] == "main"
+        for command in commands
+    )


### PR DESCRIPTION
# Summary

- Correct PR base targeting so first-review changesets target the integration branch (`workspace.parent_branch`) and stacked changesets retarget after parent integration.

# Changes

- Added canonical PR-base resolution in worker finalize state, decoupled from raw branch-cut ancestry metadata.
- Added finalize-time PR-base alignment for existing PRs: detect expected vs actual base, restack/rebase work branches when needed, force-push safely, and retarget PR base.
- Hardened issue boundary parsing to recover parent IDs from `parent-child` dependency payloads when parent metadata is null/missing.
- Added regression tests for top-level base targeting, stacked before/after integration behavior, PR-base alignment flow, and nullable parent boundary handling.
- Updated behavior docs with PR-base alignment rules and integrate-vs-merge terminology guidance.

# Testing

- `just format`
- `just lint`
- `pytest -q tests/atelier/worker/test_models_boundary.py tests/atelier/worker/test_work_finalization_state.py tests/atelier/worker/test_finalize_pipeline.py`
- `just test` (fails in existing project baseline during collection under Python 3.14: `ImportError: cannot import name Traversable from importlib.abc`)

# Tickets

- Fixes #112

# Risks / Rollout

- PR-base auto-alignment now performs branch restack/rebase plus force-push when correcting mismatched stacked PR bases; this is guarded by clean-tree checks and explicit failure diagnostics.

# Notes

- Behavior remains strategy-aware: stacked non-sequential flows can target predecessor branches before integration, then shift to workspace parent after integration.