### PR TITLE
Fix explicit-epic worker startup for standalone PR feedback

### DIFF
--- a/src/atelier/worker/session/startup.py
+++ b/src/atelier/worker/session/startup.py
@@ -380,10 +380,34 @@ def run_startup_contract_service(
     }
 
     """Apply startup-contract skill ordering to select the next epic."""
+    selected_epic: str | None = None
     if explicit_epic_id is not None:
         selected_epic = str(explicit_epic_id).strip()
         if not selected_epic:
             service.die("epic id must not be empty")
+        if branch_pr and repo_slug:
+            explicit_conflict = service.select_conflicted_changeset(
+                epic_id=selected_epic,
+                repo_slug=repo_slug,
+            )
+            if explicit_conflict is not None:
+                return StartupContractResult(
+                    epic_id=explicit_conflict.epic_id,
+                    changeset_id=explicit_conflict.changeset_id,
+                    should_exit=False,
+                    reason="merge_conflict",
+                )
+            explicit_feedback = service.select_review_feedback_changeset(
+                epic_id=selected_epic,
+                repo_slug=repo_slug,
+            )
+            if explicit_feedback is not None:
+                return StartupContractResult(
+                    epic_id=explicit_feedback.epic_id,
+                    changeset_id=explicit_feedback.changeset_id,
+                    should_exit=False,
+                    reason="review_feedback",
+                )
         return StartupContractResult(
             epic_id=selected_epic,
             changeset_id=None,


### PR DESCRIPTION
# Summary

Fix worker startup selection so explicit epic runs correctly prioritize unresolved PR review feedback and merge-conflict recovery when the epic itself is the executable changeset.

# Changes

- Updated explicit-epic startup flow to run per-epic merge-conflict and review-feedback selection before defaulting to normal explicit epic execution.
- Updated per-epic review-feedback and merge-conflict selectors to include the epic itself when it is labeled as an executable changeset (`at:changeset`), even if it has no child changesets.
- Added regression tests for:
  - explicit-epic startup prioritization of review feedback and merge conflicts
  - standalone epic-as-changeset inclusion in per-epic review-feedback and conflict selectors
  - non-claimable review-feedback candidate filtering behavior

# Testing

- `pytest -q tests/atelier/worker/test_session_startup.py`
- `pytest -q tests/atelier/worker/test_review.py`
- `just lint`
- `just test` *(fails during collection due pre-existing environment/import issue: `ImportError: cannot import name 'Traversable' from 'importlib.abc'` under Python 3.14)*

## Tickets
- Fixes #141

# Risks / Rollout

- Low risk: changes are scoped to startup selection and review/conflict candidate discovery.
- Behavior for child-changeset epics remains covered by existing and updated tests.

# Notes

- Diff summary: 4 files changed, 230 insertions, 16 deletions.
