### PR TITLE
Fail closed when worker AGENTS template cannot be loaded

### DIFF
--- a/src/atelier/templates.py
+++ b/src/atelier/templates.py
@@ -1,5 +1,6 @@
 """Template loading and rendering helpers."""
 
+from dataclasses import dataclass
 from importlib import resources
 from pathlib import Path
 
@@ -10,6 +11,31 @@ TEMPLATE_PARTS: tuple[tuple[str, ...], ...] = (
     ("AGENTS.planner.md.tmpl",),
     ("AGENTS.worker.md.tmpl",),
 )
+
+
+@dataclass(frozen=True)
+class TemplateReadResult:
+    """Template text plus source/diagnostics for fallback-aware callers.
+
+    Attributes:
+        text: Template content.
+        source: Source identifier used to return template text.
+        attempts: Ordered diagnostics describing lookup attempts.
+    """
+
+    text: str
+    source: str
+    attempts: tuple[str, ...]
+
+
+class TemplateReadError(RuntimeError):
+    """Raised when no readable template source can be resolved."""
+
+    def __init__(self, *, template: str, attempts: tuple[str, ...]) -> None:
+        self.template = template
+        self.attempts = attempts
+        summary = "; ".join(attempts) if attempts else "no lookup attempts recorded"
+        super().__init__(f"template_read_failed[{template}]: {summary}")
 
 
 def _read_template(*parts: str) -> str:
@@ -37,6 +63,10 @@ def _installed_template_path(*parts: str) -> Path:
     return paths.installed_templates_dir().joinpath(*parts)
 
 
+def _packaged_template_path(*parts: str) -> str:
+    return str(resources.files("atelier").joinpath("templates").joinpath(*parts))
+
+
 def read_installed_template(*parts: str) -> str | None:
     """Read a template from the installed cache when present.
 
@@ -50,6 +80,107 @@ def read_installed_template(*parts: str) -> str | None:
     if not path.exists():
         return None
     return path.read_text(encoding="utf-8")
+
+
+def read_template_result(
+    *parts: str,
+    prefer_installed: bool = False,
+    prefer_installed_if_modified: bool = False,
+) -> TemplateReadResult:
+    """Read template text and return detailed source diagnostics.
+
+    Args:
+        *parts: Path components under ``atelier/templates``.
+        prefer_installed: When true, prefer the installed cache when readable.
+        prefer_installed_if_modified: When true, prefer installed cache only if
+            it differs from packaged defaults, while still falling back
+            deterministically when packaged defaults are unavailable.
+
+    Returns:
+        Source diagnostics with template text.
+
+    Raises:
+        TemplateReadError: If no readable source can be resolved.
+    """
+    attempts: list[str] = []
+    installed_path = _installed_template_path(*parts)
+    packaged_path = _packaged_template_path(*parts)
+
+    def load_installed() -> str | None:
+        if not installed_path.exists():
+            attempts.append(f"installed cache missing: {installed_path}")
+            return None
+        try:
+            text = installed_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            attempts.append(
+                f"installed cache unreadable: {installed_path} ({type(exc).__name__}: {exc})"
+            )
+            return None
+        attempts.append(f"installed cache loaded: {installed_path}")
+        return text
+
+    def load_packaged() -> str | None:
+        try:
+            text = _read_template(*parts)
+        except OSError as exc:
+            attempts.append(
+                f"packaged default unreadable: {packaged_path} ({type(exc).__name__}: {exc})"
+            )
+            return None
+        attempts.append(f"packaged default loaded: {packaged_path}")
+        return text
+
+    selected_source = "packaged_default"
+    selected_text: str | None = None
+
+    if prefer_installed:
+        installed_text = load_installed()
+        if installed_text is not None:
+            selected_text = installed_text
+            selected_source = "installed_cache"
+        else:
+            selected_text = load_packaged()
+            selected_source = "packaged_default"
+    elif prefer_installed_if_modified:
+        installed_text = load_installed()
+        if installed_text is not None:
+            packaged_text = load_packaged()
+            if packaged_text is None:
+                selected_text = installed_text
+                selected_source = "installed_cache_fallback"
+                attempts.append(
+                    "selected source: installed cache fallback because packaged default "
+                    "was unavailable"
+                )
+            elif installed_text != packaged_text:
+                selected_text = installed_text
+                selected_source = "installed_cache_modified"
+                attempts.append(
+                    "selected source: installed cache because content differs from packaged default"
+                )
+            else:
+                selected_text = packaged_text
+                selected_source = "packaged_default"
+                attempts.append(
+                    "selected source: packaged default because installed cache "
+                    "matches packaged default"
+                )
+        else:
+            selected_text = load_packaged()
+            selected_source = "packaged_default"
+    else:
+        selected_text = load_packaged()
+        selected_source = "packaged_default"
+
+    if selected_text is None:
+        raise TemplateReadError(template="/".join(parts), attempts=tuple(attempts))
+
+    return TemplateReadResult(
+        text=selected_text,
+        source=selected_source,
+        attempts=tuple(attempts),
+    )
 
 
 def read_template(
@@ -68,18 +199,11 @@ def read_template(
     Returns:
         Template text.
     """
-    if prefer_installed:
-        cached = read_installed_template(*parts)
-        if cached is not None:
-            return cached
-    if prefer_installed_if_modified:
-        cached = read_installed_template(*parts)
-        if cached is not None:
-            packaged = _read_template(*parts)
-            if cached != packaged:
-                return cached
-            return packaged
-    return _read_template(*parts)
+    return read_template_result(
+        *parts,
+        prefer_installed=prefer_installed,
+        prefer_installed_if_modified=prefer_installed_if_modified,
+    ).text
 
 
 def installed_template_modified(*parts: str) -> bool:

--- a/tests/atelier/test_templates.py
+++ b/tests/atelier/test_templates.py
@@ -2,6 +2,8 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 import atelier.templates as templates
 
 
@@ -28,3 +30,50 @@ class TestInstalledTemplateComparison:
                 installed_path.write_text("custom agents\n", encoding="utf-8")
 
                 assert templates.installed_template_modified("agent", "AGENTS.md") is True
+
+
+class TestTemplateFallback:
+    def test_prefer_installed_if_modified_uses_cache_when_packaged_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            data_dir = root / "data"
+            installed_path = data_dir / "templates" / "AGENTS.worker.md.tmpl"
+            installed_path.parent.mkdir(parents=True)
+            installed_path.write_text("worker-template-cache\n", encoding="utf-8")
+
+            with (
+                patch("atelier.paths.atelier_data_dir", return_value=data_dir),
+                patch(
+                    "atelier.templates._read_template",
+                    side_effect=FileNotFoundError("missing packaged template"),
+                ),
+            ):
+                result = templates.read_template_result(
+                    "AGENTS.worker.md.tmpl",
+                    prefer_installed_if_modified=True,
+                )
+
+        assert result.text == "worker-template-cache\n"
+        assert result.source == "installed_cache_fallback"
+        assert any("packaged default unreadable:" in attempt for attempt in result.attempts)
+
+    def test_read_template_result_raises_when_all_sources_unavailable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            data_dir = root / "data"
+            with (
+                patch("atelier.paths.atelier_data_dir", return_value=data_dir),
+                patch(
+                    "atelier.templates._read_template",
+                    side_effect=FileNotFoundError("missing packaged template"),
+                ),
+            ):
+                with pytest.raises(templates.TemplateReadError) as exc_info:
+                    templates.read_template_result(
+                        "AGENTS.worker.md.tmpl",
+                        prefer_installed_if_modified=True,
+                    )
+
+        assert exc_info.value.template == "AGENTS.worker.md.tmpl"
+        assert any("installed cache missing:" in attempt for attempt in exc_info.value.attempts)
+        assert any("packaged default unreadable:" in attempt for attempt in exc_info.value.attempts)


### PR DESCRIPTION
# Summary

Harden worker session startup so missing or unreadable worker AGENTS templates no longer crash `atelier work` with an uncaught traceback.

# Changes

- Added fallback-aware template resolution that tries installed template cache first when packaged worker template reads fail.
- Added structured template-read diagnostics (`source` + ordered lookup attempts) so startup failures include missing path context and fallback history.
- Updated worker session preparation to emit actionable diagnostics with epic/worktree context when fallback is used.
- Updated startup failure handling to map worker-template load failures to a stable fail-closed summary reason (`worker_template_unavailable`).
- Added regression tests for both fallback success and fallback exhausted behavior, plus runner-level reason-code verification.

# Testing

- `just format`
- `just lint`
- `just test`

# Risks / Rollout

- Low risk: changes are scoped to template loading and worker startup error classification.
- Fallback source selection is now explicit and covered by tests for both success and failure branches.

# Notes

- This preserves fail-closed behavior while replacing uncaught `FileNotFoundError` startup crashes with deterministic blocked outcomes.
