### PR TITLE
Clarify CI check naming for lint vs test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,8 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  lint-test:
+  lint:
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -25,8 +26,40 @@ jobs:
         run: |
           bash scripts/lint-gate.sh
 
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install
+        run: |
+          uv venv --clear
+          uv pip install -e .[dev]
+
       - name: Test
         run: |
           uv run python -m atelier.skill_frontmatter_validation
           uv run pytest
           bash tests/shell/run.sh
+
+  lint_test_compat:
+    name: lint-test
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    if: ${{ always() }}
+    steps:
+      - name: Mirror lint/test outcome for branch-protection migration
+        run: |
+          if [ "${{ needs.lint.result }}" != "success" ]; then
+            echo "lint failed"
+            exit 1
+          fi
+          if [ "${{ needs.test.result }}" != "success" ]; then
+            echo "tests failed"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -92,6 +92,25 @@ Canonical lint gate for local/CI workflows:
 bash scripts/lint-gate.sh
 ```
 
+## CI Required Checks
+
+GitHub Actions CI publishes these check names:
+
+- `ci / lint`: lint gate (`bash scripts/lint-gate.sh`).
+- `ci / test`: Python + shell test suite.
+- `ci / lint-test`: temporary compatibility check that mirrors `lint` + `test`.
+
+Branch protection should require `ci / lint` and `ci / test`. Keep
+`ci / lint-test` only during migration from the legacy single check, then remove
+it once rulesets are updated.
+
+Troubleshooting:
+
+- `ci / lint` failed: lint or type checks failed.
+- `ci / test` failed: tests failed.
+- `ci / lint-test` failed while either check above failed: expected legacy
+  mirror behavior.
+
 Bootstrap or repair hooks for an existing clone:
 
 ```sh


### PR DESCRIPTION
# Summary

Clarifies GitHub Actions status reporting so lint and test failures are surfaced
under separate checks, while preserving branch-protection continuity during
migration.

# Changes

- Split `.github/workflows/ci.yml` into distinct `lint` and `test` jobs.
- Added a transitional `lint-test` compatibility job that mirrors lint/test
  outcomes so existing required checks keep working during rollout.
- Documented required check names, migration guidance, and troubleshooting in
  `README.md`.

# Testing

- `just format`
- `just lint`
- `just test` (run in the workspace Python 3.11 environment)

## Tickets

- Fixes #171

# Risks / Rollout

- Branch protection should move to requiring `ci / lint` and `ci / test`.
- Keep `ci / lint-test` required only during migration, then remove it.

# Notes

- The compatibility check intentionally fails whenever either `lint` or `test`
  fails, so legacy branch-protection behavior remains strict during transition.
