### PR TITLE
Reconcile dependent branch lineage after parent integration

### DIFF
--- a/src/atelier/worker/work_finalization_state.py
+++ b/src/atelier/worker/work_finalization_state.py
@@ -555,6 +555,29 @@ def changeset_base_branch(
             repo_root=repo_root,
             git_path=git_path,
         ):
+            changeset_id = issue.get("id")
+            if beads_root is not None and isinstance(changeset_id, str) and changeset_id:
+                root_base = (
+                    git.git_rev_parse(repo_root, root_branch, git_path=git_path)
+                    if root_branch
+                    else None
+                )
+                parent_base = git.git_rev_parse(
+                    repo_root,
+                    integration_parent_branch,
+                    git_path=git_path,
+                )
+                beads.update_changeset_branch_metadata(
+                    changeset_id,
+                    root_branch=root_branch,
+                    parent_branch=integration_parent_branch,
+                    work_branch=changeset_work_branch(issue),
+                    root_base=root_base,
+                    parent_base=parent_base,
+                    beads_root=beads_root,
+                    cwd=repo_root,
+                    allow_override=True,
+                )
             return integration_parent_branch
     if parent_branch:
         if root_branch and parent_branch == root_branch:


### PR DESCRIPTION
# Summary

- keep dependent changesets aligned to the active integration branch after their stacked parent has been merged

# Changes

- update `changeset_base_branch` to persist reconciled lineage metadata when the current parent branch is already integrated into the workspace/default parent branch
- write `changeset.parent_branch` and `changeset.parent_base` with the integration branch values so follow-on PR retargeting/restack logic uses deterministic base metadata
- add a regression test that covers dependency-derived parent lineage transitioning from merged feature branch to `main`

# Testing

- `uv run pytest tests/atelier/worker/test_work_finalization_state.py -q`
- `uv run pytest tests/atelier/worker/test_finalize_pipeline.py -q`
- `uv run pytest tests/atelier/worker/test_pr_gate.py -q`
- `just format`
- `just lint`
- `just test`

# Tickets

- Fixes #180

# Risks / Rollout

- low risk; this only changes metadata persistence in a path that already resolved the integration base branch

# Notes

- dependency edges remain untouched; only mutable execution lineage metadata is reconciled
