### PR TITLE
Close exported GitHub issues when epics close locally

### DIFF
--- a/src/atelier/repo_beads_provider.py
+++ b/src/atelier/repo_beads_provider.py
@@ -158,7 +158,14 @@ class RepoBeadsProvider:
         del comment  # Not supported by Beads close command.
         if not self.allow_write:
             raise RuntimeError("Repo Beads export disabled (allow_write=false)")
-        self._run_bd_command(["close", ref.ticket_id])
+        beads_root = self.beads_root or (self.repo_root / paths.BEADS_DIRNAME)
+        if not beads_root.exists():
+            raise RuntimeError(f"missing Beads store at {beads_root}")
+        beads.close_issue(
+            ref.ticket_id,
+            beads_root=beads_root,
+            cwd=self.repo_root,
+        )
         return self.sync_state(ref)
 
     def sync_state(self, ref: ExternalTicketRef) -> ExternalTicketRef:

--- a/src/atelier/skills/work-done/SKILL.md
+++ b/src/atelier/skills/work-done/SKILL.md
@@ -17,12 +17,14 @@ description: >-
 1. Verify all changesets are complete:
    - `bd list --parent <epic_id> --label at:changeset`
    - Ensure every changeset is `cs:merged` or `cs:abandoned`.
-1. Close the epic:
-   - `bd close <epic_id>`
-1. Clear the hook slot on the agent bead:
-   - `bd slot clear <agent_bead_id> hook`
+1. Close the epic and clear the hook through the deterministic helper:
+   - `python src/atelier/skills/work-done/scripts/close_epic.py --epic-id <epic_id> --agent-bead-id <agent_bead_id>`
+1. For explicit direct-close flows (skip readiness checks), use:
+   - `python src/atelier/skills/work-done/scripts/close_epic.py --epic-id <epic_id> --agent-bead-id <agent_bead_id> --direct-close`
 
 ## Verification
 
 - Epic is closed.
 - Agent hook slot is empty.
+- If `external_tickets` has exported GitHub links, close-state metadata is
+  reconciled.

--- a/src/atelier/skills/work-done/scripts/close_epic.py
+++ b/src/atelier/skills/work-done/scripts/close_epic.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Close an epic and clear the current worker hook."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def _bootstrap_source_import() -> None:
+    src_dir = Path(__file__).resolve().parents[4]
+    if src_dir.is_dir() and str(src_dir) not in sys.path:
+        sys.path.insert(0, str(src_dir))
+
+
+_bootstrap_source_import()
+
+from atelier import beads  # noqa: E402
+
+
+def close_epic(
+    *,
+    epic_id: str,
+    agent_bead_id: str,
+    beads_root: Path,
+    cwd: Path,
+    direct_close: bool,
+) -> bool:
+    """Close an epic and clear the worker hook.
+
+    Args:
+        epic_id: Epic bead id to close.
+        agent_bead_id: Agent bead id that currently owns the hook.
+        beads_root: Beads data directory.
+        cwd: Working directory for `bd` commands.
+        direct_close: When true, skip completion checks and close immediately.
+
+    Returns:
+        `True` when the epic was closed during this call.
+    """
+    if direct_close:
+        beads.close_issue(epic_id, beads_root=beads_root, cwd=cwd)
+        beads.clear_agent_hook(agent_bead_id, beads_root=beads_root, cwd=cwd)
+        return True
+    return beads.close_epic_if_complete(
+        epic_id,
+        agent_bead_id,
+        beads_root=beads_root,
+        cwd=cwd,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--epic-id", required=True, help="Epic bead id")
+    parser.add_argument("--agent-bead-id", required=True, help="Agent bead id")
+    parser.add_argument(
+        "--direct-close",
+        action="store_true",
+        help="Close immediately without checking descendant changeset completion",
+    )
+    parser.add_argument(
+        "--beads-dir",
+        default="",
+        help="Beads directory override (defaults to BEADS_DIR or repo .beads)",
+    )
+    args = parser.parse_args()
+
+    beads_dir = str(args.beads_dir).strip() or None
+    if beads_dir:
+        beads_root = Path(beads_dir).expanduser().resolve()
+    else:
+        beads_root = Path(os.environ.get("BEADS_DIR", str(Path.cwd() / ".beads"))).expanduser()
+        beads_root = beads_root.resolve()
+    if not beads_root.exists():
+        print(f"error: beads dir not found: {beads_root}", file=sys.stderr)
+        raise SystemExit(1)
+
+    closed = close_epic(
+        epic_id=args.epic_id.strip(),
+        agent_bead_id=args.agent_bead_id.strip(),
+        beads_root=beads_root,
+        cwd=Path.cwd(),
+        direct_close=bool(args.direct_close),
+    )
+    if not closed:
+        print(
+            (
+                "error: epic is not ready to close; ensure descendant changesets "
+                "are terminal or rerun with --direct-close"
+            ),
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    print(f"closed_epic: {args.epic_id.strip()}")
+    print(f"cleared_hook: {args.agent_bead_id.strip()}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/atelier/skills/test_work_done_script.py
+++ b/tests/atelier/skills/test_work_done_script.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_script_module():
+    script_path = (
+        Path(__file__).resolve().parents[3]
+        / "src"
+        / "atelier"
+        / "skills"
+        / "work-done"
+        / "scripts"
+        / "close_epic.py"
+    )
+    spec = importlib.util.spec_from_file_location("work_done_close_epic", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_close_epic_uses_readiness_path(monkeypatch) -> None:
+    module = _load_script_module()
+    captured: dict[str, object] = {}
+
+    def fake_close_epic_if_complete(
+        epic_id: str,
+        agent_bead_id: str,
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> bool:
+        captured["epic_id"] = epic_id
+        captured["agent_bead_id"] = agent_bead_id
+        captured["beads_root"] = beads_root
+        captured["cwd"] = cwd
+        return True
+
+    monkeypatch.setattr(module.beads, "close_epic_if_complete", fake_close_epic_if_complete)
+    monkeypatch.setattr(
+        module.beads,
+        "close_issue",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("unexpected direct close")),
+    )
+
+    closed = module.close_epic(
+        epic_id="at-epic",
+        agent_bead_id="at-agent",
+        beads_root=Path("/beads"),
+        cwd=Path("/repo"),
+        direct_close=False,
+    )
+
+    assert closed is True
+    assert captured == {
+        "epic_id": "at-epic",
+        "agent_bead_id": "at-agent",
+        "beads_root": Path("/beads"),
+        "cwd": Path("/repo"),
+    }
+
+
+def test_close_epic_direct_close_reconciles_and_clears_hook(monkeypatch) -> None:
+    module = _load_script_module()
+    events: list[tuple[str, str]] = []
+
+    def fake_close_issue(
+        issue_id: str,
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> object:
+        events.append(("close", issue_id))
+        assert beads_root == Path("/beads")
+        assert cwd == Path("/repo")
+        return object()
+
+    def fake_clear_agent_hook(agent_bead_id: str, *, beads_root: Path, cwd: Path) -> None:
+        events.append(("clear_hook", agent_bead_id))
+        assert beads_root == Path("/beads")
+        assert cwd == Path("/repo")
+
+    monkeypatch.setattr(module.beads, "close_issue", fake_close_issue)
+    monkeypatch.setattr(module.beads, "clear_agent_hook", fake_clear_agent_hook)
+    monkeypatch.setattr(
+        module.beads,
+        "close_epic_if_complete",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("unexpected readiness close")
+        ),
+    )
+
+    closed = module.close_epic(
+        epic_id="at-epic",
+        agent_bead_id="at-agent",
+        beads_root=Path("/beads"),
+        cwd=Path("/repo"),
+        direct_close=True,
+    )
+
+    assert closed is True
+    assert events == [
+        ("close", "at-epic"),
+        ("clear_hook", "at-agent"),
+    ]

--- a/tests/atelier/test_skills.py
+++ b/tests/atelier/test_skills.py
@@ -99,6 +99,13 @@ def test_packaged_planning_skills_include_scripts() -> None:
     assert "scripts/send_message.py" in definitions["mail-send"].files
 
 
+def test_work_done_skill_references_close_epic_script() -> None:
+    skill = skills.load_packaged_skills()["work-done"]
+    text = skill.files["SKILL.md"].decode("utf-8")
+    assert "scripts/close_epic.py" in text
+    assert "--direct-close" in text
+
+
 def test_publish_skill_mentions_pr_draft_and_github_prs() -> None:
     skill = skills.load_packaged_skills()["publish"]
     text = skill.files["SKILL.md"].decode("utf-8")


### PR DESCRIPTION
# Summary

- Close-path handling now reconciles exported GitHub tickets whenever an epic is closed locally.

# Changes

- Added `beads.close_issue(...)` to centralize local close behavior and external-ticket reconciliation.
- Routed epic close finalization and repo-beads provider close operations through the new helper.
- Added a deterministic `work-done` helper script (`close_epic.py`) with a direct-close mode for explicit manual close flows.
- Updated the packaged `work-done` skill guidance to use the helper script.
- Added regression coverage for helper behavior, provider close wiring, and work-done script flows.

# Testing

- `just test`
- `just format`
- `just lint`

# Tickets

- Fixes #207

# Risks / Rollout

- Low risk; changes are constrained to local close-path orchestration and covered by focused + full test gates.

# Notes

- During push, pre-push tests required running with `BEADS_DB` unset in this shell environment.
