### PR TITLE
Fix sequential gating for transitive duplicate dependencies

### DIFF
--- a/tests/atelier/test_dependency_lineage.py
+++ b/tests/atelier/test_dependency_lineage.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from atelier import dependency_lineage
+
+
+def test_resolve_parent_lineage_prefers_unique_transitive_frontier_dependency() -> None:
+    issue = {
+        "description": (
+            "changeset.parent_branch: feature-root\nchangeset.root_branch: feature-root\n"
+        ),
+        "dependencies": ["cs-1", "cs-2"],
+    }
+    lookup = {
+        "cs-1": {
+            "id": "cs-1",
+            "description": "changeset.work_branch: feature-parent-1\n",
+        },
+        "cs-2": {
+            "id": "cs-2",
+            "description": "changeset.work_branch: feature-parent-2\n",
+            "dependencies": ["cs-1"],
+        },
+    }
+
+    lineage = dependency_lineage.resolve_parent_lineage(
+        issue,
+        root_branch="feature-root",
+        lookup_issue=lookup.get,
+    )
+
+    assert lineage.blocked is False
+    assert lineage.dependency_parent_id == "cs-2"
+    assert lineage.dependency_parent_branch == "feature-parent-2"
+    assert lineage.used_dependency_parent is True
+    assert lineage.effective_parent_branch == "feature-parent-2"
+
+
+def test_resolve_parent_lineage_fails_closed_when_dependency_frontier_is_ambiguous() -> None:
+    issue = {
+        "description": (
+            "changeset.parent_branch: feature-root\nchangeset.root_branch: feature-root\n"
+        ),
+        "dependencies": ["cs-1", "cs-2"],
+    }
+    lookup = {
+        "cs-1": {
+            "id": "cs-1",
+            "description": "changeset.work_branch: feature-parent-1\n",
+        },
+        "cs-2": {
+            "id": "cs-2",
+            "description": "changeset.work_branch: feature-parent-2\n",
+        },
+    }
+
+    lineage = dependency_lineage.resolve_parent_lineage(
+        issue,
+        root_branch="feature-root",
+        lookup_issue=lookup.get,
+    )
+
+    assert lineage.blocked is True
+    assert lineage.blocker_reason == "dependency-lineage-ambiguous"
+    assert lineage.dependency_parent_id is None
+    assert lineage.dependency_parent_branch is None
+    assert lineage.diagnostics
+    assert lineage.diagnostics[0].startswith("ambiguous dependency parent branches:")


### PR DESCRIPTION
# Summary

- Make sequential PR gating deterministic when a changeset lists redundant direct dependencies (for example, `A` and `B` where `B` already depends on `A`).

# Changes

- Added transitive dependency-closure resolution in `dependency_lineage` and selected a unique frontier parent when dependency ordering is provable.
- Preserved fail-closed behavior for true multi-parent ambiguity with explicit diagnostics.
- Cached dependency issue lookups during lineage resolution to avoid repeated fetches.
- Added focused regression coverage in:
  - `tests/atelier/test_dependency_lineage.py`
  - `tests/atelier/worker/test_pr_gate.py`
  - `tests/atelier/commands/test_status.py`

# Testing

- `just test`
- `just format`
- `just lint`

## Tickets

- Fixes #185

# Risks / Rollout

- Main behavior change is limited to dependency-parent selection when there are multiple dependency candidates.
- Ambiguous graphs still block closed, so fallback safety is preserved.

# Notes

- Regression tests cover both deterministic transitive-duplicate normalization and true ambiguity preservation.
