### PR TITLE
Improve atelier open workspace resolution for hooked epics and changeset branches

### DIFF
--- a/src/atelier/commands/open.py
+++ b/src/atelier/commands/open.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 import os
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 
-from .. import beads, branching, config, exec, term, workspace, worktrees
+from .. import beads, branching, config, exec, lifecycle, term, workspace, worktrees
 from .. import command as command_util
 from ..io import die, select
 from .resolve import resolve_current_project_with_repo_root
@@ -27,56 +28,174 @@ def _workspace_choice_label(issue: dict[str, object], root_branch: str) -> str:
     return f"{root_branch} [{status}] {title} ({issue_id})"
 
 
+@dataclass(frozen=True)
+class _WorkspaceSelection:
+    issue: dict[str, object]
+    root_branch: str
+    workspace_branch: str
+    worktree_relpath: str | None = None
+
+
+def _issue_id(issue: dict[str, object]) -> str:
+    value = issue.get("id")
+    return str(value).strip() if value is not None else ""
+
+
+def _list_eligible_epics(*, beads_root: Path, repo_root: Path) -> list[dict[str, object]]:
+    issues = beads.run_bd_json(["list", "--label", "at:epic"], beads_root=beads_root, cwd=repo_root)
+    return [
+        issue
+        for issue in issues
+        if beads.extract_workspace_root_branch(issue)
+        and lifecycle.is_eligible_epic_status(issue.get("status"), allow_hooked=True)
+    ]
+
+
+def _changeset_branch_matches(
+    *,
+    candidates: list[str],
+    project_dir: Path,
+    beads_root: Path,
+    repo_root: Path,
+) -> list[_WorkspaceSelection]:
+    candidate_set = {candidate for candidate in candidates if candidate}
+    if not candidate_set:
+        return []
+
+    matches: list[_WorkspaceSelection] = []
+    for issue in _list_eligible_epics(beads_root=beads_root, repo_root=repo_root):
+        root_branch = beads.extract_workspace_root_branch(issue)
+        if not root_branch:
+            continue
+        epic_id = _issue_id(issue)
+        if not epic_id:
+            continue
+        mapping = worktrees.load_mapping(worktrees.mapping_path(project_dir, epic_id))
+        if mapping is None:
+            continue
+        for changeset_id, work_branch in mapping.changesets.items():
+            if work_branch not in candidate_set:
+                continue
+            worktree_relpath = mapping.changeset_worktrees.get(changeset_id)
+            if not worktree_relpath:
+                continue
+            matches.append(
+                _WorkspaceSelection(
+                    issue=issue,
+                    root_branch=root_branch,
+                    workspace_branch=work_branch,
+                    worktree_relpath=worktree_relpath,
+                )
+            )
+    return matches
+
+
+def _candidate_values_message(
+    workspace_name: str, *, project_dir: Path, beads_root: Path, repo_root: Path
+) -> str:
+    issues = _list_eligible_epics(beads_root=beads_root, repo_root=repo_root)
+    root_values = sorted(
+        {
+            root_branch
+            for issue in issues
+            if (root_branch := beads.extract_workspace_root_branch(issue)) is not None
+        }
+    )
+    mapped_values: set[str] = set()
+    for issue in issues:
+        epic_id = _issue_id(issue)
+        if not epic_id:
+            continue
+        mapping = worktrees.load_mapping(worktrees.mapping_path(project_dir, epic_id))
+        if mapping is None:
+            continue
+        mapped_values.update(branch for branch in mapping.changesets.values() if branch)
+    roots = ", ".join(root_values[:8]) if root_values else "(none)"
+    if mapped_values:
+        mapped = ", ".join(sorted(mapped_values)[:8])
+        return (
+            f"no epic or mapped changeset worktree found for workspace {workspace_name!r}. "
+            f"valid root workspaces: {roots}. mapped changeset branches: {mapped}"
+        )
+    return f"no epic found for workspace {workspace_name!r}. valid root workspaces: {roots}"
+
+
 def _select_epic_by_workspace(
     *,
+    project_dir: Path,
     workspace_name: str | None,
     raw: bool,
     branch_prefix: str,
     beads_root: Path,
     repo_root: Path,
-) -> tuple[dict[str, object], str]:
+) -> _WorkspaceSelection:
     if workspace_name:
         candidates = branching.candidates_for_root_branch(workspace_name, branch_prefix, raw)
-        matches: list[dict[str, object]] = []
+        matches: list[_WorkspaceSelection] = []
         for candidate in candidates:
-            matches.extend(
-                beads.find_epics_by_root_branch(candidate, beads_root=beads_root, cwd=repo_root)
+            for issue in beads.find_epics_by_root_branch(
+                candidate, beads_root=beads_root, cwd=repo_root
+            ):
+                root_branch = beads.extract_workspace_root_branch(issue)
+                if not root_branch:
+                    continue
+                matches.append(
+                    _WorkspaceSelection(
+                        issue=issue,
+                        root_branch=root_branch,
+                        workspace_branch=root_branch,
+                    )
+                )
+        if not matches:
+            matches = _changeset_branch_matches(
+                candidates=candidates,
+                project_dir=project_dir,
+                beads_root=beads_root,
+                repo_root=repo_root,
             )
         if not matches:
-            die(f"no epic found for workspace {workspace_name!r}")
+            die(
+                _candidate_values_message(
+                    workspace_name,
+                    project_dir=project_dir,
+                    beads_root=beads_root,
+                    repo_root=repo_root,
+                )
+            )
     else:
-        matches = beads.run_bd_json(
-            ["list", "--label", "at:epic"], beads_root=beads_root, cwd=repo_root
-        )
         matches = [
-            issue
-            for issue in matches
-            if beads.extract_workspace_root_branch(issue) is not None
-            and str(issue.get("status") or "").lower() in {"", "open", "in_progress", "ready"}
+            _WorkspaceSelection(
+                issue=issue,
+                root_branch=root_branch,
+                workspace_branch=root_branch,
+            )
+            for issue in _list_eligible_epics(beads_root=beads_root, repo_root=repo_root)
+            if (root_branch := beads.extract_workspace_root_branch(issue)) is not None
         ]
         if not matches:
             die("no epics with workspace branches found")
 
-    choices: dict[str, dict[str, object]] = {}
-    for issue in matches:
-        root_branch = beads.extract_workspace_root_branch(issue)
-        if not root_branch:
+    choices: dict[str, _WorkspaceSelection] = {}
+    seen: set[tuple[str, str, str | None]] = set()
+    for selection in matches:
+        issue = selection.issue
+        issue_id = _issue_id(issue)
+        dedupe_key = (issue_id, selection.workspace_branch, selection.worktree_relpath)
+        if dedupe_key in seen:
             continue
+        seen.add(dedupe_key)
+        root_branch = selection.workspace_branch
         label = _workspace_choice_label(issue, root_branch)
-        choices[label] = issue
+        choices[label] = selection
 
     if not choices:
         die("no eligible epics found for the workspace selection")
 
     if len(choices) == 1:
-        issue = next(iter(choices.values()))
-        root_branch = beads.extract_workspace_root_branch(issue) or ""
-        return issue, root_branch
+        return next(iter(choices.values()))
 
     selection = select("Workspace to open", list(choices.keys()))
-    issue = choices[selection]
-    root_branch = beads.extract_workspace_root_branch(issue) or ""
-    return issue, root_branch
+    return choices[selection]
 
 
 def _resolve_worktree_path(
@@ -92,8 +211,6 @@ def _resolve_worktree_path(
     if mapping is None:
         if not worktree_relpath:
             die("worktree not initialized; run 'atelier work' first")
-        candidate = Path(worktree_relpath)
-        worktree_path = candidate if candidate.is_absolute() else project_dir / candidate
     else:
         mapping = worktrees.ensure_worktree_mapping(
             project_dir,
@@ -102,7 +219,13 @@ def _resolve_worktree_path(
             repo_root=repo_root,
             git_path=git_path,
         )
-        worktree_path = project_dir / mapping.worktree_path
+    target_relpath = worktree_relpath
+    if not target_relpath and mapping is not None:
+        target_relpath = mapping.worktree_path
+    if not target_relpath:
+        die("worktree not initialized; run 'atelier work' first")
+    candidate = Path(target_relpath)
+    worktree_path = candidate if candidate.is_absolute() else project_dir / candidate
     if not worktree_path.exists():
         die("worktree missing; run 'atelier work' first")
     if not (worktree_path / ".git").exists():
@@ -190,28 +313,31 @@ def open_worktree(args: object) -> None:
     beads_root = config.resolve_beads_root(project_data_dir, repo_root)
     beads.run_bd_command(["prime"], beads_root=beads_root, cwd=repo_root)
 
-    issue, root_branch = _select_epic_by_workspace(
+    selection = _select_epic_by_workspace(
+        project_dir=project_data_dir,
         workspace_name=str(workspace_name) if workspace_name else None,
         raw=raw,
         branch_prefix=project_config.branch.prefix,
         beads_root=beads_root,
         repo_root=repo_root,
     )
-    if not root_branch:
+    if not selection.root_branch:
         die("selected epic is missing workspace.root_branch")
 
     worktree_path = _resolve_worktree_path(
         project_data_dir,
         repo_root,
-        str(issue.get("id") or ""),
-        root_branch,
-        beads.extract_worktree_path(issue),
+        str(selection.issue.get("id") or ""),
+        selection.root_branch,
+        selection.worktree_relpath or beads.extract_worktree_path(selection.issue),
         git_path=git_path,
     )
     project_enlistment = project_config.project.enlistment or enlistment_path
-    env = workspace.workspace_environment(project_enlistment, root_branch, worktree_path)
+    env = workspace.workspace_environment(
+        project_enlistment, selection.workspace_branch, worktree_path
+    )
     if set_title:
-        title = term.workspace_title(project_enlistment, root_branch)
+        title = term.workspace_title(project_enlistment, selection.workspace_branch)
         term.emit_title_escape(title)
 
     target_dir = worktree_path if workspace_root else worktree_path


### PR DESCRIPTION
# Summary

- Make `atelier open` include hooked epics when selecting a workspace with no explicit name.
- Allow `atelier open <name>` to resolve mapped changeset work branches, not only epic root workspace names.
- Return actionable lookup errors that suggest valid root workspaces and mapped changeset branches.

# Changes

- Added workspace-selection helpers in `open` command flow to:
  - include `hooked` epic status in no-arg candidate discovery,
  - scan worktree mapping metadata for matching `changeset.work_branch` values,
  - resolve matching changeset branches to their mapped changeset worktree paths.
- Updated worktree path resolution to honor an explicitly selected mapped changeset worktree path while still reconciling epic mapping metadata when present.
- Added regression coverage for:
  - hooked-only no-arg workspace selection,
  - explicit root workspace open,
  - explicit mapped changeset branch open,
  - unresolved lookup suggestions.

# Testing

- `pytest -q tests/atelier/commands/test_open.py`
- `UV_PROJECT_ENVIRONMENT=/Users/scott/code/atelier/.venv just format`
- `UV_PROJECT_ENVIRONMENT=/Users/scott/code/atelier/.venv just lint`
- `UV_PROJECT_ENVIRONMENT=/Users/scott/code/atelier/.venv just test`

# Risks / Rollout

- Low risk, scoped to workspace resolution logic in `atelier open` plus focused tests.
- Behavior is unchanged for existing explicit root workspace lookups.

# Notes

- Worktree resolution remains deterministic and does not auto-switch branches.
