### PR TITLE
Fix GC pruning for stale session-scoped agent beads

### DIFF
--- a/src/atelier/commands/gc.py
+++ b/src/atelier/commands/gc.py
@@ -967,11 +967,20 @@ def _gc_agent_homes(
         ["list", "--label", "at:agent"], beads_root=beads_root, cwd=repo_root
     )
     epics = beads.run_bd_json(["list", "--label", "at:epic"], beads_root=beads_root, cwd=repo_root)
-    active_assignees = {
-        str(epic.get("assignee"))
-        for epic in epics
-        if isinstance(epic.get("assignee"), str) and str(epic.get("assignee")).strip()
-    }
+    epics_by_id: dict[str, dict[str, object]] = {}
+    epics_by_assignee: dict[str, list[dict[str, object]]] = {}
+    for epic in epics:
+        epic_id = epic.get("id")
+        if isinstance(epic_id, str) and epic_id:
+            epics_by_id[epic_id] = epic
+        assignee = epic.get("assignee")
+        if not isinstance(assignee, str):
+            continue
+        assignee_id = assignee.strip()
+        if not assignee_id:
+            continue
+        epics_by_assignee.setdefault(assignee_id, []).append(epic)
+
     for issue in agent_issues:
         description = issue.get("description")
         fields = beads.parse_description_fields(description if isinstance(description, str) else "")
@@ -979,26 +988,53 @@ def _gc_agent_homes(
         if not isinstance(agent_id, str) or not agent_id.strip():
             continue
         agent_id = agent_id.strip()
+        issue_id = issue.get("id")
+        if not isinstance(issue_id, str) or not issue_id:
+            continue
         if agent_home.session_pid_from_agent_id(agent_id) is None:
             continue
         if agent_home.is_session_agent_active(agent_id):
             continue
-        issue_id = issue.get("id")
         hook_bead = None
-        if isinstance(issue_id, str) and issue_id:
+        if issue_id:
             hook_bead = beads.get_agent_hook(issue_id, beads_root=beads_root, cwd=repo_root)
         if not hook_bead:
             hook_bead = fields.get("hook_bead")
-        if hook_bead:
-            continue
-        if agent_id in active_assignees:
-            continue
-        home_path = agent_home.session_home_path_for_agent_id(project_dir, agent_id)
-        if home_path is None or not home_path.exists():
-            continue
-        description_text = f"Remove stale agent home for {agent_id}"
 
-        def _apply_remove(agent: str = agent_id) -> None:
+        dependent_epics: list[dict[str, object]] = []
+        dependent_epic_ids: set[str] = set()
+        if isinstance(hook_bead, str) and hook_bead:
+            hooked_epic = epics_by_id.get(hook_bead)
+            if hooked_epic is not None:
+                dependent_epics.append(hooked_epic)
+                dependent_epic_ids.add(hook_bead)
+        for epic in epics_by_assignee.get(agent_id, []):
+            epic_id = epic.get("id")
+            if not isinstance(epic_id, str) or not epic_id:
+                continue
+            if epic_id in dependent_epic_ids:
+                continue
+            dependent_epics.append(epic)
+            dependent_epic_ids.add(epic_id)
+
+        description_text = f"Prune stale session agent bead for {agent_id}"
+
+        def _apply_remove(
+            agent: str = agent_id,
+            agent_bead_id: str = issue_id,
+            has_hook: bool = isinstance(hook_bead, str) and bool(hook_bead),
+            epics_to_release: tuple[dict[str, object], ...] = tuple(dependent_epics),
+        ) -> None:
+            for epic_issue in epics_to_release:
+                _release_epic(epic_issue, beads_root=beads_root, cwd=repo_root)
+            if has_hook:
+                beads.clear_agent_hook(agent_bead_id, beads_root=beads_root, cwd=repo_root)
+            beads.run_bd_command(
+                ["close", agent_bead_id],
+                beads_root=beads_root,
+                cwd=repo_root,
+                allow_failure=True,
+            )
             agent_home.cleanup_agent_home_by_id(project_dir, agent)
 
         actions.append(GcAction(description=description_text, apply=_apply_remove))

--- a/tests/atelier/commands/test_gc.py
+++ b/tests/atelier/commands/test_gc.py
@@ -119,6 +119,121 @@ def test_gc_removes_stale_session_agent_home() -> None:
         assert not stale_home.exists()
 
 
+def test_gc_agent_homes_prunes_stale_session_agent_beads_deterministically() -> None:
+    project_dir = Path("/project")
+    beads_root = Path("/beads")
+    repo_root = Path("/repo")
+
+    live_agent = "atelier/worker/codex/p1111-t1"
+    stale_hook_agent = "atelier/worker/codex/p2222-t2"
+    stale_no_hook_agent = "atelier/worker/codex/p3333-t3"
+    legacy_agent = "atelier/worker/codex"
+
+    agent_issues = [
+        {
+            "id": "agent-live",
+            "title": live_agent,
+            "labels": ["at:agent"],
+            "description": f"agent_id: {live_agent}\nrole_type: worker\n",
+        },
+        {
+            "id": "agent-stale-hook",
+            "title": stale_hook_agent,
+            "labels": ["at:agent"],
+            "description": f"agent_id: {stale_hook_agent}\nrole_type: worker\n",
+        },
+        {
+            "id": "agent-stale-nohook",
+            "title": stale_no_hook_agent,
+            "labels": ["at:agent"],
+            "description": f"agent_id: {stale_no_hook_agent}\nrole_type: worker\n",
+        },
+        {
+            "id": "agent-legacy",
+            "title": legacy_agent,
+            "labels": ["at:agent"],
+            "description": f"agent_id: {legacy_agent}\nrole_type: worker\n",
+        },
+    ]
+    epics = [
+        {
+            "id": "epic-1",
+            "labels": ["at:epic", "at:hooked"],
+            "assignee": stale_hook_agent,
+            "status": "hooked",
+            "description": "",
+        }
+    ]
+
+    calls: list[tuple[str, str]] = []
+
+    def fake_run_bd_json(
+        args: list[str], *, beads_root: Path, cwd: Path
+    ) -> list[dict[str, object]]:
+        if args[:3] == ["list", "--label", "at:agent"]:
+            return agent_issues
+        if args[:3] == ["list", "--label", "at:epic"]:
+            return epics
+        return []
+
+    def fake_run_bd_command(
+        args: list[str], *, beads_root: Path, cwd: Path, allow_failure: bool = False
+    ) -> object:
+        if args[:1] == ["close"] and len(args) >= 2:
+            calls.append(("close", str(args[1])))
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    def fake_is_session_agent_active(agent_id: str) -> bool:
+        return agent_id == live_agent
+
+    with (
+        patch("atelier.commands.gc.beads.run_bd_json", side_effect=fake_run_bd_json),
+        patch("atelier.commands.gc.beads.run_bd_command", side_effect=fake_run_bd_command),
+        patch(
+            "atelier.commands.gc.beads.get_agent_hook",
+            side_effect=lambda issue_id, *, beads_root, cwd: {"agent-stale-hook": "epic-1"}.get(
+                issue_id
+            ),
+        ),
+        patch(
+            "atelier.commands.gc.agent_home.is_session_agent_active",
+            side_effect=fake_is_session_agent_active,
+        ),
+        patch(
+            "atelier.commands.gc._release_epic",
+            side_effect=lambda epic, *, beads_root, cwd: calls.append(("release", str(epic["id"]))),
+        ),
+        patch(
+            "atelier.commands.gc.beads.clear_agent_hook",
+            side_effect=lambda issue_id, *, beads_root, cwd: calls.append(("clear", issue_id)),
+        ),
+        patch(
+            "atelier.commands.gc.agent_home.cleanup_agent_home_by_id",
+            side_effect=lambda project_dir, agent_id: calls.append(("cleanup", agent_id)),
+        ),
+    ):
+        actions = gc_cmd._gc_agent_homes(
+            project_dir=project_dir,
+            beads_root=beads_root,
+            repo_root=repo_root,
+        )
+        assert [action.description for action in actions] == [
+            f"Prune stale session agent bead for {stale_hook_agent}",
+            f"Prune stale session agent bead for {stale_no_hook_agent}",
+        ]
+        for action in actions:
+            action.apply()
+
+    assert calls == [
+        ("release", "epic-1"),
+        ("clear", "agent-stale-hook"),
+        ("close", "agent-stale-hook"),
+        ("cleanup", stale_hook_agent),
+        ("close", "agent-stale-nohook"),
+        ("cleanup", stale_no_hook_agent),
+    ]
+
+
 def test_normalize_changeset_labels_for_status_uses_status_authority() -> None:
     issue = {
         "id": "at-123",


### PR DESCRIPTION
## Summary
- prune stale session-scoped `at:agent` beads during `atelier gc` when the session process is no longer active
- release stale hook/claim ownership on associated epics before archiving the stale agent bead
- continue cleaning up any stale session home directories for the same agent

## Behavior
- active session-scoped agent beads remain untouched
- non-session (legacy) agent beads are not pruned
- stale session agents with hook metadata are unhooked safely before their bead is closed
- stale session agents without hooks are closed deterministically

## Testing
- `pytest tests/atelier/commands/test_gc.py -q`
- `just format`
- `just lint`
- `just test`
