### PR TITLE
Make draft implicit and require explicit at:ready for executable work

### DIFF
--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -1394,9 +1394,14 @@ def claim_epic(
         die(f"epic not found: {epic_id}")
     issue = issues[0]
     labels = _issue_labels(issue)
-    if "at:draft" in labels:
-        die(f"epic {epic_id} is marked as draft")
     executable_labels = {"at:epic", "at:changeset"} & labels
+    if executable_labels and "at:draft" in labels:
+        die(
+            f"epic {epic_id} carries legacy at:draft label; "
+            "remove at:draft and rely on at:ready for executable readiness"
+        )
+    if executable_labels and "at:ready" not in labels:
+        die(f"epic {epic_id} is not marked at:ready")
     if executable_labels and _is_planner_assignee(agent_id):
         die(
             f"epic {epic_id} claim rejected for planner {agent_id}; "

--- a/src/atelier/planner_overview.py
+++ b/src/atelier/planner_overview.py
@@ -31,7 +31,7 @@ def render_epics(issues: list[dict[str, object]], *, show_drafts: bool) -> str:
 
     Args:
         issues: Beads epic issue payloads.
-        show_drafts: Include `at:draft` epics when true.
+        show_drafts: Include non-ready epics when true.
 
     Returns:
         Deterministic plain-text listing grouped by epic state buckets.
@@ -136,12 +136,14 @@ def _blocking_dependencies(issue: dict[str, object]) -> list[str]:
 
 
 def _status_bucket(issue: dict[str, object], *, show_drafts: bool) -> str | None:
-    labels = _labels(issue)
-    if "at:draft" in labels:
-        return "draft" if show_drafts else None
     status = _normalize_status(issue.get("status"))
     if status in {"closed", "done"}:
         return None
+    labels = _labels(issue)
+    if "at:draft" in labels and "at:ready" in labels:
+        return "other"
+    if "at:ready" not in labels:
+        return "draft" if show_drafts else None
     if _blocking_dependencies(issue):
         return "blocked"
     if status in {"blocked"}:

--- a/src/atelier/skills/beads/references/beads-conventions.md
+++ b/src/atelier/skills/beads/references/beads-conventions.md
@@ -9,7 +9,8 @@ projects. Stick to core Beads fields so existing Beads repos remain compatible.
 - `at:changeset` for changeset tasks
 - do not use `at:subtask` for executable work; nested units remain
   `at:changeset`
-- `at:draft` for epics that are not claimable
+- `at:ready` for executable beads that are claimable; missing `at:ready` implies
+  draft/planning state
 - `at:hooked` for epics claimed by an agent
 - `at:message` for message beads
 - `at:unread` for unread message beads

--- a/src/atelier/skills/epic-list/SKILL.md
+++ b/src/atelier/skills/epic-list/SKILL.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Inputs
 
-- show_drafts: Optional boolean to include draft epics.
+- show_drafts: Optional boolean to include non-ready (implicit draft) epics.
 - beads_dir: Optional Beads store path (defaults to repo .beads).
 
 ## Steps
@@ -39,4 +39,4 @@ The output must be:
 
 - Output includes each eligible epic id and title in the required format.
 - Closed epics are excluded.
-- Draft epics appear only when `show_drafts` is enabled.
+- Non-ready epics appear only when `show_drafts` is enabled.

--- a/src/atelier/skills/epic-list/scripts/list_epics.py
+++ b/src/atelier/skills/epic-list/scripts/list_epics.py
@@ -52,7 +52,7 @@ def main() -> None:
     parser.add_argument(
         "--show-drafts",
         action="store_true",
-        help="include draft epics alongside active non-closed epics",
+        help="include non-ready epics alongside active non-closed epics",
     )
     parser.add_argument(
         "--beads-dir",

--- a/src/atelier/skills/plan-promote-epic/SKILL.md
+++ b/src/atelier/skills/plan-promote-epic/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: plan-promote-epic
 description: >-
-  Promote a draft epic to ready with explicit confirmation after readiness
+  Promote an epic to ready with explicit confirmation after readiness
   checks. Use when planning is complete.
 ---
 
@@ -9,7 +9,7 @@ description: >-
 
 ## Inputs
 
-- epic_id: Draft epic bead id to promote.
+- epic_id: Epic bead id to promote.
 - beads_dir: Optional Beads store path.
 
 ## Readiness checks
@@ -27,7 +27,7 @@ description: >-
 
 ## Steps
 
-1. Show the epic and verify it is labeled `at:draft`.
+1. Show the epic and verify it is not already labeled `at:ready`.
 1. List child changesets and confirm which are fully defined.
 1. If there are no child changesets and the epic is single-changeset sized:
    - Add `at:changeset` to the epic.
@@ -41,14 +41,13 @@ description: >-
 1. Summarize the executable unit(s) for the user (child changesets or the epic
    itself).
 1. Ask for explicit confirmation to promote.
-1. On approval, remove `at:draft` and add `at:ready`.
+1. On approval, add `at:ready` (do not use `at:draft`).
 1. Promote each fully-defined `cs:planned` child changeset to `cs:ready`
    regardless of current dependency blockers.
 1. Let dependency resolution determine runnability (`bd ready`) at worker time.
 
 ## Verification
 
-- Epic no longer has `at:draft`.
 - Epic includes `at:ready`.
 - If the epic has child changesets, all fully-defined children are labeled
   `cs:ready`.

--- a/src/atelier/skills/startup-contract/SKILL.md
+++ b/src/atelier/skills/startup-contract/SKILL.md
@@ -25,7 +25,8 @@ description: >-
    - Check inbox/queue (message beads) and handle any messages; stop if a
      message requires action before claiming new work.
 1. If still idle:
-   - List eligible epics (`bd list --label at:epic`) and filter out drafts.
+   - List eligible epics (`bd list --label at:epic`) and keep only items with
+     explicit `at:ready`.
    - In auto mode: pick the oldest ready epic; if none, pick the oldest
      unfinished epic already assigned to `agent_id`.
    - In prompt mode: list eligible epics and ask for an epic id.

--- a/src/atelier/worker/session/startup.py
+++ b/src/atelier/worker/session/startup.py
@@ -175,7 +175,7 @@ def next_changeset_service(
         issue = target
         issue_id = issue.get("id")
         labels = service.issue_labels(issue)
-        if "at:draft" in labels:
+        if "at:draft" in labels or "at:ready" not in labels:
             return None
         if (
             isinstance(issue_id, str)
@@ -539,6 +539,9 @@ def run_startup_contract_service(
         if "at:draft" in labels:
             atelier_log.debug(f"startup skipping {stage} epic={epic_id} reason=draft")
             return False
+        if "at:ready" not in labels:
+            atelier_log.debug(f"startup skipping {stage} epic={epic_id} reason=not_ready")
+            return False
         status = str(issue.get("status") or "")
         if status and not worker_selection.is_eligible_status(status, allow_hooked=True):
             atelier_log.debug(
@@ -723,7 +726,7 @@ def run_startup_contract_service(
             if str(status).strip().lower() not in {"open", "ready", "in_progress"}:
                 continue
             labels = worker_selection.issue_labels(issue)
-            if "at:draft" in labels:
+            if "at:draft" in labels or "at:ready" not in labels:
                 continue
             if not is_claimable(issue_id, stage="review-feedback"):
                 continue

--- a/src/atelier/worker/work_runtime_common.py
+++ b/src/atelier/worker/work_runtime_common.py
@@ -331,7 +331,7 @@ def filter_epics(
     assignee: str | None = None,
     require_unassigned: bool = False,
 ) -> list[dict[str, object]]:
-    """Filter epics according to assignment and draft status.
+    """Filter epics according to assignment and explicit ready status.
 
     Args:
         issues: Candidate issue payloads.

--- a/tests/atelier/skills/test_epic_list_script.py
+++ b/tests/atelier/skills/test_epic_list_script.py
@@ -43,6 +43,19 @@ def test_status_bucket_ignores_closed_dependency_for_open_epic() -> None:
     assert bucket == "open"
 
 
+def test_status_bucket_treats_missing_ready_as_draft() -> None:
+    module = _load_script()
+    issue = {
+        "id": "at-a1",
+        "status": "open",
+        "labels": ["at:epic"],
+    }
+
+    bucket = module._status_bucket(issue, show_drafts=True)
+
+    assert bucket == "draft"
+
+
 def test_render_epics_includes_blocker_list_for_blocked_bucket() -> None:
     module = _load_script()
     blocked = {

--- a/tests/atelier/worker/test_selection.py
+++ b/tests/atelier/worker/test_selection.py
@@ -1,14 +1,15 @@
 from atelier.worker import selection
 
 
-def test_filter_epics_excludes_drafts_and_requires_unassigned() -> None:
+def test_filter_epics_requires_explicit_ready_and_requires_unassigned() -> None:
     issues = [
-        {"id": "at-1", "status": "open", "labels": ["at:epic"], "assignee": None},
-        {"id": "at-2", "status": "open", "labels": ["at:draft"], "assignee": None},
+        {"id": "at-1", "status": "open", "labels": ["at:epic", "at:ready"], "assignee": None},
+        {"id": "at-2", "status": "open", "labels": ["at:epic", "at:draft"], "assignee": None},
+        {"id": "at-4", "status": "open", "labels": ["at:epic"], "assignee": None},
         {
             "id": "at-3",
             "status": "in_progress",
-            "labels": ["at:epic"],
+            "labels": ["at:epic", "at:ready"],
             "assignee": "worker/a",
         },
     ]
@@ -61,14 +62,14 @@ def test_select_epic_auto_prefers_ready_before_assigned() -> None:
         {
             "id": "at-assigned",
             "status": "in_progress",
-            "labels": ["at:epic"],
+            "labels": ["at:epic", "at:ready"],
             "assignee": "worker/1",
             "created_at": "2026-02-22T00:00:00+00:00",
         },
         {
             "id": "at-ready",
             "status": "open",
-            "labels": ["at:epic"],
+            "labels": ["at:epic", "at:ready"],
             "assignee": None,
             "created_at": "2026-02-21T00:00:00+00:00",
         },
@@ -89,14 +90,14 @@ def test_select_epic_prompt_supports_assume_yes() -> None:
             "id": "at-ready",
             "status": "open",
             "title": "Ready epic",
-            "labels": ["at:epic"],
+            "labels": ["at:epic", "at:ready"],
             "assignee": None,
         },
         {
             "id": "at-resume",
             "status": "in_progress",
             "title": "Resume epic",
-            "labels": ["at:epic"],
+            "labels": ["at:epic", "at:ready"],
             "assignee": "worker/1",
             "updated_at": "2026-02-22T00:00:00+00:00",
         },
@@ -119,21 +120,21 @@ def test_stale_family_assigned_epics_filters_to_inactive_family_members() -> Non
         {
             "id": "at-stale",
             "status": "in_progress",
-            "labels": ["at:epic"],
+            "labels": ["at:epic", "at:ready"],
             "assignee": "atelier/worker/codex/p111",
             "created_at": "2026-02-20T00:00:00+00:00",
         },
         {
             "id": "at-active",
             "status": "in_progress",
-            "labels": ["at:epic"],
+            "labels": ["at:epic", "at:ready"],
             "assignee": "atelier/worker/codex/p222",
             "created_at": "2026-02-21T00:00:00+00:00",
         },
         {
             "id": "at-other-family",
             "status": "in_progress",
-            "labels": ["at:epic"],
+            "labels": ["at:epic", "at:ready"],
             "assignee": "atelier/planner/codex/p333",
             "created_at": "2026-02-22T00:00:00+00:00",
         },
@@ -150,7 +151,7 @@ def test_stale_family_assigned_epics_filters_to_inactive_family_members() -> Non
 
 def test_select_epic_from_ready_changesets_uses_epic_for_child_issue() -> None:
     issues = [
-        {"id": "at-epic", "labels": ["at:epic"], "assignee": None},
+        {"id": "at-epic", "labels": ["at:epic", "at:ready"], "assignee": None},
     ]
     ready_changesets = [
         {"id": "at-epic.1", "created_at": "2026-02-20T00:00:00+00:00"},
@@ -170,13 +171,13 @@ def test_filter_epics_skips_planner_owned_executable_issue() -> None:
         {
             "id": "at-planner",
             "status": "open",
-            "labels": ["at:epic"],
+            "labels": ["at:epic", "at:ready"],
             "assignee": "atelier/planner/codex/p333",
         },
         {
             "id": "at-worker",
             "status": "open",
-            "labels": ["at:epic"],
+            "labels": ["at:epic", "at:ready"],
             "assignee": None,
         },
     ]
@@ -195,7 +196,7 @@ def test_select_epic_from_ready_changesets_skips_planner_owned_epic() -> None:
     issues = [
         {
             "id": "at-epic",
-            "labels": ["at:epic"],
+            "labels": ["at:epic", "at:ready"],
             "assignee": "atelier/planner/codex/p333",
         },
     ]

--- a/tests/atelier/worker/test_session_startup.py
+++ b/tests/atelier/worker/test_session_startup.py
@@ -307,7 +307,13 @@ def test_run_startup_contract_prioritizes_review_feedback() -> None:
         resolve_hooked_epic=lambda *_args: "at-epic",
         select_review_feedback_changeset=lambda **_kwargs: feedback,
         next_changeset=next_changeset,
-        list_epics=lambda: [{"id": "at-epic", "assignee": "atelier/worker/codex/p100"}],
+        list_epics=lambda: [
+            {
+                "id": "at-epic",
+                "labels": ["at:epic", "at:ready"],
+                "assignee": "atelier/worker/codex/p100",
+            }
+        ],
     )
 
     assert result.reason == "review_feedback"
@@ -374,12 +380,14 @@ def test_run_startup_contract_skips_non_claimable_review_feedback_epic() -> None
             {
                 "id": "at-blocked",
                 "status": "open",
+                "labels": ["at:epic", "at:ready"],
                 "assignee": "atelier/worker/codex/p999",
                 "created_at": "2026-02-20T00:00:00Z",
             },
             {
                 "id": "at-claimable",
                 "status": "open",
+                "labels": ["at:epic", "at:ready"],
                 "assignee": None,
                 "created_at": "2026-02-21T00:00:00Z",
             },
@@ -440,6 +448,7 @@ def test_run_startup_contract_selects_stale_reclaimable_review_feedback() -> Non
     stale_issue = {
         "id": "at-stale",
         "status": "open",
+        "labels": ["at:epic", "at:ready"],
         "assignee": "atelier/worker/codex/p099",
         "created_at": "2026-02-20T00:00:00Z",
     }
@@ -478,12 +487,14 @@ def test_run_startup_contract_skips_unclaimable_global_review_feedback() -> None
             {
                 "id": "at-blocked",
                 "status": "open",
+                "labels": ["at:epic", "at:ready"],
                 "assignee": "atelier/planner/codex/p001",
                 "created_at": "2026-02-20T00:00:00Z",
             },
             {
                 "id": "at-claimable",
                 "status": "open",
+                "labels": ["at:epic", "at:ready"],
                 "assignee": None,
                 "created_at": "2026-02-21T00:00:00Z",
             },
@@ -509,7 +520,7 @@ def test_run_startup_contract_claims_global_feedback_standalone_identity() -> No
         repo_slug="org/repo",
         list_epics=lambda: [],
         show_issue=lambda issue_id: (
-            {"id": "at-bmu", "status": "open", "labels": ["at:changeset"]}
+            {"id": "at-bmu", "status": "open", "labels": ["at:changeset", "at:ready"]}
             if issue_id == "at-bmu"
             else None
         ),
@@ -554,7 +565,7 @@ def test_run_startup_contract_uses_ready_changeset_fallback() -> None:
 
 
 def test_run_startup_contract_selects_auto_epic() -> None:
-    issues = [{"id": "at-auto", "status": "open"}]
+    issues = [{"id": "at-auto", "status": "open", "labels": ["at:epic", "at:ready"]}]
 
     result = _run_startup(
         list_epics=lambda: issues,


### PR DESCRIPTION
## Summary
This pull request simplifies executable work readiness to a single explicit label: `at:ready`.

For open executable work, missing `at:ready` is now treated as draft/planning by default.

## What changed
- Worker startup/selection and claim paths now require explicit `at:ready` for executable epics and standalone executable changesets.
- Legacy `at:draft` handling is fail-closed in runtime claim paths.
- GC now migrates legacy executable readiness labels:
  - removes `at:draft`
  - backfills or removes `at:ready` to preserve prior runnable behavior
- Planner overview and epic-list behavior now infer draft from missing `at:ready`.
- Skill docs/conventions now describe explicit-ready semantics (no dual draft/ready model).
- Regression tests were added for startup selection, epic listing, claim invariants, and GC readiness normalization.

## Acceptance criteria mapping
- Explicit-ready execution gating is enforced (`at:ready` required).
- Promotion/listing semantics rely on `at:ready` only.
- Legacy beads are normalized away from `at:draft` with behavior-preserving migration.
- Legacy ambiguous combinations are repaired/rejected during rollout.
- Regression coverage covers startup selection, epic listing, and promotion-related behavior.

## Verification
- `just format`
- `just lint`
- `just test`

Closes #188
