### PR TITLE
Enforce active root-branch ownership during worker startup

### DIFF
--- a/src/atelier/cli.py
+++ b/src/atelier/cli.py
@@ -22,7 +22,7 @@ try:
 except ImportError:  # pragma: no cover - legacy Click fallback
     from click.parser import split_arg_string
 
-from . import __version__, bd_invocation, beads, config, git, paths
+from . import __version__, bd_invocation, beads, config, git, lifecycle, paths
 from . import log as atelier_log
 from .commands import config as config_cmd
 from .commands import edit as edit_cmd
@@ -136,8 +136,10 @@ def _collect_workspace_root_branches(repo_root: Path, *, beads_root: Path) -> li
     for issue in issues:
         if not isinstance(issue, dict):
             continue
-        status = str(issue.get("status") or "").lower()
-        if status and status not in {"open", "in_progress", "ready"}:
+        if not lifecycle.is_active_root_branch_owner(
+            status=issue.get("status"),
+            labels=lifecycle.normalized_labels(issue.get("labels")),
+        ):
             continue
         root_branch = beads.extract_workspace_root_branch(issue)
         if root_branch:

--- a/tests/atelier/test_lifecycle.py
+++ b/tests/atelier/test_lifecycle.py
@@ -9,6 +9,38 @@ def test_is_eligible_epic_status_accepts_core_active_states() -> None:
     assert lifecycle.is_eligible_epic_status("hooked", allow_hooked=True) is True
 
 
+def test_normalized_labels_handles_non_list_and_none_entries() -> None:
+    assert lifecycle.normalized_labels(None) == set()
+    assert lifecycle.normalized_labels(["at:ready", None, " at:hooked "]) == {
+        "at:ready",
+        "at:hooked",
+    }
+
+
+def test_is_active_root_branch_owner_uses_status_and_labels() -> None:
+    assert (
+        lifecycle.is_active_root_branch_owner(
+            status="hooked",
+            labels={"at:epic", "at:ready"},
+        )
+        is True
+    )
+    assert (
+        lifecycle.is_active_root_branch_owner(
+            status="blocked",
+            labels={"at:epic", "at:hooked"},
+        )
+        is True
+    )
+    assert (
+        lifecycle.is_active_root_branch_owner(
+            status="closed",
+            labels={"at:epic", "at:ready", "at:hooked"},
+        )
+        is False
+    )
+
+
 def test_is_changeset_ready_accepts_ready_label() -> None:
     labels = {"at:changeset", "cs:ready"}
     assert lifecycle.is_changeset_ready("open", labels) is True

--- a/tests/atelier/test_root_branch.py
+++ b/tests/atelier/test_root_branch.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import atelier.root_branch as root_branch
+
+
+def test_partition_root_branch_conflicts_treats_hooked_as_active() -> None:
+    issues = [
+        {
+            "id": "at-open",
+            "status": "open",
+            "labels": ["at:epic", "at:ready"],
+            "title": "Open epic",
+        },
+        {
+            "id": "at-hooked",
+            "status": "blocked",
+            "labels": ["at:epic", "at:hooked"],
+            "title": "Hooked via label",
+        },
+        {
+            "id": "at-closed",
+            "status": "closed",
+            "labels": ["at:epic", "at:ready"],
+            "title": "Closed epic",
+        },
+    ]
+
+    blocking, reusable = root_branch.partition_root_branch_conflicts(issues)
+
+    assert [issue["id"] for issue in blocking] == ["at-open", "at-hooked"]
+    assert [issue["id"] for issue in reusable] == ["at-closed"]
+
+
+def test_partition_root_branch_conflicts_excludes_current_owner() -> None:
+    issues = [
+        {"id": "at-current", "status": "hooked", "labels": ["at:epic", "at:hooked"]},
+        {"id": "at-other", "status": "in_progress", "labels": ["at:epic", "at:ready"]},
+    ]
+
+    blocking, reusable = root_branch.partition_root_branch_conflicts(
+        issues,
+        owner_issue_id="at-current",
+    )
+
+    assert [issue["id"] for issue in blocking] == ["at-other"]
+    assert reusable == []
+
+
+def test_prompt_root_branch_assume_yes_fails_when_active_owner_exists() -> None:
+    conflicts = [
+        {
+            "id": "at-owner",
+            "status": "hooked",
+            "labels": ["at:epic", "at:hooked", "at:ready"],
+            "title": "Owner",
+        }
+    ]
+    with (
+        patch("atelier.root_branch.branching.suggest_root_branch", return_value="feat/root"),
+        patch("atelier.root_branch.beads.find_epics_by_root_branch", return_value=conflicts),
+    ):
+        with pytest.raises(SystemExit):
+            root_branch.prompt_root_branch(
+                title="Example",
+                branch_prefix="",
+                beads_root=Path("/beads"),
+                repo_root=Path("/repo"),
+                assume_yes=True,
+            )


### PR DESCRIPTION
## Summary
Prevent root-branch reuse when the branch is already owned by an active epic, so worker startup fails early with clear diagnostics instead of reaching git worktree collisions.

## What Changed
- Added a shared lifecycle classifier for active root-branch ownership that evaluates both status and labels.
- Reused that classifier in interactive root-branch selection to treat hooked/active owners as non-reusable.
- Enforced the same ownership contract during worker startup when an epic already has a root branch set.
- Added startup diagnostics that report the owning epic and emit a planner NEEDS-DECISION notification on conflict.
- Updated workspace-root completion collection to include active hooked owners consistently.
- Added regression tests for lifecycle/root-branch classification, startup conflict blocking, and hooked completion behavior.

## Validation
- `just test`
- `just format`
- `just lint`

## Tickets
- Fixes #249
