### PR TITLE
Default bd invocations to direct mode unless daemon is explicitly configured

### DIFF
--- a/src/atelier/bd_invocation.py
+++ b/src/atelier/bd_invocation.py
@@ -1,0 +1,146 @@
+"""Utilities for constructing deterministic ``bd`` invocations."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Mapping
+
+from . import paths
+
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def _parse_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in _TRUE_VALUES:
+            return True
+        if normalized in _FALSE_VALUES:
+            return False
+    return None
+
+
+def _load_json_dict(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if isinstance(payload, dict):
+        return payload
+    return {}
+
+
+def _project_beads_settings(project_dir: Path) -> dict[str, object]:
+    sys_payload = _load_json_dict(paths.project_config_sys_path(project_dir))
+    user_payload = _load_json_dict(paths.project_config_user_path(project_dir))
+    settings: dict[str, object] = {}
+    for payload in (sys_payload, user_payload):
+        beads_section = payload.get("beads")
+        if isinstance(beads_section, dict):
+            settings.update(beads_section)
+    return settings
+
+
+def _daemon_mode_from_settings(settings: Mapping[str, object]) -> bool | None:
+    for key in ("daemon", "daemon_enabled", "use_daemon"):
+        parsed = _parse_bool(settings.get(key))
+        if parsed is not None:
+            return parsed
+
+    for key in ("no_daemon", "no-daemon"):
+        parsed = _parse_bool(settings.get(key))
+        if parsed is not None:
+            return not parsed
+
+    for key in ("mode", "invocation", "invocation_mode"):
+        value = settings.get(key)
+        if not isinstance(value, str):
+            continue
+        normalized = value.strip().lower().replace("_", "-")
+        if normalized == "daemon":
+            return True
+        if normalized in {"direct", "no-daemon"}:
+            return False
+
+    for key in ("daemon.db", "daemon_db"):
+        value = settings.get(key)
+        if isinstance(value, str) and value.strip():
+            return True
+    return None
+
+
+def _candidate_project_dirs(*, beads_dir: str | None, env: Mapping[str, str]) -> list[Path]:
+    candidates: list[Path] = []
+    seen: set[Path] = set()
+
+    for raw in (env.get("ATELIER_PROJECT"), beads_dir, env.get("BEADS_DIR")):
+        if not raw:
+            continue
+        expanded = Path(raw).expanduser()
+        project_dir = expanded
+        if expanded.name == paths.BEADS_DIRNAME:
+            project_dir = expanded.parent
+        if project_dir in seen:
+            continue
+        seen.add(project_dir)
+        candidates.append(project_dir)
+    return candidates
+
+
+def should_use_bd_daemon(*, beads_dir: str | None, env: Mapping[str, str] | None = None) -> bool:
+    """Return whether daemon mode is explicitly configured for ``bd`` calls.
+
+    The default is direct mode (``--no-daemon``). Daemon mode is enabled only
+    when explicit env/config overrides request it.
+    """
+
+    env_map = dict(env or os.environ)
+
+    for key in ("ATELIER_BD_DAEMON", "BEADS_DAEMON"):
+        parsed = _parse_bool(env_map.get(key))
+        if parsed is not None:
+            return parsed
+
+    no_daemon = _parse_bool(env_map.get("BEADS_NO_DAEMON"))
+    if no_daemon is True:
+        return False
+    if no_daemon is False:
+        return True
+
+    auto_start_daemon = _parse_bool(env_map.get("BEADS_AUTO_START_DAEMON"))
+    if auto_start_daemon is True:
+        return True
+
+    beads_db = env_map.get("BEADS_DB")
+    if isinstance(beads_db, str) and beads_db.strip():
+        return True
+
+    for project_dir in _candidate_project_dirs(beads_dir=beads_dir, env=env_map):
+        mode = _daemon_mode_from_settings(_project_beads_settings(project_dir))
+        if mode is not None:
+            return mode
+
+    return False
+
+
+def with_bd_mode(
+    *args: str, beads_dir: str | None, env: Mapping[str, str] | None = None
+) -> list[str]:
+    """Return a ``bd`` command with deterministic mode selection."""
+
+    command = ["bd", *args]
+    if args and args[0] == "daemon":
+        return command
+    if "--no-daemon" in command:
+        return command
+    if should_use_bd_daemon(beads_dir=beads_dir, env=env):
+        return command
+    command.append("--no-daemon")
+    return command

--- a/src/atelier/skills/beads/SKILL.md
+++ b/src/atelier/skills/beads/SKILL.md
@@ -19,26 +19,30 @@ description: >-
 
 1. Confirm `bd` is available. If a non-repo store is required, set `BEADS_DIR`.
 1. Prime Beads context at session start or before compaction:
-   - `bd --no-daemon prime`
+   - `bd --no-daemon prime` (default)
 1. List epics when a user needs to choose work:
-   - `bd --no-daemon list --label at:epic --status open`
+   - `bd --no-daemon list --label at:epic --status open` (default)
 1. Find ready changesets for an epic:
-   - `bd --no-daemon ready --parent <epic-id> --label at:changeset`
+   - `bd --no-daemon ready --parent <epic-id> --label at:changeset` (default)
 1. Show issue details when needed:
-   - `bd --no-daemon show <issue-id>`
+   - `bd --no-daemon show <issue-id>` (default)
 1. When creating new issues, prefer explicit fields:
    - `bd --no-daemon create --acceptance ... --design ... --estimate ... --priority ...`
+     (default)
    - use `--notes` / `--append-notes` for addendums without rewriting
      descriptions
 1. Sync Beads after changes or before ending a session:
-   - `bd --no-daemon sync`
+   - `bd --no-daemon sync` (default)
 
 ## Notes
 
 - Beads is the source of truth for intent and sequencing. Execution metadata
   should live in Atelier's project store and be derived from git/PR state rather
   than custom Beads schema.
-- Default to `--no-daemon` for agent workflows; use `bd daemon ...` only for
-  explicit daemon lifecycle management.
+- Default to `--no-daemon` for agent workflows.
+- Use daemon-backed invocations only when daemon use is explicitly configured
+  (project `beads` config, or daemon-specific env overrides such as
+  `ATELIER_BD_DAEMON` / `BEADS_DAEMON` / `BEADS_NO_DAEMON`).
+- Keep `bd daemon ...` commands for explicit daemon lifecycle management.
 - Use labels and description fields according to
   [references/beads-conventions.md](references/beads-conventions.md).

--- a/src/atelier/skills/epic-list/scripts/list_epics.py
+++ b/src/atelier/skills/epic-list/scripts/list_epics.py
@@ -11,22 +11,16 @@ import sys
 from pathlib import Path
 
 from atelier import planner_overview
+from atelier.bd_invocation import with_bd_mode
 
 # Re-exported for tests that load this script directly.
 _status_bucket = planner_overview._status_bucket  # pyright: ignore[reportPrivateUsage]
 _render_epics = planner_overview.render_epics
 
 
-def _bd_command(*args: str) -> list[str]:
-    command = ["bd", *args]
-    if "--no-daemon" not in command:
-        command.append("--no-daemon")
-    return command
-
-
 def _run_bd_list(beads_dir: str | None) -> list[dict[str, object]]:
-    cmd = _bd_command("list", "--label", "at:epic", "--json")
     env = dict(os.environ)
+    cmd = with_bd_mode("list", "--label", "at:epic", "--json", beads_dir=beads_dir, env=env)
     if beads_dir:
         env["BEADS_DIR"] = beads_dir
     try:

--- a/src/atelier/skills/plan-changeset-guardrails/scripts/check_guardrails.py
+++ b/src/atelier/skills/plan-changeset-guardrails/scripts/check_guardrails.py
@@ -12,6 +12,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from atelier.bd_invocation import with_bd_mode
+
 _LOC_TRIGGER = re.compile(r"\b(?:loc|estimate)\b", re.IGNORECASE)
 _NUMBER = re.compile(r"\b\d{2,5}\b")
 _APPROVAL = re.compile(r"\b(?:approve|approved|approval|sign[- ]?off|ok(?:ay)?)\b", re.IGNORECASE)
@@ -28,16 +30,9 @@ class _GuardrailReport:
     checked_ids: list[str]
 
 
-def _bd_command(*args: str) -> list[str]:
-    command = ["bd", *args]
-    if "--no-daemon" not in command:
-        command.append("--no-daemon")
-    return command
-
-
 def _run_bd_json(args: list[str], *, beads_dir: str | None) -> list[dict[str, object]]:
-    command = _bd_command(*args)
     env = dict(os.environ)
+    command = with_bd_mode(*args, beads_dir=beads_dir, env=env)
     if beads_dir:
         env["BEADS_DIR"] = beads_dir
     try:

--- a/src/atelier/skills/pr-draft/scripts/render_tickets_section.py
+++ b/src/atelier/skills/pr-draft/scripts/render_tickets_section.py
@@ -11,6 +11,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from atelier.bd_invocation import with_bd_mode
+
 
 @dataclass(frozen=True)
 class TicketRef:
@@ -99,18 +101,11 @@ def render_ticket_section(issue: dict[str, object]) -> str:
     return "\n".join(["## Tickets", *lines])
 
 
-def _bd_command(*args: str) -> list[str]:
-    command = ["bd", *args]
-    if "--no-daemon" not in command:
-        command.append("--no-daemon")
-    return command
-
-
 def load_issue(changeset_id: str, *, beads_dir: Path, repo_path: Path) -> dict[str, object]:
     """Load a changeset issue payload from Beads."""
     env = os.environ.copy()
     env["BEADS_DIR"] = str(beads_dir)
-    command = _bd_command("show", changeset_id, "--json")
+    command = with_bd_mode("show", changeset_id, "--json", beads_dir=str(beads_dir), env=env)
     result = subprocess.run(
         command,
         cwd=repo_path,

--- a/tests/atelier/skills/test_plan_changeset_guardrails_script.py
+++ b/tests/atelier/skills/test_plan_changeset_guardrails_script.py
@@ -124,3 +124,27 @@ def test_run_bd_json_defaults_to_direct_mode(monkeypatch) -> None:
 
     assert payload == []
     assert "--no-daemon" in captured["command"]
+
+
+def test_run_bd_json_uses_daemon_when_project_config_enables_it(
+    monkeypatch, tmp_path: Path
+) -> None:
+    module = _load_script_module()
+    captured: dict[str, list[str]] = {}
+    project_dir = tmp_path / "project"
+    beads_dir = project_dir / ".beads"
+    beads_dir.mkdir(parents=True)
+    (project_dir / "config.user.json").write_text('{"beads":{"daemon":true}}', encoding="utf-8")
+    for key in ("ATELIER_PROJECT", "ATELIER_BD_DAEMON", "BEADS_DAEMON", "BEADS_NO_DAEMON"):
+        monkeypatch.delenv(key, raising=False)
+
+    def fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        return subprocess.CompletedProcess(args=command, returncode=0, stdout="[]", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    payload = module._run_bd_json(["list", "--json"], beads_dir=str(beads_dir))
+
+    assert payload == []
+    assert "--no-daemon" not in captured["command"]

--- a/tests/atelier/skills/test_pr_draft_scripts.py
+++ b/tests/atelier/skills/test_pr_draft_scripts.py
@@ -70,3 +70,30 @@ def test_load_issue_defaults_to_direct_mode(monkeypatch, tmp_path: Path) -> None
 
     assert issue["id"] == "at-1"
     assert "--no-daemon" in captured["command"]
+
+
+def test_load_issue_uses_daemon_when_project_config_enables_it(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script_module()
+    captured: dict[str, list[str]] = {}
+    project_dir = tmp_path / "project"
+    beads_dir = project_dir / ".beads"
+    beads_dir.mkdir(parents=True)
+    (project_dir / "config.user.json").write_text('{"beads":{"daemon":true}}', encoding="utf-8")
+    for key in ("ATELIER_PROJECT", "ATELIER_BD_DAEMON", "BEADS_DAEMON", "BEADS_NO_DAEMON"):
+        monkeypatch.delenv(key, raising=False)
+
+    def fake_run(command: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured["command"] = command
+        return subprocess.CompletedProcess(
+            args=command,
+            returncode=0,
+            stdout='[{"id":"at-1","description":"scope: test"}]',
+            stderr="",
+        )
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+
+    issue = module.load_issue("at-1", beads_dir=beads_dir, repo_path=tmp_path)
+
+    assert issue["id"] == "at-1"
+    assert "--no-daemon" not in captured["command"]

--- a/tests/atelier/test_bd_invocation.py
+++ b/tests/atelier/test_bd_invocation.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from atelier.bd_invocation import should_use_bd_daemon, with_bd_mode
+
+
+def test_with_bd_mode_defaults_to_direct_mode() -> None:
+    command = with_bd_mode("list", "--json", beads_dir=None, env={})
+
+    assert command[:3] == ["bd", "list", "--json"]
+    assert "--no-daemon" in command
+
+
+def test_with_bd_mode_honors_explicit_daemon_env_override() -> None:
+    command = with_bd_mode(
+        "show",
+        "at-1",
+        "--json",
+        beads_dir=None,
+        env={"ATELIER_BD_DAEMON": "true"},
+    )
+
+    assert command == ["bd", "show", "at-1", "--json"]
+
+
+def test_should_use_bd_daemon_reads_project_config(tmp_path: Path) -> None:
+    project_dir = tmp_path / "project"
+    beads_dir = project_dir / ".beads"
+    beads_dir.mkdir(parents=True)
+    (project_dir / "config.sys.json").write_text('{"beads":{"mode":"daemon"}}', encoding="utf-8")
+
+    assert should_use_bd_daemon(beads_dir=str(beads_dir), env={}) is True
+
+
+def test_with_bd_mode_never_mutates_daemon_subcommands() -> None:
+    command = with_bd_mode("daemon", "status", beads_dir=None, env={})
+
+    assert command == ["bd", "daemon", "status"]


### PR DESCRIPTION
# Summary

Default agent-facing `bd` calls to direct mode, while honoring explicit daemon
configuration when a project intentionally enables daemon-backed invocations.

# Changes

- Added a shared invocation helper (`src/atelier/bd_invocation.py`) that:
  - defaults to direct mode by appending `--no-daemon`
  - skips `--no-daemon` only when daemon usage is explicitly configured via
    project `beads` config or daemon override environment variables
- Updated direct `bd` call sites in skill scripts to use the shared helper:
  - epic list renderer
  - changeset guardrails checker
  - PR ticket section renderer
- Removed one-off command wrapper functions from those scripts.
- Updated `skills/beads/SKILL.md` guidance to document default direct mode and
  explicit daemon override paths.
- Added regression coverage for both default direct mode and explicit
  daemon-enabled mode.

# Acceptance Criteria Coverage

- Agent-facing `bd` skill/script calls now default to direct mode unless daemon
  usage is explicitly configured.
- Skill guidance explicitly documents the default and the daemon override path.
- Daemon lifecycle paths (`bd daemon ...`) remain explicit and unchanged.
- Verification includes command-construction tests for common planner/worker
  skill flows.

# Testing

- `just format`
- `just lint`
- `uv run pytest tests/atelier/test_bd_invocation.py tests/atelier/skills/test_epic_list_script.py tests/atelier/skills/test_plan_changeset_guardrails_script.py tests/atelier/skills/test_pr_draft_scripts.py`
- `just test` *(fails during collection in this environment due to a pre-existing Python 3.14 `importlib.abc.Traversable` ImportError unrelated to this changeset)*

## Tickets

- Fixes #134
