### PR TITLE
Fix worker changeset selection for Beads dependency payloads

### DIFF
--- a/tests/atelier/worker/test_models_boundary.py
+++ b/tests/atelier/worker/test_models_boundary.py
@@ -78,6 +78,27 @@ def test_parse_issue_boundary_handles_parent_child_dependency_variants(
     assert boundary.dependency_ids == ("at-2",)
 
 
+def test_parse_issue_boundary_supports_depends_on_dependency_shapes() -> None:
+    issue = {
+        "id": "at-123",
+        "status": "open",
+        "labels": ["at:changeset"],
+        "parent": None,
+        "dependencies": [
+            {"depends_on_id": "at-1"},
+            {"dependsOnId": "at-2"},
+            {"depends_on": {"id": "at-3"}},
+            {"dependsOn": {"id": "at-4"}},
+            {"dependency_type": "parent-child", "depends_on_id": "at-parent"},
+        ],
+    }
+
+    boundary = parse_issue_boundary(issue, source="test")
+
+    assert boundary.parent_id == "at-parent"
+    assert boundary.dependency_ids == ("at-1", "at-2", "at-3", "at-4")
+
+
 def test_parse_issue_boundary_rejects_missing_issue_id() -> None:
     with pytest.raises(ValueError, match="invalid beads issue payload"):
         parse_issue_boundary({"status": "open"}, source="test")


### PR DESCRIPTION
## Summary
- Fix worker changeset selection so dependency blockers encoded in Beads payload variants are honored.
- Ensure startup selection uses canonical issue data instead of sparse ready-list entries.

## Acceptance Criteria Coverage
- Dependencies encoded as `depends_on_id` and equivalent payload forms are treated as blockers.
- Running worker startup for this epic selects the true dependency frontier (upstream open blocker before downstream dependent).
- Startup selection rehydrates sparse ready-list entries with canonical issue payloads before evaluation.
- Regression tests cover real dependency payload variants and sparse ready frontier ordering.

## Changes
- Extended issue-boundary dependency parsing to support `depends_on_id`, `dependsOnId`, and nested `depends_on`/`dependsOn` references while preserving parent-child detection.
- Updated startup candidate assembly to canonicalize sparse ready entries using descendant/full issue payloads.
- Enforced dependency-satisfied gating for actionable ready candidates prior to review/signal filtering.
- Added regression tests for dependency payload parsing and sparse ready-list frontier behavior.

## Testing
- `env -u BEADS_DIR -u BEADS_DB uv run pytest -q tests/atelier/worker/test_models_boundary.py tests/atelier/worker/test_session_next_changeset.py`
- `env -u BEADS_DIR -u BEADS_DB just format`
- `env -u BEADS_DIR -u BEADS_DB just lint`
- `env -u BEADS_DIR -u BEADS_DB just test` *(fails in this environment due existing Python 3.14 import-collection issue: `from importlib.abc import Traversable`)*

## Tickets
- Fixes #209
