### PR TITLE
Prevent planner messages from targeting inactive workers

### DIFF
--- a/src/atelier/skills/mail-send/SKILL.md
+++ b/src/atelier/skills/mail-send/SKILL.md
@@ -19,13 +19,16 @@ description: >-
 
 ## Steps
 
-1. Render the message description with YAML frontmatter (use
-   `atelier.messages.render_message`).
-1. Create the message bead:
-   - `bd create --type task --label at:message --label at:unread --title <subject> --assignee <to> --body-file <path>`
+1. Use the dispatch script:
+   - `python skills/mail-send/scripts/send_message.py --subject "<subject>" --body "<body>" --to "<to>" --from "<from>" [--thread "<thread>"] [--reply-to "<reply_to>"] [--beads-dir "<beads_dir>"]`
+1. Do not create planner-to-worker message beads directly with `bd create`.
+1. The script enforces worker liveness checks:
+   - active worker recipient: create an `at:message` bead assigned to `to`
+   - inactive worker recipient: create an unassigned executable reroute epic
+     (`at:epic` + `at:changeset` + `cs:ready`) with routing diagnostics
 
 ## Verification
 
-- Message bead exists and is assigned to the recipient.
-- Description includes YAML frontmatter with `from`, `thread`, and `reply_to`
-  when provided.
+- Active recipient path: message bead exists and is assigned to the recipient.
+- Inactive worker path: no worker-targeted message bead is created; reroute epic
+  exists with `routing.inactive_worker` and `routing.decision`.

--- a/src/atelier/skills/mail-send/scripts/send_message.py
+++ b/src/atelier/skills/mail-send/scripts/send_message.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Send a planner message or reroute to executable work for inactive workers."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _bootstrap_source_import() -> None:
+    src_dir = Path(__file__).resolve().parents[4]
+    if src_dir.is_dir() and str(src_dir) not in sys.path:
+        sys.path.insert(0, str(src_dir))
+
+
+_bootstrap_source_import()
+
+from atelier import agent_home, beads  # noqa: E402
+
+
+@dataclass(frozen=True)
+class DispatchOutcome:
+    decision: str
+    issue_id: str
+    recipient: str
+
+
+def _agent_role(agent_id: str) -> str | None:
+    role, _name, _session = agent_home.parse_agent_identity(agent_id)
+    if role:
+        return role.strip().lower() or None
+    parts = [part for part in str(agent_id).split("/") if part]
+    if not parts:
+        return None
+    return parts[0].strip().lower() or None
+
+
+def _is_inactive_worker(agent_id: str) -> bool:
+    return _agent_role(agent_id) == "worker" and not agent_home.is_session_agent_active(agent_id)
+
+
+def _build_reroute_acceptance() -> str:
+    return (
+        "- Dispatch intent is executed by an active worker session.\n"
+        "- Routing metadata identifies the inactive recipient and reroute decision."
+    )
+
+
+def _build_reroute_description(
+    *,
+    subject: str,
+    body: str,
+    sender: str,
+    recipient: str,
+    thread: str | None,
+    reply_to: str | None,
+) -> str:
+    timestamp = dt.datetime.now(tz=dt.timezone.utc).replace(microsecond=0).isoformat()
+    lines = [
+        "Intent",
+        "Planner dispatch was blocked because the recipient worker session is inactive.",
+        "",
+        "Routing diagnostics",
+        "routing.decision: rerouted_inactive_worker",
+        f"routing.inactive_worker: {recipient}",
+        f"routing.sender: {sender}",
+        f"routing.original_subject: {subject}",
+        f"routing.generated_at: {timestamp}",
+    ]
+    if thread:
+        lines.append(f"routing.thread: {thread}")
+    if reply_to:
+        lines.append(f"routing.reply_to: {reply_to}")
+    body_text = body.strip()
+    if body_text:
+        lines.extend(["", "Original message", body_text])
+    return "\n".join(lines).strip()
+
+
+def _create_reroute_epic(
+    *,
+    subject: str,
+    body: str,
+    sender: str,
+    recipient: str,
+    thread: str | None,
+    reply_to: str | None,
+    beads_root: Path,
+    cwd: Path,
+) -> dict[str, object]:
+    description = _build_reroute_description(
+        subject=subject,
+        body=body,
+        sender=sender,
+        recipient=recipient,
+        thread=thread,
+        reply_to=reply_to,
+    )
+    title = f"Rerouted worker dispatch: {subject}"
+    result = beads.run_bd_command(
+        [
+            "create",
+            "--type",
+            "epic",
+            "--label",
+            "at:epic",
+            "--label",
+            "at:changeset",
+            "--label",
+            "cs:ready",
+            "--title",
+            title,
+            "--acceptance",
+            _build_reroute_acceptance(),
+            "--description",
+            description,
+            "--silent",
+        ],
+        beads_root=beads_root,
+        cwd=cwd,
+    )
+    issue_id = (result.stdout or "").strip()
+    if not issue_id:
+        raise RuntimeError("failed to create rerouted executable epic")
+    issues = beads.run_bd_json(["show", issue_id], beads_root=beads_root, cwd=cwd)
+    return issues[0] if issues else {"id": issue_id, "title": title}
+
+
+def dispatch_message(
+    *,
+    subject: str,
+    body: str,
+    to: str,
+    from_agent: str,
+    thread: str | None,
+    reply_to: str | None,
+    beads_root: Path,
+    cwd: Path,
+) -> DispatchOutcome:
+    if _agent_role(from_agent) == "planner" and _is_inactive_worker(to):
+        rerouted = _create_reroute_epic(
+            subject=subject,
+            body=body,
+            sender=from_agent,
+            recipient=to,
+            thread=thread,
+            reply_to=reply_to,
+            beads_root=beads_root,
+            cwd=cwd,
+        )
+        rerouted_id = str(rerouted.get("id") or "").strip()
+        if not rerouted_id:
+            raise RuntimeError("rerouted executable epic is missing an id")
+        return DispatchOutcome(
+            decision="rerouted_inactive_worker",
+            issue_id=rerouted_id,
+            recipient=to,
+        )
+
+    metadata: dict[str, object] = {"from": from_agent}
+    if thread:
+        metadata["thread"] = thread
+    if reply_to:
+        metadata["reply_to"] = reply_to
+
+    message = beads.create_message_bead(
+        subject=subject,
+        body=body,
+        metadata=metadata,
+        assignee=to,
+        beads_root=beads_root,
+        cwd=cwd,
+    )
+    message_id = str(message.get("id") or "").strip()
+    if not message_id:
+        raise RuntimeError("created message bead is missing an id")
+    return DispatchOutcome(decision="delivered", issue_id=message_id, recipient=to)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--subject", required=True, help="Message subject")
+    parser.add_argument("--body", required=True, help="Message body")
+    parser.add_argument("--to", required=True, help="Recipient agent id")
+    parser.add_argument("--from", dest="from_agent", required=True, help="Sender agent id")
+    parser.add_argument("--thread", default="", help="Optional thread id")
+    parser.add_argument("--reply-to", default="", help="Optional reply message id")
+    parser.add_argument(
+        "--beads-dir",
+        default="",
+        help="Beads directory override (defaults to BEADS_DIR or repo .beads)",
+    )
+    args = parser.parse_args()
+
+    beads_dir = str(args.beads_dir).strip() or None
+    if beads_dir:
+        beads_root = Path(beads_dir).expanduser().resolve()
+    else:
+        beads_root = Path(os.environ.get("BEADS_DIR", str(Path.cwd() / ".beads"))).expanduser()
+        beads_root = beads_root.resolve()
+    if not beads_root.exists():
+        print(f"error: beads dir not found: {beads_root}", file=sys.stderr)
+        raise SystemExit(1)
+
+    try:
+        outcome = dispatch_message(
+            subject=args.subject,
+            body=args.body,
+            to=args.to.strip(),
+            from_agent=args.from_agent.strip(),
+            thread=args.thread.strip() or None,
+            reply_to=args.reply_to.strip() or None,
+            beads_root=beads_root,
+            cwd=Path.cwd(),
+        )
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc
+
+    if outcome.decision == "rerouted_inactive_worker":
+        print("dispatch: rerouted_inactive_worker")
+        print(f"inactive_worker: {outcome.recipient}")
+        print(f"rerouted_epic: {outcome.issue_id}")
+        return
+
+    print("dispatch: delivered")
+    print(f"recipient: {outcome.recipient}")
+    print(f"message_id: {outcome.issue_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/atelier/templates/AGENTS.planner.md.tmpl
+++ b/src/atelier/templates/AGENTS.planner.md.tmpl
@@ -20,6 +20,8 @@ The CLI does not enforce planning correctness. You do, via skills.
 - Run `planner-startup-check` before any planning work.
 - Run `plan-changeset-guardrails` after creating or updating changesets.
 - Use `plan-promote-epic` to promote epics, with explicit user confirmation.
+- Use `mail-send` script for planner-to-worker dispatch; if a worker is inactive,
+  reroute by creating new executable work instead of sending direct messages.
 
 ## No Approval Step (Except Promotion)
 

--- a/tests/atelier/skills/test_mail_send_script.py
+++ b/tests/atelier/skills/test_mail_send_script.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from subprocess import CompletedProcess
+from unittest.mock import patch
+
+
+def _load_script_module():
+    script_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "atelier"
+        / "skills"
+        / "mail-send"
+        / "scripts"
+        / "send_message.py"
+    )
+    spec = importlib.util.spec_from_file_location("mail_send_script", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_dispatch_message_delivers_to_active_worker() -> None:
+    module = _load_script_module()
+    with (
+        patch.object(module.agent_home, "is_session_agent_active", return_value=True),
+        patch.object(
+            module.beads, "create_message_bead", return_value={"id": "at-msg-1"}
+        ) as create,
+    ):
+        result = module.dispatch_message(
+            subject="Need follow-up",
+            body="Please investigate.",
+            to="atelier/worker/codex/p101-t1",
+            from_agent="atelier/planner/codex/p202-t2",
+            thread="at-thread-1",
+            reply_to="at-msg-0",
+            beads_root=Path("/beads"),
+            cwd=Path("/repo"),
+        )
+
+    assert result.decision == "delivered"
+    assert result.issue_id == "at-msg-1"
+    call = create.call_args.kwargs
+    assert call["assignee"] == "atelier/worker/codex/p101-t1"
+    assert call["metadata"]["from"] == "atelier/planner/codex/p202-t2"
+    assert call["metadata"]["thread"] == "at-thread-1"
+    assert call["metadata"]["reply_to"] == "at-msg-0"
+
+
+def test_dispatch_message_reroutes_when_worker_inactive() -> None:
+    module = _load_script_module()
+    with (
+        patch.object(module.agent_home, "is_session_agent_active", return_value=False),
+        patch.object(module, "_create_reroute_epic", return_value={"id": "at-epic-5"}) as reroute,
+        patch.object(module.beads, "create_message_bead") as create_message,
+    ):
+        result = module.dispatch_message(
+            subject="Fix failing check",
+            body="Please investigate CI logs.",
+            to="atelier/worker/codex/p303-t3",
+            from_agent="atelier/planner/codex/p202-t2",
+            thread=None,
+            reply_to=None,
+            beads_root=Path("/beads"),
+            cwd=Path("/repo"),
+        )
+
+    assert result.decision == "rerouted_inactive_worker"
+    assert result.issue_id == "at-epic-5"
+    reroute.assert_called_once()
+    create_message.assert_not_called()
+
+
+def test_create_reroute_epic_writes_diagnostics_and_labels() -> None:
+    module = _load_script_module()
+    captured_args: list[str] = []
+
+    def _fake_run_bd_command(args: list[str], *, beads_root: Path, cwd: Path):
+        captured_args.extend(args)
+        return CompletedProcess(args=["bd", *args], returncode=0, stdout="at-epic-9\n", stderr="")
+
+    with (
+        patch.object(module.beads, "run_bd_command", side_effect=_fake_run_bd_command),
+        patch.object(module.beads, "run_bd_json", return_value=[{"id": "at-epic-9"}]),
+    ):
+        created = module._create_reroute_epic(
+            subject="Investigate stale task",
+            body="Original payload",
+            sender="atelier/planner/codex/p11",
+            recipient="atelier/worker/codex/p22",
+            thread="at-thread",
+            reply_to="at-msg-2",
+            beads_root=Path("/beads"),
+            cwd=Path("/repo"),
+        )
+
+    assert created["id"] == "at-epic-9"
+    assert "--label" in captured_args
+    assert "at:epic" in captured_args
+    assert "at:changeset" in captured_args
+    assert "cs:ready" in captured_args
+    description = captured_args[captured_args.index("--description") + 1]
+    assert "routing.decision: rerouted_inactive_worker" in description
+    assert "routing.inactive_worker: atelier/worker/codex/p22" in description
+    assert "routing.thread: at-thread" in description
+    assert "routing.reply_to: at-msg-2" in description
+
+
+def test_dispatch_message_non_planner_sender_does_not_reroute() -> None:
+    module = _load_script_module()
+    with (
+        patch.object(module.agent_home, "is_session_agent_active", return_value=False),
+        patch.object(
+            module.beads, "create_message_bead", return_value={"id": "at-msg-2"}
+        ) as create,
+        patch.object(module, "_create_reroute_epic") as reroute,
+    ):
+        result = module.dispatch_message(
+            subject="Heads up",
+            body="FYI",
+            to="atelier/worker/codex/p404-t4",
+            from_agent="atelier/worker/codex/p505-t5",
+            thread=None,
+            reply_to=None,
+            beads_root=Path("/beads"),
+            cwd=Path("/repo"),
+        )
+
+    assert result.decision == "delivered"
+    assert result.issue_id == "at-msg-2"
+    create.assert_called_once()
+    reroute.assert_not_called()

--- a/tests/atelier/test_planner_agents_template.py
+++ b/tests/atelier/test_planner_agents_template.py
@@ -21,6 +21,7 @@ def test_planner_agents_template_contains_core_sections() -> None:
     assert "plan-changeset-guardrails" in content
     assert "plan-promote-epic" in content
     assert "planner-startup-check" in content
+    assert "mail-send" in content
     assert "epic-list" in content
     assert "one child changeset" in content
     assert "decomposition rationale" in content

--- a/tests/atelier/test_skills.py
+++ b/tests/atelier/test_skills.py
@@ -96,6 +96,7 @@ def test_packaged_planning_skills_include_scripts() -> None:
     assert "scripts/create_changeset.py" in definitions["plan-changesets"].files
     assert "scripts/create_epic.py" in definitions["plan-create-epic"].files
     assert "scripts/refresh_overview.py" in definitions["planner-startup-check"].files
+    assert "scripts/send_message.py" in definitions["mail-send"].files
 
 
 def test_publish_skill_mentions_pr_draft_and_github_prs() -> None:


### PR DESCRIPTION
## Summary
- Gate planner `mail-send` dispatches with worker session liveness checks.
- When the recipient worker session is inactive, create a new unassigned executable epic instead of a direct message bead.
- Record reroute diagnostics (`routing.decision`, `routing.inactive_worker`, sender, subject, and thread/reply context) in the rerouted epic.

## Acceptance Criteria Covered
- Planner no longer emits worker-targeted message beads for inactive worker IDs.
- Inactive-recipient dispatch attempts create executable planning work for reassignment.
- Reroute decisions include actionable context for follow-up routing.
- Regression tests cover both active and inactive recipient paths.

## Validation
- `just format`
- `just lint`
- `env -u ATELIER_AGENT_ID -u BD_ACTOR -u BEADS_AGENT_NAME -u ATELIER_AGENT_SESSION just test`