### PR TITLE
Close or reconcile exported GitHub issues when beads close

### DIFF
--- a/docs/SPEC-external-ticket-integration.md
+++ b/docs/SPEC-external-ticket-integration.md
@@ -49,6 +49,14 @@ Recommended per-entry fields:
 - `notes_updated_at`: optional timestamp for cached notes.
 - `last_synced_at`: optional last successful sync timestamp.
 
+Closed-bead reconciliation defaults:
+
+- For `direction=exported` GitHub tickets, closing the local bead attempts a
+  deterministic remote close unless `relation=context` or `on_close=none`.
+- `on_close=sync` only refreshes cached remote state.
+- Reconciliation failures append an `external_close_pending:` note so planner
+  follow-up is explicit.
+
 ### `relation`
 
 Defines why a ticket is linked.

--- a/src/atelier/external_providers.py
+++ b/src/atelier/external_providers.py
@@ -41,6 +41,7 @@ class ExternalProviderCapabilities:
     supports_update: bool = False
     supports_children: bool = False
     supports_state_sync: bool = False
+    supports_close: bool = False
 
     @property
     def supports_export(self) -> bool:
@@ -155,4 +156,13 @@ class ExternalProvider(Protocol):
 
     def sync_state(self, ref: ExternalTicketRef) -> ExternalTicketRef:
         """Optional: refresh cached state for the external ticket."""
+        ...
+
+    def close_ticket(
+        self,
+        ref: ExternalTicketRef,
+        *,
+        comment: str | None = None,
+    ) -> ExternalTicketRef:
+        """Optional: close the external ticket and return refreshed state."""
         ...

--- a/src/atelier/github_issues_provider.py
+++ b/src/atelier/github_issues_provider.py
@@ -41,6 +41,7 @@ class GithubIssuesProvider:
         supports_update=True,
         supports_children=False,
         supports_state_sync=True,
+        supports_close=True,
     )
 
     def import_tickets(
@@ -152,6 +153,19 @@ class GithubIssuesProvider:
         self, ref: ExternalTicketRef, *, title: str, body: str | None = None
     ) -> ExternalTicketRef:
         raise NotImplementedError("GitHub Issues does not support child tickets")
+
+    def close_ticket(
+        self,
+        ref: ExternalTicketRef,
+        *,
+        comment: str | None = None,
+    ) -> ExternalTicketRef:
+        _require_gh()
+        cmd = ["gh", "issue", "close", str(ref.ticket_id), "--repo", self.repo]
+        if comment:
+            cmd.extend(["--comment", comment])
+        _run(cmd)
+        return self.sync_state(ref)
 
     def sync_state(self, ref: ExternalTicketRef) -> ExternalTicketRef:
         if not self.sync_options.include_state:

--- a/src/atelier/repo_beads_provider.py
+++ b/src/atelier/repo_beads_provider.py
@@ -42,6 +42,7 @@ class RepoBeadsProvider:
             supports_update=self.allow_write,
             supports_children=False,
             supports_state_sync=True,
+            supports_close=self.allow_write,
         )
 
     def import_tickets(
@@ -147,6 +148,18 @@ class RepoBeadsProvider:
         if not issue_id:
             raise RuntimeError("Failed to create child Beads issue")
         return ExternalTicketRef(provider="beads", ticket_id=issue_id)
+
+    def close_ticket(
+        self,
+        ref: ExternalTicketRef,
+        *,
+        comment: str | None = None,
+    ) -> ExternalTicketRef:
+        del comment  # Not supported by Beads close command.
+        if not self.allow_write:
+            raise RuntimeError("Repo Beads export disabled (allow_write=false)")
+        self._run_bd_command(["close", ref.ticket_id])
+        return self.sync_state(ref)
 
     def sync_state(self, ref: ExternalTicketRef) -> ExternalTicketRef:
         if not self.sync_options.include_state:

--- a/src/atelier/worker/changeset_state.py
+++ b/src/atelier/worker/changeset_state.py
@@ -107,6 +107,11 @@ def mark_changeset_closed(changeset_id: str, *, beads_root: Path, repo_root: Pat
         beads_root=beads_root,
         cwd=repo_root,
     )
+    beads.reconcile_closed_issue_exported_github_tickets(
+        changeset_id,
+        beads_root=beads_root,
+        cwd=repo_root,
+    )
 
 
 def mark_changeset_merged(changeset_id: str, *, beads_root: Path, repo_root: Path) -> None:
@@ -132,6 +137,11 @@ def mark_changeset_merged(changeset_id: str, *, beads_root: Path, repo_root: Pat
         beads_root=beads_root,
         cwd=repo_root,
     )
+    beads.reconcile_closed_issue_exported_github_tickets(
+        changeset_id,
+        beads_root=beads_root,
+        cwd=repo_root,
+    )
 
 
 def mark_changeset_abandoned(changeset_id: str, *, beads_root: Path, repo_root: Path) -> None:
@@ -154,6 +164,11 @@ def mark_changeset_abandoned(changeset_id: str, *, beads_root: Path, repo_root: 
             "--status",
             "closed",
         ],
+        beads_root=beads_root,
+        cwd=repo_root,
+    )
+    beads.reconcile_closed_issue_exported_github_tickets(
+        changeset_id,
         beads_root=beads_root,
         cwd=repo_root,
     )

--- a/tests/atelier/worker/test_changeset_state.py
+++ b/tests/atelier/worker/test_changeset_state.py
@@ -102,3 +102,23 @@ def test_promote_planned_descendant_changesets_promotes_planned_only() -> None:
 
     assert promoted == ["at-1.1"]
     run_bd_command.assert_called_once()
+
+
+def test_mark_changeset_merged_reconciles_external_tickets() -> None:
+    with (
+        patch("atelier.worker.changeset_state.beads.run_bd_command"),
+        patch(
+            "atelier.worker.changeset_state.beads.reconcile_closed_issue_exported_github_tickets"
+        ) as reconcile,
+    ):
+        changeset_state.mark_changeset_merged(
+            "at-1.1",
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+        )
+
+    reconcile.assert_called_once_with(
+        "at-1.1",
+        beads_root=Path("/beads"),
+        cwd=Path("/repo"),
+    )


### PR DESCRIPTION
# Summary

This change reconciles exported GitHub issues when a linked local bead is closed so exported tickets do not remain stale and open.

# What changed

- Added closed-bead reconciliation logic for exported GitHub tickets in `beads.py`.
- Defaulted exported GitHub links to close-on-close, with policy-safe skips for `relation=context` and `on_close=none`.
- Added provider close capability and implemented close support for GitHub issues and repo-beads providers.
- Wired reconciliation into close paths for changesets (`closed`, `merged`, `abandoned`) and epic close.
- Added explicit `external_close_pending:` notes when reconciliation cannot safely complete.
- Updated the external ticket integration spec for closed-bead reconciliation defaults.

# Acceptance criteria mapping

- Closed beads with exported GitHub tickets are detected when ticket state remains open.
- Deterministic close/reconcile behavior updates remote ticket state or records explicit follow-up notes.
- `external_tickets.state` and timestamps are refreshed after reconciliation.
- Regression coverage includes closed-bead/open-exported-ticket scenarios.
- Context-only and explicit opt-out links are not auto-closed.

# Testing

- `just test`
- `just format`
- `just lint`

## Tickets

- Fixes #175
