### PR TITLE
Preserve runtime agent bead state during startup migration

### DIFF
--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -56,6 +56,8 @@ _BEADS_STARTUP_INSUFFICIENT_DOLT = "insufficient_dolt_vs_legacy_data"
 _BEADS_STARTUP_UNKNOWN = "startup_state_unknown"
 _STARTUP_AUTO_MIGRATION_MIN_BD_VERSION = (0, 56, 1)
 _STARTUP_AUTO_MIGRATION_ATTEMPTED: set[Path] = set()
+_RUNTIME_AGENT_ID_ENV = "ATELIER_AGENT_ID"
+_RUNTIME_AGENT_BEAD_ID_ENV = "ATELIER_AGENT_BEAD_ID"
 
 
 class _IssueTypeModel(BaseModel):
@@ -219,6 +221,15 @@ class StartupBeadsState:
         return tuple(details)
 
 
+@dataclass(frozen=True)
+class _RuntimeAgentSnapshot:
+    issue_id: str
+    title: str
+    description: str
+    labels: tuple[str, ...]
+    agent_id: str | None
+
+
 def beads_env(beads_root: Path) -> dict[str, str]:
     """Return an environment mapping with BEADS_DIR set."""
     env = os.environ.copy()
@@ -309,6 +320,228 @@ def _read_bd_stats_total(
     if issue_total is None:
         return None, "stats payload missing summary.total_issues"
     return issue_total, None
+
+
+def _clean_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    return cleaned
+
+
+def _parse_raw_json_output(result: exec.CommandResult | None) -> object | None:
+    if result is None or result.returncode != 0:
+        return None
+    raw = (result.stdout or "").strip()
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+
+
+def _issue_from_json_payload(payload: object) -> dict[str, object] | None:
+    if isinstance(payload, dict):
+        return payload
+    if isinstance(payload, list):
+        for entry in payload:
+            if isinstance(entry, dict):
+                return entry
+    return None
+
+
+def _raw_show_issue(issue_id: str, *, cwd: Path, env: dict[str, str]) -> dict[str, object] | None:
+    payload = _parse_raw_json_output(
+        _run_raw_bd_command(
+            ["bd", "show", issue_id, "--json"],
+            cwd=cwd,
+            env=env,
+        )
+    )
+    return _issue_from_json_payload(payload)
+
+
+def _is_agent_issue(issue: dict[str, object]) -> bool:
+    if "at:agent" in _issue_labels(issue):
+        return True
+    issue_type = _clean_text(issue.get("type"))
+    if issue_type == "agent":
+        return True
+    description = issue.get("description")
+    fields = _parse_description_fields(description if isinstance(description, str) else "")
+    return _clean_text(fields.get("agent_id")) is not None
+
+
+def _runtime_agent_snapshot(issue: dict[str, object]) -> _RuntimeAgentSnapshot | None:
+    issue_id = _clean_text(issue.get("id"))
+    if issue_id is None or not _is_agent_issue(issue):
+        return None
+    title = _clean_text(issue.get("title")) or issue_id
+    description = issue.get("description")
+    text = description if isinstance(description, str) else ""
+    fields = _parse_description_fields(text)
+    agent_id = _clean_text(fields.get("agent_id")) or _clean_text(issue.get("title"))
+    return _RuntimeAgentSnapshot(
+        issue_id=issue_id,
+        title=title,
+        description=text,
+        labels=tuple(sorted(_issue_labels(issue))),
+        agent_id=agent_id,
+    )
+
+
+def _collect_required_runtime_agent_snapshots(
+    *,
+    cwd: Path,
+    env: dict[str, str],
+) -> dict[str, _RuntimeAgentSnapshot]:
+    snapshots: dict[str, _RuntimeAgentSnapshot] = {}
+    required_bead_id = _clean_text(env.get(_RUNTIME_AGENT_BEAD_ID_ENV))
+    if not required_bead_id:
+        return snapshots
+    issue = _raw_show_issue(required_bead_id, cwd=cwd, env=env)
+    if issue is None:
+        return snapshots
+    snapshot = _runtime_agent_snapshot(issue)
+    if snapshot is not None:
+        snapshots[snapshot.issue_id] = snapshot
+    return snapshots
+
+
+def _merge_runtime_agent_description(
+    *,
+    existing_description: str | None,
+    snapshot_description: str | None,
+    agent_id: str | None,
+) -> str:
+    merged = _normalize_description(existing_description)
+    snapshot = _normalize_description(snapshot_description)
+    snapshot_fields = _parse_description_fields(snapshot)
+    if snapshot_fields:
+        for key, value in snapshot_fields.items():
+            merged = _update_description_field(merged, key=key, value=value)
+    elif snapshot and not merged:
+        merged = snapshot
+    if agent_id:
+        merged = _update_description_field(merged, key="agent_id", value=agent_id)
+        merged_fields = _parse_description_fields(merged)
+        role = _agent_role(agent_id)
+        has_role = _clean_text(merged_fields.get("role_type")) or _clean_text(
+            merged_fields.get("role")
+        )
+        if role and not has_role:
+            merged = _update_description_field(merged, key="role_type", value=role)
+    return merged
+
+
+def _create_runtime_agent_bead(
+    issue_id: str,
+    *,
+    snapshot: _RuntimeAgentSnapshot | None,
+    runtime_agent_id: str | None,
+    beads_root: Path,
+    cwd: Path,
+) -> None:
+    agent_id = snapshot.agent_id if snapshot is not None else runtime_agent_id
+    title = snapshot.title if snapshot is not None else (agent_id or issue_id)
+    labels = set(snapshot.labels if snapshot is not None else ())
+    labels.add("at:agent")
+    description = _merge_runtime_agent_description(
+        existing_description=snapshot.description if snapshot is not None else "",
+        snapshot_description=snapshot.description if snapshot is not None else "",
+        agent_id=agent_id,
+    )
+    create_args = [
+        "create",
+        "--id",
+        issue_id,
+        "--type",
+        _agent_issue_type(beads_root=beads_root, cwd=cwd),
+        "--labels",
+        ",".join(sorted(labels)),
+        "--title",
+        title,
+        "--silent",
+    ]
+    if description:
+        create_args.extend(["--description", description])
+    run_bd_command(create_args, beads_root=beads_root, cwd=cwd)
+
+
+def _reconcile_runtime_agent_bead(
+    issue_id: str,
+    *,
+    existing_issue: dict[str, object] | None,
+    snapshot: _RuntimeAgentSnapshot | None,
+    runtime_agent_id: str | None,
+    beads_root: Path,
+    cwd: Path,
+) -> None:
+    if existing_issue is None:
+        _create_runtime_agent_bead(
+            issue_id,
+            snapshot=snapshot,
+            runtime_agent_id=runtime_agent_id,
+            beads_root=beads_root,
+            cwd=cwd,
+        )
+        return
+    raw_description = existing_issue.get("description")
+    current_description = raw_description if isinstance(raw_description, str) else ""
+    snapshot_description = snapshot.description if snapshot is not None else ""
+    agent_id = snapshot.agent_id if snapshot is not None else runtime_agent_id
+    merged = _merge_runtime_agent_description(
+        existing_description=current_description,
+        snapshot_description=snapshot_description,
+        agent_id=agent_id,
+    )
+    if _normalize_description(merged) != _normalize_description(current_description):
+        _update_issue_description(issue_id, merged, beads_root=beads_root, cwd=cwd)
+    labels = {"at:agent"}
+    if snapshot is not None:
+        labels.update(snapshot.labels)
+    missing_labels = sorted(labels - _issue_labels(existing_issue))
+    if missing_labels:
+        update_args = ["update", issue_id]
+        for label in missing_labels:
+            update_args.extend(["--add-label", label])
+        run_bd_command(update_args, beads_root=beads_root, cwd=cwd)
+    if snapshot is not None:
+        current_title = _clean_text(existing_issue.get("title")) or ""
+        if snapshot.title and snapshot.title != current_title:
+            run_bd_command(
+                ["update", issue_id, "--title", snapshot.title],
+                beads_root=beads_root,
+                cwd=cwd,
+            )
+
+
+def _reconcile_required_runtime_agent_beads(
+    *,
+    beads_root: Path,
+    cwd: Path,
+    env: dict[str, str],
+    snapshots: dict[str, _RuntimeAgentSnapshot],
+) -> None:
+    required_bead_id = _clean_text(env.get(_RUNTIME_AGENT_BEAD_ID_ENV))
+    runtime_agent_id = _clean_text(env.get(_RUNTIME_AGENT_ID_ENV))
+    required_ids = set(snapshots)
+    if required_bead_id:
+        required_ids.add(required_bead_id)
+    for issue_id in sorted(required_ids):
+        existing_issue = _raw_show_issue(issue_id, cwd=cwd, env=env)
+        snapshot = snapshots.get(issue_id)
+        _reconcile_runtime_agent_bead(
+            issue_id,
+            existing_issue=existing_issue,
+            snapshot=snapshot,
+            runtime_agent_id=runtime_agent_id,
+            beads_root=beads_root,
+            cwd=cwd,
+        )
 
 
 def detect_startup_beads_state(*, beads_root: Path, cwd: Path) -> StartupBeadsState:
@@ -481,6 +714,7 @@ def _attempt_startup_auto_migration(
     if not startup_state.migration_eligible:
         return
     _STARTUP_AUTO_MIGRATION_ATTEMPTED.add(key)
+    runtime_agent_snapshots = _collect_required_runtime_agent_snapshots(cwd=cwd, env=env)
 
     required_version = _format_semver(_STARTUP_AUTO_MIGRATION_MIN_BD_VERSION)
     startup_diagnostics = format_startup_beads_diagnostics(startup_state)
@@ -540,6 +774,13 @@ def _attempt_startup_auto_migration(
             f"after={format_startup_beads_diagnostics(post_state)}\n"
             "Run `bd migrate --to-dolt --inspect` and resolve parity before retrying."
         )
+    _ISSUE_TYPE_CACHE.pop(beads_root, None)
+    _reconcile_required_runtime_agent_beads(
+        beads_root=beads_root,
+        cwd=cwd,
+        env=env,
+        snapshots=runtime_agent_snapshots,
+    )
     atelier_log.warning(
         "Startup Beads auto-migration completed: "
         f"backup_path={backup_path}; "

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -625,6 +625,228 @@ def test_run_bd_command_prime_blocks_when_migration_parity_fails(tmp_path: Path)
     assert ["bd", "prime"] not in calls
 
 
+def test_run_bd_command_prime_reconciles_runtime_agent_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    beads_root = tmp_path / ".beads"
+    beads_root.mkdir()
+    (beads_root / "beads.db").write_bytes(b"legacy")
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+    monkeypatch.setenv("ATELIER_AGENT_BEAD_ID", "at-agent-runtime")
+    monkeypatch.setenv("ATELIER_AGENT_ID", "atelier/planner/codex/runtime")
+
+    db_stats = ["bd", "--db", str(beads_root / "beads.db"), "stats", "--json"]
+    migrate = [
+        "bd",
+        "--db",
+        str(beads_root / "beads.db"),
+        "migrate",
+        "--to-dolt",
+        "--yes",
+        "--json",
+    ]
+    stats_calls = 0
+    show_calls = 0
+    updated_descriptions: list[str] = []
+
+    def fake_run_with_runner(request: exec_util.CommandRequest) -> exec_util.CommandResult | None:
+        nonlocal stats_calls, show_calls
+        argv = list(request.argv)
+        if argv == ["bd", "stats", "--json"]:
+            stats_calls += 1
+            if stats_calls == 1:
+                return exec_util.CommandResult(
+                    argv=request.argv,
+                    returncode=2,
+                    stdout="",
+                    stderr=(
+                        "panic: runtime error: invalid memory address or nil pointer dereference\n"
+                        "doltdb.(*DoltDB).SetCrashOnFatalError"
+                    ),
+                )
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout='{"summary":{"total_issues":8}}',
+                stderr="",
+            )
+        if argv == db_stats:
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout='{"summary":{"total_issues":8}}',
+                stderr="",
+            )
+        if argv == ["bd", "show", "at-agent-runtime", "--json"]:
+            show_calls += 1
+            description = (
+                "agent_id: atelier/planner/codex/runtime\nplanner_sync.last_synced_sha: fresh\n"
+            )
+            if show_calls > 1:
+                description = (
+                    "agent_id: atelier/planner/codex/runtime\nplanner_sync.last_synced_sha: stale\n"
+                )
+            payload = [
+                {
+                    "id": "at-agent-runtime",
+                    "title": "atelier/planner/codex/runtime",
+                    "labels": ["at:agent"],
+                    "description": description,
+                }
+            ]
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout=json.dumps(payload),
+                stderr="",
+            )
+        if argv == migrate:
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout='{"migrated":8}',
+                stderr="",
+            )
+        if argv[:3] == ["bd", "update", "at-agent-runtime"] and "--body-file" in argv:
+            body_path = Path(argv[argv.index("--body-file") + 1])
+            updated_descriptions.append(body_path.read_text(encoding="utf-8"))
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout="updated",
+                stderr="",
+            )
+        if argv == ["bd", "prime"]:
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout="primed",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {argv}")
+
+    with (
+        patch("atelier.beads.bd_invocation.ensure_supported_bd_version"),
+        patch("atelier.beads.bd_invocation.detect_bd_version", return_value=(0, 56, 1)),
+        patch("atelier.beads.exec.run_with_runner", side_effect=fake_run_with_runner),
+    ):
+        result = beads.run_bd_command(["prime"], beads_root=beads_root, cwd=cwd)
+
+    assert result.returncode == 0
+    assert updated_descriptions
+    assert "planner_sync.last_synced_sha: fresh" in updated_descriptions[0]
+    assert "planner_sync.last_synced_sha: stale" not in updated_descriptions[0]
+
+
+def test_run_bd_command_prime_recreates_missing_runtime_agent_bead(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    beads_root = tmp_path / ".beads"
+    beads_root.mkdir()
+    (beads_root / "beads.db").write_bytes(b"legacy")
+    cwd = tmp_path / "repo"
+    cwd.mkdir()
+    monkeypatch.setenv("ATELIER_AGENT_BEAD_ID", "at-agent-required")
+    monkeypatch.setenv("ATELIER_AGENT_ID", "atelier/planner/codex/runtime")
+
+    db_stats = ["bd", "--db", str(beads_root / "beads.db"), "stats", "--json"]
+    migrate = [
+        "bd",
+        "--db",
+        str(beads_root / "beads.db"),
+        "migrate",
+        "--to-dolt",
+        "--yes",
+        "--json",
+    ]
+    stats_calls = 0
+    create_calls: list[list[str]] = []
+
+    def fake_run_with_runner(request: exec_util.CommandRequest) -> exec_util.CommandResult | None:
+        nonlocal stats_calls
+        argv = list(request.argv)
+        if argv == ["bd", "stats", "--json"]:
+            stats_calls += 1
+            if stats_calls == 1:
+                return exec_util.CommandResult(
+                    argv=request.argv,
+                    returncode=2,
+                    stdout="",
+                    stderr=(
+                        "panic: runtime error: invalid memory address or nil pointer dereference\n"
+                        "doltdb.(*DoltDB).SetCrashOnFatalError"
+                    ),
+                )
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout='{"summary":{"total_issues":2}}',
+                stderr="",
+            )
+        if argv == db_stats:
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout='{"summary":{"total_issues":2}}',
+                stderr="",
+            )
+        if argv == ["bd", "show", "at-agent-required", "--json"]:
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout="[]",
+                stderr="",
+            )
+        if argv == migrate:
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout='{"migrated":2}',
+                stderr="",
+            )
+        if argv == ["bd", "types", "--json"]:
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout='{"types":[{"name":"task"}]}',
+                stderr="",
+            )
+        if argv[:2] == ["bd", "create"]:
+            create_calls.append(argv)
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout="at-agent-required\n",
+                stderr="",
+            )
+        if argv == ["bd", "prime"]:
+            return exec_util.CommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout="primed",
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {argv}")
+
+    with (
+        patch("atelier.beads.bd_invocation.ensure_supported_bd_version"),
+        patch("atelier.beads.bd_invocation.detect_bd_version", return_value=(0, 56, 1)),
+        patch("atelier.beads.exec.run_with_runner", side_effect=fake_run_with_runner),
+    ):
+        result = beads.run_bd_command(["prime"], beads_root=beads_root, cwd=cwd)
+
+    assert result.returncode == 0
+    assert create_calls
+    create_call = create_calls[0]
+    assert "--id" in create_call
+    assert create_call[create_call.index("--id") + 1] == "at-agent-required"
+    assert "--description" in create_call
+    description = create_call[create_call.index("--description") + 1]
+    assert "agent_id: atelier/planner/codex/runtime" in description
+    assert "role_type: planner" in description
+
+
 def test_detect_startup_beads_state_reports_healthy_dolt(tmp_path: Path) -> None:
     beads_root = tmp_path / ".beads"
     (beads_root / "dolt" / "beads_at" / ".dolt").mkdir(parents=True)


### PR DESCRIPTION
# Summary

Preserve runtime-required agent bead records when startup auto-migration upgrades a legacy Beads store.

# Changes

- Capture a runtime snapshot for the required agent bead before startup migration when `ATELIER_AGENT_BEAD_ID` is set.
- Reconcile that agent bead after migration by merging snapshot description fields back into the migrated record so newer runtime metadata is retained.
- Recreate the required runtime agent bead by explicit id when migration output does not contain it, including `agent_id`, inferred `role_type`, and `at:agent` labeling.
- Add regression tests for metadata preservation and missing-bead recreation in startup migration flows.

# Testing

- `pytest -q tests/atelier/test_beads.py -k "reconciles_runtime_agent_metadata or recreates_missing_runtime_agent_bead or prime_auto_migrates_recoverable_startup_state or prime_blocks_when_migration_parity_fails"`
- `just format`
- `just lint`
- `env -u BEADS_DB -u BEADS_DIR UV_PYTHON=3.11 just test`

# Tickets

- Fixes #201

# Risks / Rollout

- Startup auto-migration now performs a focused post-migration reconciliation step for runtime-required agent beads; behavior is limited to required runtime bead ids.

# Notes

- `just test` fails in this worker shell unless `BEADS_DB`/`BEADS_DIR` are unset because those environment variables point to the worker's project Beads store.
