### PR TITLE
Fix merged PR lifecycle drift during worker startup

### DIFF
--- a/src/atelier/worker/selection.py
+++ b/src/atelier/worker/selection.py
@@ -160,7 +160,6 @@ def stale_family_assigned_epics(
     agent_id: str,
     is_session_active: Callable[[str], bool],
 ) -> list[dict[str, object]]:
-    family = agent_family_id(agent_id)
     candidates: list[dict[str, object]] = []
     for issue in issues:
         evaluation = evaluate_epic_claimability(issue)
@@ -172,8 +171,6 @@ def stale_family_assigned_epics(
             continue
         assignee = issue.get("assignee")
         if not isinstance(assignee, str) or not assignee or assignee == agent_id:
-            continue
-        if agent_family_id(assignee) != family:
             continue
         if is_session_active(assignee):
             continue

--- a/tests/atelier/worker/test_selection.py
+++ b/tests/atelier/worker/test_selection.py
@@ -136,7 +136,7 @@ def test_select_epic_prompt_supports_assume_yes() -> None:
     assert selected == "at-ready"
 
 
-def test_stale_family_assigned_epics_filters_to_inactive_family_members() -> None:
+def test_stale_family_assigned_epics_reclaims_inactive_assignees_across_families() -> None:
     issues = [
         {
             "id": "at-stale",
@@ -156,7 +156,7 @@ def test_stale_family_assigned_epics_filters_to_inactive_family_members() -> Non
             "id": "at-other-family",
             "status": "in_progress",
             "labels": ["at:epic", "at:ready"],
-            "assignee": "atelier/planner/codex/p333",
+            "assignee": "atelier/worker/other/p333",
             "created_at": "2026-02-22T00:00:00+00:00",
         },
     ]
@@ -167,7 +167,7 @@ def test_stale_family_assigned_epics_filters_to_inactive_family_members() -> Non
         is_session_active=lambda assignee: assignee.endswith("/p222"),
     )
 
-    assert [item["id"] for item in stale] == ["at-stale"]
+    assert [item["id"] for item in stale] == ["at-stale", "at-other-family"]
 
 
 def test_select_epic_from_ready_changesets_uses_epic_for_child_issue() -> None:


### PR DESCRIPTION
# Summary

- Reconcile merged pull request state into local changeset lifecycle deterministically so merged work does not remain stuck in `in_progress`.

# Changes

- Reworked worker startup reconciliation to mark any changeset with authoritative merge evidence as `cs:merged` (including stale non-terminal states), persist integrated SHA when present, and close completed epics in the same run.
- Applied startup reconciliation on both entry paths:
  - explicit epic startup (before next-changeset selection)
  - auto-select startup pre-pass (before actionable selection/dependency evaluation)
- Updated stale assignment reclaim behavior to be liveness-driven across worker families; active sessions remain fail-closed and planner-owned work remains excluded.
- Expanded merged-changeset reconcile sweep candidate detection to include merged-evidence changesets even when local labels are stale (not only pre-labeled `cs:merged`).
- Added regression coverage for:
  - merged PR + local in-progress changeset convergence on explicit startup
  - auto-startup reconciliation pre-pass
  - family-mismatch stale reclaim behavior
  - non-terminal merge-signal candidate detection in reconcile sweep

# Testing

- `just format`
- `just lint`
- `just test`
- `uv run pytest tests/atelier/worker/test_selection.py tests/atelier/worker/test_session_startup.py tests/atelier/worker/test_reconcile.py`

# Tickets

- Fixes #272

# Risks / Rollout

- Startup now performs an additional reconciliation pass over executable epics, which adds extra Beads reads during startup.
- Merge reconciliation remains fail-closed when integration evidence is missing.

# Notes

- PR/claimability behavior remains conservative for active assignees; no takeover occurs while a live assignee session is detected.
