### PR TITLE
Auto-migrate recoverable legacy Beads stores at startup

### DIFF
--- a/src/atelier/bd_invocation.py
+++ b/src/atelier/bd_invocation.py
@@ -40,7 +40,11 @@ def _read_bd_version_for_executable(executable: str) -> tuple[int, int, int] | N
     return _parse_semver(output)
 
 
-def ensure_supported_bd_version(*, env: Mapping[str, str] | None = None) -> None:
+def ensure_supported_bd_version(
+    *,
+    env: Mapping[str, str] | None = None,
+    min_version: tuple[int, int, int] | None = None,
+) -> None:
     """Validate that the active ``bd`` executable meets Atelier's minimum version.
 
     Args:
@@ -57,12 +61,13 @@ def ensure_supported_bd_version(*, env: Mapping[str, str] | None = None) -> None
         raise RuntimeError("missing required command: bd")
 
     detected = _read_bd_version_for_executable(executable)
-    required = _format_version(MIN_SUPPORTED_BD_VERSION)
+    minimum = min_version or MIN_SUPPORTED_BD_VERSION
+    required = _format_version(minimum)
     if detected is None:
         raise RuntimeError(
             f"unsupported bd version: unable to determine version; Atelier requires bd >= {required}"
         )
-    if detected < MIN_SUPPORTED_BD_VERSION:
+    if detected < minimum:
         detected_str = _format_version(detected)
         raise RuntimeError(
             f"unsupported bd version: {detected_str}; Atelier requires bd >= {required}"


### PR DESCRIPTION
# Summary

Automatically recover legacy Beads stores during startup when Dolt state is missing or behind SQLite by running a guarded migration path.

# Changes

- Added startup auto-migration execution on `bd prime` for recoverable legacy states.
- Added a migration version gate requiring `bd >= 0.56.1` before auto-migration runs.
- Added pre-migration SQLite backups and post-migration parity verification checks.
- Added blocked-path diagnostics when migration prerequisites, migration execution, or parity checks fail.
- Hardened worker startup preparation to fail closed: mark the selected changeset blocked, notify planner with remediation context, and release hook/assignment on non-recoverable prep errors.
- Added tests for version detection, migration success/failure/parity paths, and startup preparation blocking behavior.

# Testing

- `just test`
- `just format`
- `just lint`

## Tickets
- Fixes #200

# Risks / Rollout

- Startup now performs recovery logic only for recoverable legacy states with a local `beads.db` and `bd prime` entrypoint.
- Recovery is guarded by version checks and parity validation to avoid silently proceeding with incomplete data.

# Notes

- PR content intentionally avoids internal planning identifiers and reflects user-facing startup recovery behavior.
