### PR TITLE
Enforce Ruff pre-commit checks across Atelier worktrees

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/.." && pwd)"
+if ! git -C "${repo_root}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "pre-commit: ${repo_root} is not a git work tree" >&2
+  exit 1
+fi
+
+resolve_ruff_cmd() {
+  if [[ -n "${ATELIER_RUFF_BIN:-}" ]]; then
+    RUFF_CMD=("${ATELIER_RUFF_BIN}")
+    return 0
+  fi
+
+  if command -v uv >/dev/null 2>&1; then
+    RUFF_CMD=(uv run ruff)
+    return 0
+  fi
+
+  if command -v ruff >/dev/null 2>&1; then
+    RUFF_CMD=(ruff)
+    return 0
+  fi
+
+  cat >&2 <<'EOF'
+pre-commit: missing Ruff runtime (uv or ruff not found).
+pre-commit: install uv/ruff, or set ATELIER_RUFF_BIN to a Ruff executable.
+EOF
+  return 1
+}
+
+mapfile -t staged_python_files < <(
+  git -C "${repo_root}" diff --cached --name-only --diff-filter=ACMR \
+    | awk '/\.(py|pyi)$/'
+)
+
+if [[ ${#staged_python_files[@]} -eq 0 ]]; then
+  exit 0
+fi
+
+resolve_ruff_cmd
+
+if ! (
+  cd "${repo_root}" && "${RUFF_CMD[@]}" check --select I,RUF022 "${staged_python_files[@]}"
+); then
+  cat >&2 <<'EOF'
+pre-commit: Ruff lint checks failed.
+pre-commit: run 'just format' and stage updated files before committing.
+EOF
+  exit 1
+fi
+
+if ! (
+  cd "${repo_root}" && "${RUFF_CMD[@]}" format --check "${staged_python_files[@]}"
+); then
+  cat >&2 <<'EOF'
+pre-commit: Ruff formatting check failed.
+pre-commit: run 'just format' and stage updated files before committing.
+EOF
+  exit 1
+fi

--- a/.githooks/worktree-bootstrap.sh
+++ b/.githooks/worktree-bootstrap.sh
@@ -15,6 +15,7 @@ main() {
 
   local required_hooks=(
     "${HOOKS_PATH}/worktree-bootstrap.sh"
+    "${HOOKS_PATH}/pre-commit"
     "${HOOKS_PATH}/commit-msg"
     "${HOOKS_PATH}/post-checkout"
   )

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,7 +215,11 @@ ______________________________________________________________________
 
 ## Workflow Requirements
 
+- Keep repo-local hooks bootstrapped (`bash .githooks/worktree-bootstrap.sh`) so
+  `pre-commit` Ruff checks run in both the main enlistment and linked worktrees.
 - Run `just format` before making commits.
+- Treat `pre-commit` as the fast format/lint gate; keep full test execution in
+  `just test`/CI.
 - Ensure `just lint` and `just test` pass before shipping changes.
 - When merging PRs to `main`, keep merge commit messages non-Conventional (use
   the default “Merge pull request #...” message) so Release Please does not

--- a/README.md
+++ b/README.md
@@ -77,10 +77,13 @@ Command-specific details live in module docstrings under `src/atelier/commands`.
 - Git (for worktrees and branch operations)
 - `bd` on your PATH (Atelier's local planning store)
 
-## Conventional Commit Hooks
+## Repo-Local Commit Hooks
 
-This repository enforces Conventional Commits at local commit time with a
-repo-local hook path (`.githooks/`) and `commitlint.config.cjs`.
+This repository uses a repo-local hook path (`.githooks/`) for fast local
+quality gates:
+
+- `pre-commit`: Ruff lint/format checks for staged Python files.
+- `commit-msg`: Conventional Commit validation via `commitlint.config.cjs`.
 
 Bootstrap or repair hooks for an existing clone:
 
@@ -96,6 +99,9 @@ The bootstrap step is idempotent and does the following:
 
 If your environment does not expose `commitlint`, the commit hook falls back to
 `npx`. If you use a custom binary path, set `ATELIER_COMMITLINT_BIN`.
+
+If your environment does not expose `uv` or `ruff`, set `ATELIER_RUFF_BIN` to an
+executable Ruff binary path.
 
 ## Agent Setup
 

--- a/tests/shell/repo_hooks_test.sh
+++ b/tests/shell/repo_hooks_test.sh
@@ -16,9 +16,11 @@ create_temp_repo() {
   cp "${ROOT_DIR}/commitlint.config.cjs" "${repo}/commitlint.config.cjs"
   mkdir -p "${repo}/.githooks"
   cp "${ROOT_DIR}/.githooks/worktree-bootstrap.sh" "${repo}/.githooks/worktree-bootstrap.sh"
+  cp "${ROOT_DIR}/.githooks/pre-commit" "${repo}/.githooks/pre-commit"
   cp "${ROOT_DIR}/.githooks/commit-msg" "${repo}/.githooks/commit-msg"
   cp "${ROOT_DIR}/.githooks/post-checkout" "${repo}/.githooks/post-checkout"
   chmod +x "${repo}/.githooks/worktree-bootstrap.sh" \
+    "${repo}/.githooks/pre-commit" \
     "${repo}/.githooks/commit-msg" \
     "${repo}/.githooks/post-checkout"
   git -C "$repo" add commitlint.config.cjs .githooks
@@ -40,7 +42,10 @@ teardown() {
 
 test_bootstrap_sets_hookspath_and_exec_bits() {
   TMP_REPO="$(create_temp_repo)"
-  chmod -x "${TMP_REPO}/.githooks/commit-msg" "${TMP_REPO}/.githooks/post-checkout"
+  chmod -x \
+    "${TMP_REPO}/.githooks/pre-commit" \
+    "${TMP_REPO}/.githooks/commit-msg" \
+    "${TMP_REPO}/.githooks/post-checkout"
   git -C "${TMP_REPO}" config --unset-all core.hooksPath || true
 
   "${TMP_REPO}/.githooks/worktree-bootstrap.sh" >/dev/null 2>&1
@@ -50,17 +55,53 @@ test_bootstrap_sets_hookspath_and_exec_bits() {
   hooks_path="$(git -C "${TMP_REPO}" config --local --get core.hooksPath)"
   assert_equals ".githooks" "${hooks_path}"
 
-  local commit_msg_executable post_checkout_executable
+  local pre_commit_executable commit_msg_executable post_checkout_executable
+  pre_commit_executable=1
   commit_msg_executable=1
   post_checkout_executable=1
+  if [[ -x "${TMP_REPO}/.githooks/pre-commit" ]]; then
+    pre_commit_executable=0
+  fi
   if [[ -x "${TMP_REPO}/.githooks/commit-msg" ]]; then
     commit_msg_executable=0
   fi
   if [[ -x "${TMP_REPO}/.githooks/post-checkout" ]]; then
     post_checkout_executable=0
   fi
+  assert_equals 0 "${pre_commit_executable}"
   assert_equals 0 "${commit_msg_executable}"
   assert_equals 0 "${post_checkout_executable}"
+}
+
+test_pre_commit_uses_override_linter_binary_for_staged_python_files() {
+  TMP_REPO="$(create_temp_repo)"
+
+  local fake_ruff args_file expected_first expected_second actual_first actual_second
+  fake_ruff="${TMP_REPO}/fake-ruff.sh"
+  args_file="${TMP_REPO}/ruff-args.txt"
+
+  cat > "${fake_ruff}" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${ATELIER_TEST_ARGS_FILE}"
+SCRIPT
+  chmod +x "${fake_ruff}"
+
+  echo 'print("hi")' > "${TMP_REPO}/hook_target.py"
+  echo "not python" > "${TMP_REPO}/notes.txt"
+  git -C "${TMP_REPO}" add hook_target.py notes.txt
+
+  ATELIER_RUFF_BIN="${fake_ruff}" \
+    ATELIER_TEST_ARGS_FILE="${args_file}" \
+    "${TMP_REPO}/.githooks/pre-commit" >/dev/null 2>&1
+  assert_equals 0 "$?"
+
+  expected_first="check --select I,RUF022 hook_target.py"
+  expected_second="format --check hook_target.py"
+  actual_first="$(sed -n '1p' "${args_file}")"
+  actual_second="$(sed -n '2p' "${args_file}")"
+  assert_equals "${expected_first}" "${actual_first}"
+  assert_equals "${expected_second}" "${actual_second}"
 }
 
 test_commit_msg_uses_override_linter_binary() {


### PR DESCRIPTION
# Summary

Enforce Ruff formatting and lightweight lint checks at commit time so format drift is blocked locally before commits and CI runs.

# Changes

- Added `.githooks/pre-commit` to run Ruff checks on staged Python files (`ruff check --select I,RUF022` and `ruff format --check`) with clear remediation guidance.
- Updated `.githooks/worktree-bootstrap.sh` to require and chmod `pre-commit` alongside existing repo-local hooks.
- Expanded shell tests in `tests/shell/repo_hooks_test.sh` to verify bootstrap includes `pre-commit` and pre-commit invokes Ruff correctly for staged Python files.
- Updated `README.md` and `AGENTS.md` to document pre-commit Ruff enforcement and clarify that full test execution remains a downstream gate.

# Testing

- `bash tests/shell/run.sh`
- `just format`
- `just lint`
- `just test` (fails in this environment during test collection due existing Python 3.14 import error: `ImportError: cannot import name 'Traversable' from 'importlib.abc'`)

## Tickets
- Fixes #143

# Risks / Rollout

- Low risk: changes are scoped to repo-local hook wiring, docs, and hook tests.
- Existing developer environments may need one-time bootstrap (`bash .githooks/worktree-bootstrap.sh`) if `core.hooksPath` is not already set.

# Notes

- The pre-commit hook intentionally stays fast and limited to format/lint class checks; full test suite remains in CI/pre-push workflows.
