### PR TITLE
Stop autonomous worker loops after first PR handoff

### DIFF
--- a/src/atelier/worker/context.py
+++ b/src/atelier/worker/context.py
@@ -38,3 +38,4 @@ class ChangesetSelectionContext:
 
     selected_epic: str
     startup_changeset_id: str | None
+    resume_review: bool = False

--- a/src/atelier/worker/ports.py
+++ b/src/atelier/worker/ports.py
@@ -353,6 +353,7 @@ class WorkerLifecycleService(Protocol):
         branch_pr: bool,
         branch_pr_strategy: PrStrategy,
         git_path: str | None,
+        resume_review: bool,
     ) -> Issue | None: ...
 
     def persist_review_feedback_cursor(

--- a/src/atelier/worker/runtime.py
+++ b/src/atelier/worker/runtime.py
@@ -168,6 +168,7 @@ class WorkerLifecycleAdapter:
         branch_pr: bool,
         branch_pr_strategy: PrStrategy,
         git_path: str | None,
+        resume_review: bool,
     ) -> Issue | None:
         return worker_work.next_changeset(
             epic_id=epic_id,
@@ -177,6 +178,7 @@ class WorkerLifecycleAdapter:
             branch_pr=branch_pr,
             branch_pr_strategy=branch_pr_strategy,
             git_path=git_path,
+            resume_review=resume_review,
         )
 
     def persist_review_feedback_cursor(

--- a/src/atelier/worker/work_startup_runtime.py
+++ b/src/atelier/worker/work_startup_runtime.py
@@ -193,6 +193,7 @@ def next_changeset(
     branch_pr: bool = True,
     branch_pr_strategy: object = pr_strategy.PR_STRATEGY_DEFAULT,
     git_path: str | None = None,
+    resume_review: bool = False,
 ) -> dict[str, object] | None:
     """Next changeset.
 
@@ -204,6 +205,7 @@ def next_changeset(
         branch_pr: Value for `branch_pr`.
         branch_pr_strategy: Value for `branch_pr_strategy`.
         git_path: Value for `git_path`.
+        resume_review: Value for `resume_review`.
 
     Returns:
         Function result.
@@ -214,6 +216,7 @@ def next_changeset(
         branch_pr=branch_pr,
         branch_pr_strategy=branch_pr_strategy,
         git_path=git_path,
+        resume_review=resume_review,
     )
     service = _NextChangesetService(beads_root=beads_root, repo_root=repo_root)
     return worker_startup.next_changeset_service(context=context, service=service)
@@ -582,6 +585,7 @@ class _StartupContractService(worker_startup.StartupContractService):
         branch_pr: bool,
         branch_pr_strategy: object,
         git_path: str | None,
+        resume_review: bool,
     ) -> dict[str, object] | None:
         return next_changeset(
             epic_id=epic_id,
@@ -591,6 +595,7 @@ class _StartupContractService(worker_startup.StartupContractService):
             branch_pr=branch_pr,
             branch_pr_strategy=branch_pr_strategy,
             git_path=git_path,
+            resume_review=resume_review,
         )
 
     def resolve_hooked_epic(self, agent_bead_id: str, agent_id: str) -> str | None:

--- a/tests/atelier/worker/test_runtime.py
+++ b/tests/atelier/worker/test_runtime.py
@@ -55,6 +55,31 @@ def test_run_worker_sessions_dry_run_once_exits_after_started() -> None:
     assert calls == 1
 
 
+def test_run_worker_sessions_default_exits_after_review_handoff() -> None:
+    calls = 0
+
+    def run_once(args: object, *, mode: str, dry_run: bool, session_key: str) -> WorkerRunSummary:
+        del args, mode, dry_run, session_key
+        nonlocal calls
+        calls += 1
+        return WorkerRunSummary(started=False, reason="changeset_review_handoff")
+
+    runtime.run_worker_sessions(
+        args=type("Args", (), {"queue": False})(),
+        mode="auto",
+        run_mode="default",
+        dry_run=False,
+        session_key="sess",
+        run_worker_once=run_once,
+        report_worker_summary=lambda _summary, _dry: None,
+        watch_interval_seconds=lambda: 5,
+        dry_run_log=lambda _message: None,
+        emit=lambda _message: None,
+    )
+
+    assert calls == 1
+
+
 def test_run_worker_sessions_watch_logs_and_sleeps_on_no_ready() -> None:
     calls = 0
     emitted: list[str] = []

--- a/tests/atelier/worker/test_session_runner_flow.py
+++ b/tests/atelier/worker/test_session_runner_flow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import datetime as dt
 from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
@@ -382,6 +383,7 @@ def test_run_worker_once_releases_epic_when_selected_changeset_read_fails() -> N
         preview_agent=agent,
     )
     deps.lifecycle.next_changeset = lambda **_kwargs: {"id": "at-epic.1", "title": "Changeset"}
+    deps.lifecycle.find_invalid_changeset_labels = lambda *_args, **_kwargs: []
 
     def run_bd_json(args: list[str], *, beads_root: Path, cwd: Path) -> list[dict[str, object]]:  # noqa: ARG001
         if args[:2] == ["show", "at-epic.1"]:
@@ -414,3 +416,67 @@ def test_run_worker_once_releases_epic_when_selected_changeset_read_fails() -> N
         cwd=Path("/repo"),
     )
     assert not deps.control._die.called
+
+
+def test_run_worker_once_returns_terminal_handoff_after_review_pending_finalize() -> None:
+    agent = AgentHome(
+        name="worker",
+        agent_id="atelier/worker/codex/p7",
+        role="worker",
+        path=Path("/tmp/worker"),
+        session_key="p7",
+    )
+    deps = _build_runner_deps(
+        startup_result=StartupContractResult(
+            epic_id="at-epic",
+            changeset_id=None,
+            should_exit=False,
+            reason="selected_auto",
+        ),
+        preview_agent=agent,
+    )
+    deps.lifecycle.next_changeset = lambda **_kwargs: {"id": "at-epic.1", "title": "Changeset"}
+    deps.lifecycle.find_invalid_changeset_labels = lambda *_args, **_kwargs: []
+    deps.infra.beads.run_bd_json = Mock(
+        side_effect=lambda args, **_kwargs: (
+            [{"id": "at-epic.1", "title": "Changeset", "description": ""}]
+            if args[:2] == ["show", "at-epic.1"]
+            else []
+        )
+    )
+    deps.infra.worker_session_worktree.prepare_worktrees = Mock(
+        return_value=SimpleNamespace(
+            epic_worktree_path=Path("/tmp/epic"),
+            changeset_worktree_path=Path("/tmp/changeset"),
+            branch="feat/root-at-epic.1",
+        )
+    )
+    deps.infra.worker_session_agent.prepare_agent_session = Mock(
+        return_value=SimpleNamespace(
+            agent_spec=SimpleNamespace(name="demo", display_name="Demo"),
+            agent_options=[],
+            project_enlistment=Path("/repo"),
+            workspace_branch="feat/root",
+            env={},
+        )
+    )
+    deps.infra.worker_session_agent.start_agent_session = Mock(
+        return_value=SimpleNamespace(
+            started_at=dt.datetime.now(dt.timezone.utc),
+            returncode=0,
+        )
+    )
+    deps.lifecycle.finalize_changeset = lambda **_kwargs: FinalizeResult(
+        continue_running=True,
+        reason="changeset_review_pending",
+    )
+
+    summary = runner.run_worker_once(
+        SimpleNamespace(epic_id=None, queue=False, yes=False, reconcile=False),
+        run_context=WorkerRunContext(mode="auto", dry_run=False, session_key="p7"),
+        deps=deps,
+    )
+
+    assert summary.started is False
+    assert summary.reason == "changeset_review_handoff"
+    deps.infra.worker_session_agent.start_agent_session.assert_called_once()

--- a/tests/atelier/worker/test_session_startup.py
+++ b/tests/atelier/worker/test_session_startup.py
@@ -78,6 +78,7 @@ class FakeStartupService:
         branch_pr: bool,
         branch_pr_strategy: object,
         git_path: str | None,
+        resume_review: bool,
     ) -> dict[str, object] | None:
         return self._next_changeset(
             epic_id=epic_id,
@@ -85,6 +86,7 @@ class FakeStartupService:
             branch_pr=branch_pr,
             branch_pr_strategy=branch_pr_strategy,
             git_path=git_path,
+            resume_review=resume_review,
         )
 
     def resolve_hooked_epic(self, agent_bead_id: str, agent_id: str) -> str | None:


### PR DESCRIPTION
## Summary
- stop default worker loops after a changeset reaches changeset_review_pending so first PR publication becomes a review handoff boundary
- allow explicit resume runs (explicit epic selection) to pick review-pending changesets only when handoff signals exist
- keep startup gating strict by treating draft/open/in-review PR lifecycle as non-actionable unless explicit resume is requested
- add regression coverage for resume-aware changeset selection and for preventing a second autonomous session after review handoff

## Validation
- env -u BEADS_DB -u BEADS_DIR just test
- env -u BEADS_DB -u BEADS_DIR just format
- env -u BEADS_DB -u BEADS_DIR just lint

Fixes #215
