### PR TITLE
Auto-reconcile stale worktree root-branch mappings after branch replacement

### DIFF
--- a/src/atelier/commands/edit.py
+++ b/src/atelier/commands/edit.py
@@ -73,9 +73,12 @@ def _select_epic_by_workspace(
 
 def _resolve_worktree_path(
     project_dir: Path,
+    repo_root: Path,
     epic_id: str,
     root_branch: str,
     worktree_relpath: str | None,
+    *,
+    git_path: str | None = None,
 ) -> Path:
     mapping = worktrees.load_mapping(worktrees.mapping_path(project_dir, epic_id))
     if mapping is None:
@@ -84,10 +87,13 @@ def _resolve_worktree_path(
         candidate = Path(worktree_relpath)
         worktree_path = candidate if candidate.is_absolute() else project_dir / candidate
     else:
-        if mapping.root_branch and mapping.root_branch != root_branch:
-            die("workspace root branch does not match worktree mapping")
-        if not mapping.root_branch:
-            die("worktree mapping missing root branch")
+        mapping = worktrees.ensure_worktree_mapping(
+            project_dir,
+            epic_id,
+            root_branch,
+            repo_root=repo_root,
+            git_path=git_path,
+        )
         worktree_path = project_dir / mapping.worktree_path
     if not worktree_path.exists():
         die("worktree missing; run 'atelier work' first")
@@ -107,6 +113,7 @@ def open_workspace_editor(args: object) -> None:
         resolve_current_project_with_repo_root()
     )
     project_data_dir = config.resolve_project_data_dir(project_root, project_config)
+    git_path = config.resolve_git_path(project_config)
     beads_root = config.resolve_beads_root(project_data_dir, repo_root)
     issue, root_branch = _select_epic_by_workspace(
         workspace_name=str(workspace_name) if workspace_name else None,
@@ -120,9 +127,11 @@ def open_workspace_editor(args: object) -> None:
 
     worktree_path = _resolve_worktree_path(
         project_data_dir,
+        repo_root,
         str(issue.get("id") or ""),
         root_branch,
         beads.extract_worktree_path(issue),
+        git_path=git_path,
     )
     project_enlistment = project_config.project.enlistment or enlistment_path
     env = workspace.workspace_environment(

--- a/src/atelier/worker/session/worktree.py
+++ b/src/atelier/worker/session/worktree.py
@@ -115,6 +115,8 @@ def prepare_worktrees(
         selected_epic,
         changeset_id,
         root_branch=root_branch_value,
+        repo_root=repo_root,
+        git_path=git_path,
     )
     beads.update_worktree_path(
         selected_epic,


### PR DESCRIPTION
# Summary

- Auto-reconcile stale worktree root-branch mappings when a workspace root branch is replaced.
- Unblock `atelier work --yes`, `atelier open`, and `atelier edit` for safe mismatch cases without manual metadata edits.

# Changes

- Added deterministic root-branch reconciliation in `worktrees.ensure_worktree_mapping` for stale mapping mismatches.
- Added guarded failure paths for unsafe migration scenarios: non-git mapped paths, dirty worktree migration attempts, and ambiguous checked-out branches.
- Updated epic-as-changeset mapping entries to the new root branch when migration is accepted.
- Wired reconciliation through worker worktree preparation and `open`/`edit` worktree resolution paths.
- Added regression tests for safe auto-heal and guarded-fail behavior, plus command-path coverage for `open` and `edit`.

# Testing

- `just format`
- `just lint`
- `env -u ATELIER_AGENT_ID -u ATELIER_AGENT_SESSION just test`

## Tickets
- Fixes #124

# Risks / Rollout

- Low risk: behavior is unchanged when mappings already match.
- Migration only mutates metadata (and safe branch checkout when needed); unsafe states still fail fast with explicit diagnostics.

# Notes

- Full `just test` under the worker session environment can fail unrelated `agent_home` tests due to injected `ATELIER_AGENT_*` env vars, so the test run unsets those vars for deterministic suite behavior.