### PR TITLE
Surface planner-owned executable blockers during startup review-feedback selection

### DIFF
--- a/src/atelier/worker/work_startup_runtime.py
+++ b/src/atelier/worker/work_startup_runtime.py
@@ -174,6 +174,12 @@ def _no_eligible_epics_summary(
             if ownership_detail
             else "- Ownership violations: none"
         ),
+        (
+            "- Ownership-policy blockers may prevent review-feedback pickup. "
+            "Reassign blocked epics from planner to a worker, then rerun startup."
+            if planner_owned
+            else "- Ownership-policy blockers: none detected"
+        ),
         f"- Timestamp: {timestamp}",
     ]
 

--- a/tests/atelier/worker/test_runtime.py
+++ b/tests/atelier/worker/test_runtime.py
@@ -198,3 +198,6 @@ def test_startup_service_reports_planner_owned_executable_violations() -> None:
 
     assert any("Planner-owned executable epics: 1" in line for line in emitted)
     assert any("Ownership violations: at-violation" in line for line in emitted)
+    assert any(
+        "Ownership-policy blockers may prevent review-feedback pickup." in line for line in emitted
+    )


### PR DESCRIPTION
## Summary
Surface planner-owned executable blockers during startup review-feedback selection

## Acceptance Criteria
- Startup selection emits explicit diagnostics when review-feedback candidates are skipped for planner-owned executable assignment, including epic id and remediation hint.
- No-eligible-epics needs-decision messaging includes ownership-policy blocker summary when applicable.
- Existing selection ordering (merge conflict before review feedback) remains unchanged.
- Tests verify at-0ca-like scenario yields explicit policy-block output instead of opaque no-eligible result.

## Tickets
- Fixes #163