### PR TITLE
Surface planner-owned startup blockers for review-feedback selection

### DIFF
--- a/src/atelier/worker/work_startup_runtime.py
+++ b/src/atelier/worker/work_startup_runtime.py
@@ -174,6 +174,12 @@ def _no_eligible_epics_summary(
             if ownership_detail
             else "- Ownership violations: none"
         ),
+        (
+            "- Ownership-policy blockers may prevent review-feedback pickup. "
+            "Reassign blocked epics from planner to a worker, then rerun startup."
+            if planner_owned
+            else "- Ownership-policy blockers: none detected"
+        ),
         f"- Timestamp: {timestamp}",
     ]
 

--- a/tests/atelier/worker/test_runtime.py
+++ b/tests/atelier/worker/test_runtime.py
@@ -198,3 +198,6 @@ def test_startup_service_reports_planner_owned_executable_violations() -> None:
 
     assert any("Planner-owned executable epics: 1" in line for line in emitted)
     assert any("Ownership violations: at-violation" in line for line in emitted)
+    assert any(
+        "Ownership-policy blockers may prevent review-feedback pickup." in line for line in emitted
+    )


### PR DESCRIPTION
# Summary

- Surface explicit startup diagnostics when review-feedback candidates are blocked by planner ownership.
- Include ownership-policy blocker details and remediation guidance in no-eligible startup output.
- Preserve selection priority so merge-conflict recovery still runs before review-feedback pickup.

# Changes

- Added startup-session messaging that reports planner-owned review-feedback blockers with epic identifiers and a reassignment hint.
- Added no-eligible summary messaging that calls out ownership-policy blockers to make remediation deterministic.
- Added regression coverage for planner-owned review-feedback skip behavior and ownership-blocker summary output.

# Testing

- `just test`
- `just format`
- `just lint`

## Tickets

- Fixes #163

# Risks / Rollout

- Low risk; change is limited to startup diagnostics and corresponding tests.

# Notes

- Diagnostics are informational only; ownership policy remains strict and does not auto-reassign work.
