### PR TITLE
Harden worker identity and executable claim boundaries

### DIFF
--- a/src/atelier/agent_home.py
+++ b/src/atelier/agent_home.py
@@ -96,6 +96,17 @@ def parse_agent_identity(agent_id: str) -> tuple[str | None, str | None, str | N
     return role, name, session_key
 
 
+def _enforce_role_consistent_agent_id(*, role: str, agent_id: str, source: str) -> None:
+    expected_role = role.strip().lower()
+    actual_role, _name, _session_key = parse_agent_identity(agent_id)
+    if actual_role is None or actual_role.strip().lower() == expected_role:
+        return
+    die(
+        f"{source} role mismatch: expected atelier/{expected_role}/<name> for this session, "
+        f"got {agent_id!r}. Unset {source} or set a matching agent identity."
+    )
+
+
 def session_pid_from_agent_id(agent_id: str) -> int | None:
     """Extract the session PID from an agent id when present."""
     _role, _name, session_key = parse_agent_identity(agent_id)
@@ -360,6 +371,11 @@ def resolve_agent_home(
         agent_id = env_agent_id.strip()
         if not agent_id:
             die("ATELIER_AGENT_ID must not be empty")
+        _enforce_role_consistent_agent_id(
+            role=role,
+            agent_id=agent_id,
+            source="ATELIER_AGENT_ID",
+        )
         agent_name = _derive_agent_name(agent_id)
     elif config_agent_id:
         agent_id = config_agent_id
@@ -523,6 +539,11 @@ def preview_agent_home(
         agent_id = env_agent_id.strip()
         if not agent_id:
             die("ATELIER_AGENT_ID must not be empty")
+        _enforce_role_consistent_agent_id(
+            role=role,
+            agent_id=agent_id,
+            source="ATELIER_AGENT_ID",
+        )
         agent_name = _derive_agent_name(agent_id)
     elif config_agent_id:
         agent_id = config_agent_id

--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -1243,8 +1243,14 @@ def claim_epic(
     labels = _issue_labels(issue)
     if "at:draft" in labels:
         die(f"epic {epic_id} is marked as draft")
+    executable_labels = {"at:epic", "at:changeset"} & labels
+    if executable_labels and _is_planner_assignee(agent_id):
+        die(
+            f"epic {epic_id} claim rejected for planner {agent_id}; "
+            "planner agents cannot claim executable work"
+        )
     existing_assignee = issue.get("assignee")
-    if _is_planner_assignee(existing_assignee) and {"at:epic", "at:changeset"} & labels:
+    if _is_planner_assignee(existing_assignee) and executable_labels:
         die(
             f"epic {epic_id} is assigned to planner {existing_assignee}; "
             "planner agents cannot own executable work"

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -209,6 +209,29 @@ def test_claim_epic_blocks_planner_owned_executable_work() -> None:
     assert "planner agents cannot own executable work" in str(die_fn.call_args.args[0])
 
 
+def test_claim_epic_rejects_planner_claimant_for_executable_work() -> None:
+    issue = {
+        "id": "atelier-9",
+        "labels": ["at:epic"],
+        "assignee": None,
+    }
+
+    with (
+        patch("atelier.beads.run_bd_json", return_value=[issue]),
+        patch("atelier.beads.run_bd_command") as run_command,
+        patch("atelier.beads.die", side_effect=RuntimeError("die called")) as die_fn,
+    ):
+        with pytest.raises(RuntimeError, match="die called"):
+            beads.claim_epic(
+                "atelier-9",
+                "atelier/planner/codex/p111",
+                beads_root=Path("/beads"),
+                cwd=Path("/repo"),
+            )
+    run_command.assert_not_called()
+    assert "planner agents cannot claim executable work" in str(die_fn.call_args.args[0])
+
+
 def test_claim_epic_backfills_epic_label_for_standalone_changeset() -> None:
     issue = {"id": "at-legacy", "labels": ["at:changeset"], "assignee": None}
     updated = {


### PR DESCRIPTION
# Summary

- Enforce worker-role identity invariants so worker runs cannot silently reuse a planner `ATELIER_AGENT_ID`.
- Reject planner identities at executable epic/changeset claim time to preserve worker/planner ownership boundaries.

# Changes

- Added role-consistency validation in agent home resolution and preview paths.
- Added explicit planner-claimant rejection in `beads.claim_epic` for executable labels.
- Added regression tests for env-role mismatch handling in both resolve/preview flows.
- Added regression tests for worker command early-fail behavior on role mismatch.
- Added regression tests for planner claimant rejection in executable claim flow.

# Testing

- `uv run pytest tests/atelier/test_agent_home.py tests/atelier/test_beads.py tests/atelier/commands/test_work.py`
- `just format`
- `just lint`
- `just test` (fails in this environment due existing Python 3.14 import error: `importlib.abc.Traversable`)

## Tickets

- Fixes #162

# Risks / Rollout

- Low risk; behavior changes are constrained to role-validation and executable-claim guardrails.

# Notes

- This change intentionally fails fast with an actionable error when role identity does not match the worker session role.
