### PR TITLE
Replace deprecated Beads sync guidance with export commands

### DIFF
--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -669,6 +669,15 @@ def run_bd_issues(
     ]
 
 
+_DEPRECATED_SYNC_COMMAND_PATTERN = re.compile(r"\bbd sync(?: --flush-only)?\b")
+_CANONICAL_SYNC_EXPORT_COMMAND = 'bd export -o "${BEADS_DIR:-.beads}/issues.jsonl"'
+
+
+def _normalize_prime_addendum_markdown(markdown: str) -> str:
+    """Rewrite deprecated sync guidance to current export guidance."""
+    return _DEPRECATED_SYNC_COMMAND_PATTERN.sub(_CANONICAL_SYNC_EXPORT_COMMAND, markdown)
+
+
 def prime_addendum(*, beads_root: Path, cwd: Path) -> str | None:
     """Return `bd prime --full` markdown without failing the caller."""
     env = beads_env(beads_root)
@@ -687,7 +696,7 @@ def prime_addendum(*, beads_root: Path, cwd: Path) -> str | None:
         return None
     if result.returncode != 0:
         return None
-    output = (result.stdout or "").strip()
+    output = _normalize_prime_addendum_markdown((result.stdout or "").strip())
     return output or None
 
 

--- a/src/atelier/skills/beads/SKILL.md
+++ b/src/atelier/skills/beads/SKILL.md
@@ -30,8 +30,8 @@ description: >-
    - `bd create --acceptance ... --design ... --estimate ... --priority ...`
    - use `--notes` / `--append-notes` for addendums without rewriting
      descriptions
-1. Sync Beads after changes or before ending a session:
-   - `bd sync`
+1. Export Beads JSONL after changes or before ending a session:
+   - `bd export -o "${BEADS_DIR:-.beads}/issues.jsonl"`
 
 ## Notes
 

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -589,6 +589,26 @@ def test_prime_addendum_returns_none_on_error() -> None:
     assert value is None
 
 
+def test_prime_addendum_rewrites_deprecated_sync_guidance() -> None:
+    stdout = (
+        "## Beads Workflow Context\n\n"
+        "```\n"
+        "[ ] bd sync --flush-only\n"
+        "```\n"
+        "- `bd sync` exports JSONL.\n"
+    )
+    with patch(
+        "atelier.beads.subprocess.run",
+        return_value=CompletedProcess(args=["bd", "prime"], returncode=0, stdout=stdout, stderr=""),
+    ):
+        value = beads.prime_addendum(beads_root=Path("/beads"), cwd=Path("/repo"))
+
+    assert value is not None
+    assert "bd sync --flush-only" not in value
+    assert "`bd sync`" not in value
+    assert value.count('bd export -o "${BEADS_DIR:-.beads}/issues.jsonl"') == 2
+
+
 def test_ensure_issue_prefix_noop_when_already_expected() -> None:
     with (
         patch("atelier.beads._current_issue_prefix", return_value="at"),


### PR DESCRIPTION
# Summary

Replace deprecated `bd sync` guidance with canonical JSONL export guidance in
Atelier’s Beads instructions and generated AGENTS addendum content.

# Changes

- Updated the Beads skill instructions to recommend:
  `bd export -o "${BEADS_DIR:-.beads}/issues.jsonl"`.
- Added prime-addendum normalization in `atelier.beads` so runtime-injected
  `bd prime --full` markdown rewrites deprecated `bd sync` and
  `bd sync --flush-only` command snippets.
- Added regression coverage to ensure deprecated sync command guidance is not
  reintroduced in prime addendum output.

# Testing

- `PATH="$PATH" env -u BEADS_DB UV_PROJECT_ENVIRONMENT=/Users/scott/code/atelier/.venv just test`
- `PATH="$PATH" UV_PROJECT_ENVIRONMENT=/Users/scott/code/atelier/.venv just format`
- `PATH="$PATH" UV_PROJECT_ENVIRONMENT=/Users/scott/code/atelier/.venv just lint`

# Risks / Rollout

- Low risk: normalization only rewrites explicit deprecated sync command
  snippets in generated addendum markdown.

# Notes

- No external tickets are linked on this changeset, so no `## Tickets` section
  is included.
