### PR TITLE
Harden commit, issue, and PR draft transport safety

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -170,6 +170,19 @@ Changeset description fields include:
 - `atelier list`: list available workspaces (root branches).
 - `atelier gc`: clean up stale hooks and orphaned worktrees.
 
+### Command transport safety
+
+When Atelier drafts and submits user-authored text to external tools, command
+construction must avoid shell interpolation.
+
+- Commit messages: write content to a temporary file and use `git commit -F`.
+- Issue/PR bodies: write markdown to a temporary file and pass via body-file
+  flags (`--body-file` or provider-equivalent input-file options).
+- Titles: pass as argv values (for example `["--title", title]`) rather than
+  interpolating into shell command strings.
+
+This applies to both create and update flows.
+
 Worker modes:
 
 - `atelier work --mode prompt|auto` controls epic selection.


### PR DESCRIPTION
## Summary
- codify command transport rules so commit, issue, and PR drafting never relies on shell interpolation for user-authored text
- document file-backed body transport and argv-based title handling as a required pattern for both create and update flows
- tighten regression coverage for shell-sensitive issue titles to ensure literal argv transport with `--title`

## What Changed
- added a new **Command transport safety** section to `docs/SPEC.md` defining required behavior:
  - use `git commit -F <file>` for drafted commit messages
  - pass issue/PR markdown via file-backed inputs (`--body-file` or provider-equivalent input files)
  - pass titles as argv values rather than interpolated shell strings
- extended `tests/atelier/test_github_issues_provider.py` so `update_ticket` also asserts that a title containing backticks and shell metacharacters is passed as the exact value after `--title`

## Validation
- `uv run --extra dev pytest tests/atelier/test_github_issues_provider.py`
- `uv run ruff check docs/SPEC.md tests/atelier/test_github_issues_provider.py`
- `uv run --extra dev mdformat --check --wrap 80 docs/SPEC.md`
- `just test` currently fails at collection in this environment due an existing Python 3.14 import issue (`ImportError: cannot import name 'Traversable' from importlib.abc`) unrelated to this changeset

## Tickets
- Fixes #133
