### PR TITLE
Make Beads command guidance capability-aware

### DIFF
--- a/src/atelier/skills/beads/SKILL.md
+++ b/src/atelier/skills/beads/SKILL.md
@@ -30,8 +30,8 @@ description: >-
    - `bd create --acceptance ... --design ... --estimate ... --priority ...`
    - use `--notes` / `--append-notes` for addendums without rewriting
      descriptions
-1. Export Beads JSONL after changes or before ending a session:
-   - `bd export -o "${BEADS_DIR:-.beads}/issues.jsonl"`
+1. Persist Beads changes after updates or before ending a session:
+   - `bd dolt commit`
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- keep `prime_addendum` pass-through so Atelier uses capability-aware guidance emitted by the active `bd prime --full` runtime
- remove unsupported guidance rewrites that could suggest unavailable commands
- update packaged Beads skill persistence guidance to use supported Dolt commit commands in this runtime
- keep regression coverage for prime addendum behavior so output is preserved exactly as emitted

## Acceptance Criteria Mapping
- guidance now comes from the active `bd` binary output instead of hard-coded runtime rewrites
- deprecated `bd sync` guidance is no longer rewritten to unsupported replacements
- when `bd export` is unavailable in this runtime, guidance points to supported Dolt persistence via `bd dolt commit`
- regression tests cover the prime addendum pass-through path that preserves runtime capability-specific guidance

## Testing
- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #232
