### PR TITLE
Harden commit, issue, and PR drafting with file-backed body transport

### DIFF
--- a/src/atelier/skills/github-issues/SKILL.md
+++ b/src/atelier/skills/github-issues/SKILL.md
@@ -14,7 +14,7 @@ description: >-
 - repo: GitHub repository in `OWNER/REPO` form.
 - issue: issue number or URL (required for read/update/close).
 - title: issue title for create/update.
-- body: issue body for create/update.
+- body_file: path to a UTF-8 issue body file for create/update.
 - labels: comma-separated label list; empty string clears labels.
 - comment: optional closing comment when closing.
 - reason: optional close reason (`completed` or `not planned`).
@@ -27,7 +27,7 @@ description: >-
 1. Confirm `gh` is available and authenticated for the target repo.
 1. For create:
    - Run
-     `scripts/create_issue.py --repo <repo> --title <title> --body <body> [--labels <labels>]`.
+     `scripts/create_issue.py --repo <repo> --title <title> --body-file <path> [--labels <labels>]`.
 1. For read:
    - Run `scripts/read_issue.py --repo <repo> --issue <issue>`.
 1. For list:
@@ -35,7 +35,7 @@ description: >-
      `scripts/list_issues.py --repo <repo> [--state <state>] [--search <search>] [--limit <limit>]`.
 1. For update:
    - Run
-     `scripts/update_issue.py --repo <repo> --issue <issue> [--title <title>] [--body <body>] [--labels <labels>]`.
+     `scripts/update_issue.py --repo <repo> --issue <issue> [--title <title>] [--body-file <path>] [--labels <labels>]`.
 1. For close:
    - Run
      `scripts/close_issue.py --repo <repo> --issue <issue> [--comment <comment>] [--reason <reason>]`.
@@ -45,3 +45,4 @@ description: >-
 ## Outputs
 
 - Scripts print issue metadata as JSON to stdout after each action.
+- Body markdown transport must use `--body-file`, not inline shell text.

--- a/src/atelier/skills/github-issues/references/github-issues-gh.md
+++ b/src/atelier/skills/github-issues/references/github-issues-gh.md
@@ -3,10 +3,10 @@
 ## Required gh commands
 
 - Create:
-  `gh issue create --repo <OWNER/REPO> --title <title> --body <body> [--label <label>]`
+  `gh issue create --repo <OWNER/REPO> --title <title> --body-file <path> [--label <label>]`
 - Read: `gh issue view <issue> --repo <OWNER/REPO> --json <fields>`
 - Update:
-  `gh issue edit <issue> --repo <OWNER/REPO> [--title <title>] [--body <body>] [--add-label <label>] [--remove-label <label>]`
+  `gh issue edit <issue> --repo <OWNER/REPO> [--title <title>] [--body-file <path>] [--add-label <label>] [--remove-label <label>]`
 - Close:
   `gh issue close <issue> --repo <OWNER/REPO> [--comment <comment>] [--reason completed|not planned]`
 

--- a/src/atelier/skills/github-issues/scripts/create_issue.py
+++ b/src/atelier/skills/github-issues/scripts/create_issue.py
@@ -7,7 +7,10 @@ import argparse
 import json
 import subprocess
 import sys
-from typing import Iterable, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Iterable, Iterator, Sequence
 
 FIELDS = ["number", "title", "body", "state", "url", "labels", "assignees", "author"]
 
@@ -56,11 +59,29 @@ def last_non_empty_line(lines: Iterable[str]) -> str | None:
     return candidate
 
 
+@contextmanager
+def body_file_path(*, body: str | None, body_file: str | None) -> Iterator[str]:
+    if body_file:
+        yield body_file
+        return
+    if body is None:
+        raise ValueError("body text is required when --body-file is not provided")
+    with NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(body)
+        temp_path = Path(handle.name)
+    try:
+        yield str(temp_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", required=True, help="GitHub repo in OWNER/REPO form")
     parser.add_argument("--title", required=True, help="Issue title")
-    parser.add_argument("--body", required=True, help="Issue body")
+    body_group = parser.add_mutually_exclusive_group(required=True)
+    body_group.add_argument("--body", help="Issue body")
+    body_group.add_argument("--body-file", help="Path to issue body file")
     parser.add_argument(
         "--labels",
         default=None,
@@ -70,20 +91,20 @@ def main() -> None:
 
     labels = parse_labels(args.labels)
 
-    cmd = [
-        "issue",
-        "create",
-        "--repo",
-        args.repo,
-        "--title",
-        args.title,
-        "--body",
-        args.body,
-    ]
-    for label in labels:
-        cmd.extend(["--label", label])
-
-    output = run_gh(cmd)
+    with body_file_path(body=args.body, body_file=args.body_file) as issue_body_file:
+        cmd = [
+            "issue",
+            "create",
+            "--repo",
+            args.repo,
+            "--title",
+            args.title,
+            "--body-file",
+            issue_body_file,
+        ]
+        for label in labels:
+            cmd.extend(["--label", label])
+        output = run_gh(cmd)
     issue_ref = last_non_empty_line(output.splitlines())
     if issue_ref is None or not issue_ref:
         die("gh issue create returned no issue reference", 2)

--- a/src/atelier/skills/github-issues/scripts/update_issue.py
+++ b/src/atelier/skills/github-issues/scripts/update_issue.py
@@ -7,7 +7,10 @@ import argparse
 import json
 import subprocess
 import sys
-from typing import Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+from typing import Iterator, Sequence
 
 FIELDS = ["number", "title", "body", "state", "url", "labels", "assignees", "author"]
 
@@ -43,12 +46,31 @@ def issue_view(repo: str, issue_ref: str) -> dict:
     return json.loads(payload)
 
 
+@contextmanager
+def issue_body_file(*, body: str | None, body_file: str | None) -> Iterator[str | None]:
+    if body_file:
+        yield body_file
+        return
+    if body is None:
+        yield None
+        return
+    with NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(body)
+        temp_path = Path(handle.name)
+    try:
+        yield str(temp_path)
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--repo", required=True, help="GitHub repo in OWNER/REPO form")
     parser.add_argument("--issue", required=True, help="Issue number or URL")
     parser.add_argument("--title", default=None, help="New issue title")
-    parser.add_argument("--body", default=None, help="New issue body")
+    body_group = parser.add_mutually_exclusive_group(required=False)
+    body_group.add_argument("--body", default=None, help="New issue body")
+    body_group.add_argument("--body-file", default=None, help="Path to new issue body file")
     parser.add_argument(
         "--labels",
         default=None,
@@ -69,19 +91,21 @@ def main() -> None:
         to_add = sorted(desired_set - current_set)
         to_remove = sorted(current_set - desired_set)
 
-    has_changes = args.title is not None or args.body is not None or to_add or to_remove
+    body_supplied = args.body is not None or args.body_file is not None
+    has_changes = args.title is not None or body_supplied or to_add or to_remove
 
     if has_changes:
-        cmd = ["issue", "edit", args.issue, "--repo", args.repo]
-        if args.title is not None:
-            cmd.extend(["--title", args.title])
-        if args.body is not None:
-            cmd.extend(["--body", args.body])
-        for label in to_add:
-            cmd.extend(["--add-label", label])
-        for label in to_remove:
-            cmd.extend(["--remove-label", label])
-        run_gh(cmd)
+        with issue_body_file(body=args.body, body_file=args.body_file) as new_body_file:
+            cmd = ["issue", "edit", args.issue, "--repo", args.repo]
+            if args.title is not None:
+                cmd.extend(["--title", args.title])
+            if new_body_file is not None:
+                cmd.extend(["--body-file", new_body_file])
+            for label in to_add:
+                cmd.extend(["--add-label", label])
+            for label in to_remove:
+                cmd.extend(["--remove-label", label])
+            run_gh(cmd)
 
     payload = run_gh(
         [

--- a/src/atelier/skills/github-prs/SKILL.md
+++ b/src/atelier/skills/github-prs/SKILL.md
@@ -15,7 +15,7 @@ description: >-
 - base: base branch name for the PR (target branch).
 - head: head branch name for the PR (source branch).
 - title: PR title string.
-- body: PR body string.
+- body_file: path to a UTF-8 PR body file.
 - labels: comma-separated label list (use an empty string to clear labels).
 - pr_number: PR number for review-thread operations.
 
@@ -24,7 +24,7 @@ description: >-
 1. Read [references/github-cli.md](references/github-cli.md) for GitHub CLI
    behavior and JSON field notes.
 1. Create or update a PR with:
-   `scripts/create_or_update_pr.py --repo <repo> --base <base> --head <head> --title <title> --body <body> --labels <labels>`
+   `scripts/create_or_update_pr.py --repo <repo> --base <base> --head <head> --title <title> --body-file <path> --labels <labels>`
 1. Retarget the PR base branch with:
    `scripts/retarget_pr_base.py --repo <repo> --head <head> --base <base>`
 1. Read PR status/metadata with:
@@ -39,6 +39,7 @@ description: >-
 ## Invariants
 
 - Provide all parameters explicitly; do not infer repo, base, or head.
+- Pass markdown bodies via file (`--body-file`) rather than inline shell text.
 - Keep label updates deterministic by matching the exact label set provided.
 - Fail fast when no matching PR exists for an update or status read.
 - When feedback comes from inline review comments, reply inline to that comment

--- a/src/atelier/skills/github-prs/references/github-cli.md
+++ b/src/atelier/skills/github-prs/references/github-cli.md
@@ -15,9 +15,9 @@ scripts.
 - View a PR:
   `gh pr view <number|branch> --repo <repo> --json number,url,state,baseRefName,headRefName,title,body,labels,isDraft,mergedAt,closedAt,updatedAt,reviewDecision,mergeable,mergeStateStatus`
 - Create a PR:
-  `gh pr create --repo <repo> --base <base> --head <head> --title <title> --body <body> --label <labels>`
+  `gh pr create --repo <repo> --base <base> --head <head> --title <title> --body-file <path> --label <labels>`
 - Edit a PR:
-  `gh pr edit <number> --repo <repo> --title <title> --body <body> --base <base> --add-label <label> --remove-label <label>`
+  `gh pr edit <number> --repo <repo> --title <title> --body-file <path> --base <base> --add-label <label> --remove-label <label>`
 
 ## JSON field notes
 

--- a/tests/atelier/skills/test_github_issue_scripts.py
+++ b/tests/atelier/skills/test_github_issue_scripts.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_script(filename: str):
+    scripts_dir = Path(__file__).resolve().parents[3] / "src/atelier/skills/github-issues/scripts"
+    path = scripts_dir / filename
+    module_name = f"test_{filename.replace('.', '_')}"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_create_issue_script_uses_body_file(capsys) -> None:
+    module = _load_script("create_issue.py")
+    observed: dict[str, object] = {}
+
+    def fake_run_gh(args: list[str]) -> str:
+        if args[:2] == ["issue", "create"]:
+            body_index = args.index("--body-file")
+            body_path = Path(args[body_index + 1])
+            observed["body"] = body_path.read_text(encoding="utf-8")
+            observed["body_path"] = body_path
+            observed["body_exists_during_call"] = body_path.exists()
+            return "https://github.com/org/repo/issues/123\n"
+        if args[:2] == ["issue", "view"]:
+            return json.dumps(
+                {
+                    "number": 123,
+                    "title": "Title with `ticks` and $(echo safe)",
+                    "body": "Body with `code` and $(echo safe)",
+                    "state": "OPEN",
+                    "url": "https://github.com/org/repo/issues/123",
+                    "labels": [],
+                    "assignees": [],
+                    "author": {"login": "tester"},
+                }
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    with (
+        patch.object(
+            module.sys,
+            "argv",
+            [
+                "create_issue.py",
+                "--repo",
+                "org/repo",
+                "--title",
+                "Title with `ticks` and $(echo safe)",
+                "--body",
+                "Body with `code` and $(echo safe)",
+            ],
+        ),
+        patch.object(module, "run_gh", side_effect=fake_run_gh),
+    ):
+        module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["number"] == 123
+    assert observed["body_exists_during_call"] is True
+    assert observed["body"] == "Body with `code` and $(echo safe)"
+    body_path = observed["body_path"]
+    assert isinstance(body_path, Path)
+    assert not body_path.exists()
+
+
+def test_update_issue_script_uses_body_file(capsys) -> None:
+    module = _load_script("update_issue.py")
+    observed: dict[str, object] = {}
+
+    def fake_run_gh(args: list[str]) -> str:
+        if args[:2] == ["issue", "edit"]:
+            body_index = args.index("--body-file")
+            body_path = Path(args[body_index + 1])
+            observed["body"] = body_path.read_text(encoding="utf-8")
+            observed["body_path"] = body_path
+            observed["body_exists_during_call"] = body_path.exists()
+            return ""
+        if args[:2] == ["issue", "view"]:
+            return json.dumps(
+                {
+                    "number": 44,
+                    "title": "Title with `ticks` and $(echo safe)",
+                    "body": "Body with `code` and $(echo safe)",
+                    "state": "OPEN",
+                    "url": "https://github.com/org/repo/issues/44",
+                    "labels": [],
+                    "assignees": [],
+                    "author": {"login": "tester"},
+                }
+            )
+        raise AssertionError(f"unexpected args: {args}")
+
+    with (
+        patch.object(
+            module.sys,
+            "argv",
+            [
+                "update_issue.py",
+                "--repo",
+                "org/repo",
+                "--issue",
+                "44",
+                "--title",
+                "Title with `ticks` and $(echo safe)",
+                "--body",
+                "Body with `code` and $(echo safe)",
+            ],
+        ),
+        patch.object(module, "run_gh", side_effect=fake_run_gh),
+    ):
+        module.main()
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["number"] == 44
+    assert observed["body_exists_during_call"] is True
+    assert observed["body"] == "Body with `code` and $(echo safe)"
+    body_path = observed["body_path"]
+    assert isinstance(body_path, Path)
+    assert not body_path.exists()


### PR DESCRIPTION
## Summary
- harden commit, issue, and pull request drafting so markdown bodies are always transported through files instead of inline shell arguments
- preserve titles containing backticks or shell metacharacters by keeping title handling argv-based across create and update flows
- add regression tests that exercise markdown/backtick-heavy payloads and verify body transport is file-backed

## What Changed
- updated runtime PR creation in worker finalization to call `gh pr create --body-file <path>`
- updated runtime GitHub issue provider create/update paths to use temp-file payloads (`gh api --input <path>` / `gh issue edit --body-file <path>`)
- switched squash integration commit drafting from `git commit -m` to `git commit -F <path>`
- updated GitHub issue/PR skill scripts to invoke `gh` with `--body-file`, while still accepting `--body` input by materializing a temp file
- updated GitHub issue/PR skill docs and references to codify file-backed body transport as required behavior
- added tests covering provider/runtime/script paths with markdown, backticks, and shell-style metacharacters

## Validation
- `just format`
- `just lint`
- `uv run pytest tests/atelier/test_github_issues_provider.py tests/atelier/worker/test_pr_gate.py tests/atelier/worker/test_integration.py tests/atelier/skills/test_github_pr_scripts.py tests/atelier/skills/test_github_issue_scripts.py`
- `just test` currently fails during collection due an existing Python 3.14 environment/import issue (`ImportError: cannot import name 'Traversable' from importlib.abc`) unrelated to this changeset

## Tickets
- Fixes #133
