### PR TITLE
Normalize epic identity for standalone worker changesets

### DIFF
--- a/src/atelier/worker/work_startup_runtime.py
+++ b/src/atelier/worker/work_startup_runtime.py
@@ -560,6 +560,14 @@ class _StartupContractService(worker_startup.StartupContractService):
             cwd=self._repo_root,
         )
 
+    def show_issue(self, issue_id: str) -> dict[str, object] | None:
+        issues = beads.run_bd_json(
+            ["show", issue_id],
+            beads_root=self._beads_root,
+            cwd=self._repo_root,
+        )
+        return issues[0] if issues else None
+
     def next_changeset(
         self,
         *,


### PR DESCRIPTION
## Summary
Normalize identity handling for standalone top-level changesets so startup claimability and review-feedback resume apply the same executable-work rules.

## Problem
Review feedback could be selected for standalone top-level work, but startup could skip claiming it when the work item was missing the epic marker. That created a selected-then-skipped path where feedback was not resumed.

## What Changed
- Added startup fallback hydration for feedback candidate IDs that are not present in the initial epic list.
- Unified executable-work identity checks so standalone top-level changesets are treated consistently.
- Added claim-time backfill to apply the epic marker when claiming legacy standalone top-level changesets that are missing it.
- Added regression coverage for standalone feedback resume and claim-time label normalization.

## Acceptance Criteria Coverage
- Startup claimability and review-feedback selection now use consistent standalone identity rules.
- Standalone executable work is interpreted consistently across startup and claim flows.
- Worker startup can resume review feedback for standalone executable work without manual relabeling.
- Legacy standalone work missing the epic marker is handled deterministically through fallback and backfill.
- Regression tests prevent the selected-then-dropped feedback failure mode.

## Validation
- `just format`
- `just lint`
- `env -u ATELIER_AGENT_ID just test`
