### PR TITLE
Migrate finalize and reconcile transitions to status-native lifecycle

### DIFF
--- a/src/atelier/lifecycle.py
+++ b/src/atelier/lifecycle.py
@@ -411,12 +411,9 @@ def is_changeset_in_progress(status: object, labels: set[str]) -> bool:
         labels: Normalized issue labels.
 
     Returns:
-        ``True`` for explicit in-progress status or legacy in-progress label.
+        ``True`` when canonical lifecycle status is ``in_progress``.
     """
-    normalized = normalize_status_value(status)
-    if normalized == "in_progress":
-        return True
-    return "cs:in_progress" in labels
+    return canonical_lifecycle_status(status, labels=labels) == "in_progress"
 
 
 def is_changeset_ready(status: object, labels: set[str]) -> bool:
@@ -427,23 +424,12 @@ def is_changeset_ready(status: object, labels: set[str]) -> bool:
         labels: Normalized issue labels.
 
     Returns:
-        ``True`` when the changeset is considered runnable by current
-        compatibility rules.
+        ``True`` when the issue is a changeset with active canonical status.
     """
-    if "cs:ready" in labels:
-        return True
-    if "at:changeset" not in labels and "cs:in_progress" not in labels:
-        return False
-    if "cs:planned" in labels or "cs:blocked" in labels:
-        return False
-    if TERMINAL_CHANGESET_LABELS.intersection(labels):
+    if "at:changeset" not in labels:
         return False
     canonical_status = canonical_lifecycle_status(status, labels=labels)
-    if canonical_status in {"closed", "blocked", "deferred"}:
-        return False
-    if canonical_status in ACTIVE_LIFECYCLE_STATUSES:
-        return True
-    return "cs:in_progress" in labels
+    return canonical_status in ACTIVE_LIFECYCLE_STATUSES
 
 
 def is_changeset_in_review_candidate(

--- a/src/atelier/worker/changeset_state.py
+++ b/src/atelier/worker/changeset_state.py
@@ -6,7 +6,7 @@ import datetime as dt
 from collections.abc import Callable
 from pathlib import Path
 
-from .. import beads
+from .. import beads, lifecycle
 
 
 def issue_labels(issue: dict[str, object]) -> set[str]:
@@ -250,11 +250,12 @@ def close_completed_container_changesets(
         issue_id = issue.get("id")
         if not isinstance(issue_id, str) or not issue_id:
             continue
-        status = str(issue.get("status") or "").lower()
-        if status in {"closed", "done"}:
-            continue
         labels = issue_labels(issue)
-        if "cs:merged" not in labels and "cs:abandoned" not in labels:
+        canonical_status = lifecycle.canonical_lifecycle_status(issue.get("status"), labels=labels)
+        if canonical_status != "closed":
+            continue
+        status = str(issue.get("status") or "").strip().lower()
+        if status in {"closed", "done"}:
             continue
         if has_open_descendant_changesets(issue_id):
             continue

--- a/tests/atelier/test_lifecycle.py
+++ b/tests/atelier/test_lifecycle.py
@@ -46,11 +46,15 @@ def test_is_changeset_ready_accepts_ready_label() -> None:
     assert lifecycle.is_changeset_ready("open", labels) is True
 
 
-def test_is_changeset_ready_rejects_planned_blocked_or_terminal_labels() -> None:
-    assert lifecycle.is_changeset_ready("open", {"at:changeset", "cs:planned"}) is False
-    assert lifecycle.is_changeset_ready("open", {"at:changeset", "cs:blocked"}) is False
-    assert lifecycle.is_changeset_ready("open", {"at:changeset", "cs:merged"}) is False
-    assert lifecycle.is_changeset_ready("open", {"at:changeset", "cs:abandoned"}) is False
+def test_is_changeset_ready_uses_status_authority_over_legacy_labels() -> None:
+    assert lifecycle.is_changeset_ready("open", {"at:changeset", "cs:planned"}) is True
+    assert lifecycle.is_changeset_ready("open", {"at:changeset", "cs:blocked"}) is True
+    assert lifecycle.is_changeset_ready("open", {"at:changeset", "cs:merged"}) is True
+    assert lifecycle.is_changeset_ready("open", {"at:changeset", "cs:abandoned"}) is True
+
+
+def test_is_changeset_ready_rejects_non_changesets() -> None:
+    assert lifecycle.is_changeset_ready("open", {"at:epic", "cs:ready"}) is False
 
 
 def test_is_changeset_ready_rejects_closed_status() -> None:

--- a/tests/atelier/worker/test_changeset_state.py
+++ b/tests/atelier/worker/test_changeset_state.py
@@ -50,12 +50,12 @@ def test_close_completed_container_changesets_closes_eligible_nodes() -> None:
     descendants = [
         {
             "id": "at-1.1",
-            "status": "open",
+            "status": "",
             "labels": ["at:changeset", "cs:merged"],
         },
         {
             "id": "at-1.2",
-            "status": "open",
+            "status": "",
             "labels": ["at:changeset", "cs:abandoned"],
         },
         {

--- a/tests/atelier/worker/test_finalize_pipeline.py
+++ b/tests/atelier/worker/test_finalize_pipeline.py
@@ -345,6 +345,31 @@ def test_run_finalize_pipeline_waiting_on_review_returns_pending(monkeypatch) ->
     assert result.continue_running is True
 
 
+def test_run_finalize_pipeline_waiting_on_review_uses_in_progress_status(monkeypatch) -> None:
+    issue = {
+        "id": "at-epic.1",
+        "status": "in_progress",
+        "labels": ["at:changeset"],
+        "description": "changeset.work_branch: feat/root-at-epic.1\n",
+    }
+    monkeypatch.setattr(
+        finalize_pipeline.beads,
+        "run_bd_json",
+        lambda *_args, **_kwargs: [issue],
+    )
+
+    service = _FinalizeServiceStub()
+    service.changeset_waiting_on_review_or_signals_fn = lambda _issue, *, context: True
+
+    result = finalize_pipeline.run_finalize_pipeline(
+        context=_pipeline_context(),
+        service=service,
+    )
+
+    assert result.reason == "changeset_review_pending"
+    assert result.continue_running is True
+
+
 def test_run_finalize_pipeline_blocks_on_stack_integrity_preflight(monkeypatch) -> None:
     issue = {
         "id": "at-epic.1",
@@ -417,6 +442,33 @@ def test_run_finalize_pipeline_keeps_terminal_labeled_changeset_open_while_pr_ac
     assert result.continue_running is True
     assert marks == ["at-epic.1"]
     assert closed == []
+
+
+def test_run_finalize_pipeline_treats_closed_status_as_terminal_without_labels(monkeypatch) -> None:
+    issue = {
+        "id": "at-epic.1",
+        "status": "closed",
+        "labels": ["at:changeset"],
+        "description": "changeset.work_branch: feat/root-at-epic.1\n",
+    }
+    monkeypatch.setattr(
+        finalize_pipeline.beads,
+        "run_bd_json",
+        lambda *_args, **_kwargs: [issue],
+    )
+
+    service = _FinalizeServiceStub()
+    closed: list[str] = []
+    service.mark_changeset_closed_fn = lambda changeset_id: closed.append(changeset_id)
+
+    result = finalize_pipeline.run_finalize_pipeline(
+        context=_pipeline_context(),
+        service=service,
+    )
+
+    assert result.reason == "changeset_complete"
+    assert result.continue_running is True
+    assert closed == ["at-epic.1"]
 
 
 def test_run_finalize_pipeline_updates_missing_integrated_sha(monkeypatch) -> None:

--- a/tests/atelier/worker/test_reconcile.py
+++ b/tests/atelier/worker/test_reconcile.py
@@ -18,7 +18,7 @@ def test_list_reconcile_epic_candidates_groups_by_epic() -> None:
         {
             "id": "at-1.1",
             "status": "blocked",
-            "labels": ["at:changeset", "cs:merged"],
+            "labels": ["at:changeset"],
         }
     ]
     with patch("atelier.worker.reconcile.beads.run_bd_json", return_value=issues):
@@ -40,7 +40,7 @@ def test_list_reconcile_epic_candidates_includes_non_terminal_merge_signal() -> 
         {
             "id": "at-1.2",
             "status": "in_progress",
-            "labels": ["at:changeset", "cs:in_progress"],
+            "labels": ["at:changeset"],
         }
     ]
     with patch("atelier.worker.reconcile.beads.run_bd_json", return_value=issues):
@@ -61,7 +61,7 @@ def test_list_reconcile_epic_candidates_includes_closed_open_pr_drift() -> None:
     drift_issue = {
         "id": "at-1.9",
         "status": "closed",
-        "labels": ["at:changeset", "cs:merged"],
+        "labels": ["at:changeset"],
         "description": "changeset.work_branch: feat/at-1.9\npr_state: closed\n",
     }
     with (
@@ -120,7 +120,7 @@ def test_reconcile_blocked_merged_changesets_dry_run_counts_candidates() -> None
         {
             "id": "at-1.1",
             "status": "blocked",
-            "labels": ["at:changeset", "cs:merged"],
+            "labels": ["at:changeset"],
         }
     ]
     with patch("atelier.worker.reconcile.beads.run_bd_json", return_value=issues):
@@ -159,7 +159,7 @@ def test_reconcile_blocked_merged_changesets_reconciles_non_terminal_merge_signa
         {
             "id": "at-1.2",
             "status": "in_progress",
-            "labels": ["at:changeset", "cs:in_progress"],
+            "labels": ["at:changeset"],
         }
     ]
     with patch("atelier.worker.reconcile.beads.run_bd_json", return_value=issues):
@@ -193,7 +193,7 @@ def test_reconcile_blocked_merged_changesets_reopens_closed_review_drift() -> No
     drift_issue = {
         "id": "at-1.9",
         "status": "closed",
-        "labels": ["at:changeset", "cs:merged"],
+        "labels": ["at:changeset"],
         "description": "changeset.work_branch: feat/at-1.9\npr_state: closed\n",
     }
     project = config.ProjectConfig(


### PR DESCRIPTION
## Summary
- migrate worker finalize transition decisions to rely on canonical status plus PR/integration signals instead of lifecycle label gates
- migrate reconcile candidate and dependency-finalization checks to status-native lifecycle semantics
- preserve deterministic handling for blocked and in-progress transitions under dependency and review gates
- resolve default-branch merge conflicts by rebasing on `main` and reconciling `reconcile` logic/tests with current mainline behavior

## Acceptance Criteria
- changeset and epic transition helpers use intrinsic status and PR signals for terminal and in-progress decisions
- finalize and reconcile paths do not require lifecycle labels for in-progress/terminal decisions
- blocked and in-progress transitions remain deterministic under dependency gating

## Testing
- `just test` (pre-push hook, Python 3.11)
- `just format`
- `just lint`

## Tickets
- Fixes #257
