### PR TITLE
Detect recoverable legacy Beads startup states

### DIFF
--- a/tests/atelier/worker/test_session_runner_flow.py
+++ b/tests/atelier/worker/test_session_runner_flow.py
@@ -300,6 +300,8 @@ def test_run_worker_once_releases_epic_when_label_validation_reads_fail() -> Non
     assert summary.reason == "changeset_label_validation_failed"
     assert summary.epic_id == "at-epic"
     deps.lifecycle.send_planner_notification.assert_called_once()
+    notification = deps.lifecycle.send_planner_notification.call_args.kwargs
+    assert "Startup state: Startup Beads state:" in str(notification.get("body"))
     deps.lifecycle.release_epic_assignment.assert_called_once_with(
         "at-epic",
         beads_root=Path("/project/.atelier/.beads"),
@@ -351,6 +353,8 @@ def test_run_worker_once_releases_epic_when_changeset_selection_reads_fail() -> 
     assert summary.reason == "changeset_selection_read_failed"
     assert summary.epic_id == "at-epic"
     deps.lifecycle.send_planner_notification.assert_called_once()
+    notification = deps.lifecycle.send_planner_notification.call_args.kwargs
+    assert "Startup state: Startup Beads state:" in str(notification.get("body"))
     deps.lifecycle.release_epic_assignment.assert_called_once_with(
         "at-epic",
         beads_root=Path("/project/.atelier/.beads"),
@@ -403,6 +407,8 @@ def test_run_worker_once_releases_epic_when_selected_changeset_read_fails() -> N
     assert summary.reason == "changeset_metadata_read_failed"
     assert summary.epic_id == "at-epic"
     deps.lifecycle.send_planner_notification.assert_called_once()
+    notification = deps.lifecycle.send_planner_notification.call_args.kwargs
+    assert "Startup state: Startup Beads state:" in str(notification.get("body"))
     deps.lifecycle.release_epic_assignment.assert_called_once_with(
         "at-epic",
         beads_root=Path("/project/.atelier/.beads"),


### PR DESCRIPTION
# Summary

- Add deterministic startup-state classification for Beads storage so startup diagnostics can distinguish healthy Dolt from recoverable legacy SQLite mismatch scenarios.

# Changes

- Added a read-only classifier in `src/atelier/beads.py` that compares Dolt `bd stats --json` totals with legacy SQLite totals (`bd --db <beads.db> stats --json`).
- Classified startup state into:
  - `healthy_dolt`
  - `missing_dolt_with_legacy_sqlite`
  - `insufficient_dolt_vs_legacy_data`
  - `startup_state_unknown` fallback
- Emitted startup diagnostics in Beads command failure guidance and worker startup NEEDS-DECISION notifications.
- Added tests covering all required classifier outcomes and notification wiring.

# Testing

- `just format`
- `just lint`
- `UV_PYTHON=3.11 just test`

# Tickets

- Fixes #199

# Risks / Rollout

- This changeset is detection-only and read-only; it does not perform migration or mutation.
- Diagnostics now include startup state metadata when Beads reads fail.

# Notes

- `just test` was run with `UV_PYTHON=3.11` to match the repository’s supported runtime.
