### PR TITLE
Mirror exported epic/changeset hierarchy in GitHub Issues

### DIFF
--- a/src/atelier/auto_export.py
+++ b/src/atelier/auto_export.py
@@ -344,9 +344,15 @@ def _create_ticket_ref(
     body: str | None,
     parent_ticket: ExternalTicketRef | None,
 ) -> ExternalTicketRef:
+    labels = _external_labels(issue)
     if parent_ticket and provider.capabilities.supports_children:
         try:
-            return provider.create_child_ticket(parent_ticket, title=title, body=body)
+            return provider.create_child_ticket(
+                parent_ticket,
+                title=title,
+                body=body,
+                labels=labels,
+            )
         except NotImplementedError:
             pass
     issue_id = str(issue.get("id") or "").strip()
@@ -355,7 +361,7 @@ def _create_ticket_ref(
             bead_id=issue_id or title,
             title=title,
             body=body,
-            labels=_external_labels(issue),
+            labels=labels,
         )
     )
     return record.ref

--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -1285,6 +1285,7 @@ def _merge_ticket_state(
     return replace(
         ticket,
         url=refreshed.url or ticket.url,
+        parent_id=refreshed.parent_id or ticket.parent_id,
         state=refreshed.state or ("closed" if assume_closed else ticket.state),
         raw_state=refreshed.raw_state or ticket.raw_state,
         state_updated_at=refreshed.state_updated_at or ticket.state_updated_at,

--- a/src/atelier/external_providers.py
+++ b/src/atelier/external_providers.py
@@ -149,7 +149,12 @@ class ExternalProvider(Protocol):
         ...
 
     def create_child_ticket(
-        self, ref: ExternalTicketRef, *, title: str, body: str | None = None
+        self,
+        ref: ExternalTicketRef,
+        *,
+        title: str,
+        body: str | None = None,
+        labels: tuple[str, ...] = (),
     ) -> ExternalTicketRef:
         """Optional: create a child/split ticket for review-sized work."""
         ...

--- a/src/atelier/repo_beads_provider.py
+++ b/src/atelier/repo_beads_provider.py
@@ -136,13 +136,21 @@ class RepoBeadsProvider:
         return self.sync_state(ref)
 
     def create_child_ticket(
-        self, ref: ExternalTicketRef, *, title: str, body: str | None = None
+        self,
+        ref: ExternalTicketRef,
+        *,
+        title: str,
+        body: str | None = None,
+        labels: tuple[str, ...] = (),
     ) -> ExternalTicketRef:
         if not self.allow_write:
             raise RuntimeError("Repo Beads export disabled (allow_write=false)")
+        del ref
         args = ["create", "--title", title, "--type", "task", "--silent"]
         if body:
             args.extend(["--description", body])
+        if labels:
+            args.extend(["--labels", ",".join(labels)])
         result = self._run_bd_command(args)
         issue_id = result.stdout.strip()
         if not issue_id:

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -1294,6 +1294,7 @@ def test_reconcile_closed_issue_exported_github_tickets_closes_and_updates() -> 
                 "direction": "exported",
                 "sync_mode": "export",
                 "state": "open",
+                "parent_id": "174",
             }
         ]
     )
@@ -1309,6 +1310,7 @@ def test_reconcile_closed_issue_exported_github_tickets_closes_and_updates() -> 
         state="closed",
         raw_state="completed",
         state_updated_at="2026-02-25T21:00:00Z",
+        parent_id="200",
     )
     captured: dict[str, object] = {}
 
@@ -1346,6 +1348,7 @@ def test_reconcile_closed_issue_exported_github_tickets_closes_and_updates() -> 
     assert isinstance(updated_tickets, list)
     assert updated_tickets[0].state == "closed"
     assert updated_tickets[0].state_updated_at == "2026-02-25T21:00:00Z"
+    assert updated_tickets[0].parent_id == "200"
     assert updated_tickets[0].last_synced_at is not None
 
 


### PR DESCRIPTION
# Summary

- Mirror exported planning hierarchy in GitHub Issues so child changeset issues are attached to their epic issue as parent-child relationships.
- Preserve parent linkage metadata during follow-up sync/reconcile paths so hierarchy fields remain accurate over time.

# Changes

- Enabled GitHub provider child-issue support and implemented sub-issue attachment using GitHub's issue hierarchy API.
- Updated GitHub state sync to resolve parent issue linkage and populate `parent_id` on refreshed ticket refs.
- Updated external provider child-creation contract to accept labels and wired auto-export to pass labels through child creation.
- Preserved refreshed `parent_id` in Beads ticket-state merge logic to prevent hierarchy metadata loss during reconcile updates.
- Added regression coverage for GitHub child creation, parent-link parsing/sync, auto-export child path behavior, and reconcile parent metadata updates.

# Testing

- `just format`
- `just lint`
- `env -u BEADS_DB -u BEADS_DIR -u ATELIER_AGENT_ID -u ATELIER_AGENT_SESSION just test`

## Tickets
- Fixes #208

# Risks / Rollout

- GitHub hierarchy linking now depends on sub-issues endpoint availability/permissions for the configured token.

# Notes

- Existing fallback behavior remains for providers that do not support child hierarchy APIs.
