### PR TITLE
Enforce single-child decomposition as a planning anti-pattern

### DIFF
--- a/src/atelier/skills/plan-changeset-guardrails/SKILL.md
+++ b/src/atelier/skills/plan-changeset-guardrails/SKILL.md
@@ -20,8 +20,8 @@ description: >-
 - If a changeset exceeds the approval threshold (default 800 LOC), notes should
   include an explicit approval record.
 - Guardrails should be recorded in notes or description when exceptions apply.
-- Detect anti-pattern: an epic with exactly one child changeset and no
-  decomposition rationale.
+- Detect anti-pattern: an epic with exactly one child changeset. This is an
+  actionable violation, not informational.
 
 ## Steps
 
@@ -35,14 +35,16 @@ description: >-
 1. For each changeset, inspect description/notes:
    - Look for a LOC estimate (e.g., `loc`, `LOC`, `estimate`).
    - If a large estimate is found (>800), ensure approval is recorded.
-1. If an epic has exactly one child changeset, require explicit decomposition
-   rationale in the epic or child notes/description.
-1. Summarize any violations and send a message to the planner/overseer with
-   actionable fixes.
+1. If an epic has exactly one child changeset, report it as an actionable
+   violation and require remediation:
+   - collapse to the epic as executable changeset, or
+   - split into at least two child changesets for true multi-step execution.
+1. Summarize violations and send a message to the planner/overseer with concrete
+   remediation.
 1. Do not block planning; use messages and bead notes instead.
 
 ## Verification
 
 - Violations are reported with bead ids and missing guardrail details.
-- One-child anti-pattern warnings are reported when rationale is missing.
+- One-child anti-pattern violations are always reported when present.
 - No beads are blocked or re-labeled automatically.

--- a/src/atelier/skills/plan-changeset-guardrails/scripts/check_guardrails.py
+++ b/src/atelier/skills/plan-changeset-guardrails/scripts/check_guardrails.py
@@ -17,10 +17,6 @@ from atelier.bd_invocation import with_bd_mode
 _LOC_TRIGGER = re.compile(r"\b(?:loc|estimate)\b", re.IGNORECASE)
 _NUMBER = re.compile(r"\b\d{2,5}\b")
 _APPROVAL = re.compile(r"\b(?:approve|approved|approval|sign[- ]?off|ok(?:ay)?)\b", re.IGNORECASE)
-_RATIONALE = re.compile(
-    r"\b(?:rationale|split because|split due to|reviewability|dependency|sequencing)\b",
-    re.IGNORECASE,
-)
 
 
 @dataclass(frozen=True)
@@ -165,17 +161,12 @@ def _evaluate_guardrails(
         elif len(child_changesets) == 1:
             child = child_changesets[0]
             child_id = _issue_id(child) or "(child)"
-            rationale_text = "\n".join((_text_blob(epic_issue), _text_blob(child)))
-            if _RATIONALE.search(rationale_text):
-                path_summary = (
-                    f"{epic_id}: one child changeset ({child_id}) with explicit rationale."
-                )
-            else:
-                path_summary = f"{epic_id}: one child changeset ({child_id}) without rationale."
-                violations.append(
-                    f"{epic_id}: one-child anti-pattern; add decomposition rationale "
-                    f"for {child_id} or keep the epic as the executable changeset."
-                )
+            path_summary = f"{epic_id}: one child changeset ({child_id}); actionable anti-pattern."
+            violations.append(
+                f"{epic_id}: one-child anti-pattern for {child_id}; collapse to the "
+                "epic as executable changeset or split into 2+ child changesets for "
+                "documented multi-step execution."
+            )
         else:
             path_summary = (
                 f"{epic_id}: multi-unit decomposition ({len(child_changesets)} children)."

--- a/src/atelier/skills/plan-changesets/SKILL.md
+++ b/src/atelier/skills/plan-changesets/SKILL.md
@@ -27,9 +27,10 @@ create/edit deferred work.
 - Separate renames from behavioral changes.
 - Prefer additive-first changesets.
 - Keep changesets reviewable (~200–400 LOC; split when >800 LOC).
-- Avoid one-child decomposition by default. If a split would produce exactly one
-  child changeset, keep the epic as the executable changeset unless you record
-  explicit decomposition rationale.
+- Do not create one-child decompositions. If a split would produce exactly one
+  child changeset, keep the epic as the executable changeset.
+- Decision rule: split only when there are multiple executable/reviewable steps;
+  otherwise keep work in the parent bead.
 - Keep tests with the nearest production change.
 - Ask for an estimated LOC range per changeset and confirm approval when a
   changeset exceeds ~800 LOC (unless purely mechanical).
@@ -41,10 +42,10 @@ create/edit deferred work.
 
 1. For each changeset, create a bead with the script:
    - `python skills/plan-changesets/scripts/create_changeset.py --epic-id <epic_id> --title "<title>" --acceptance "<acceptance>" [--status deferred|open] [--description "<scope/guardrails>"] [--notes "<notes>"] [--beads-dir "<beads_dir>"] [--no-export]`
-1. If decomposition would produce exactly one child changeset, stop and either:
-   - keep the epic as the executable changeset, or
-   - record explicit decomposition rationale in epic/changeset notes before
-     creating the child.
+1. If decomposition would produce exactly one child changeset, stop and keep the
+   epic as the executable changeset.
+1. If multi-step execution is required, define at least two child changesets; a
+   one-child split is always a planning anti-pattern.
 1. Default new changesets to `status=deferred`; promote to `status=open` only
    via the explicit promotion flow.
 1. Capture an estimated LOC range and record it in notes.
@@ -58,7 +59,7 @@ create/edit deferred work.
 
 - Changeset beads exist under the epic with `at:changeset` labels.
 - Decomposition happened only when needed for scope/dependency/reviewability.
-- Any one-child decomposition has explicit rationale recorded in notes or
-  description.
+- No one-child decompositions exist; single-unit work remains on the parent epic
+  (`at:changeset`).
 - When auto-export is enabled and not opted out, each changeset gets its own
   exported external ticket link.

--- a/src/atelier/skills/plan-promote-epic/SKILL.md
+++ b/src/atelier/skills/plan-promote-epic/SKILL.md
@@ -22,8 +22,8 @@ description: >-
 - Changeset guardrails have been validated (run `plan-changeset-guardrails`
   first).
 - Do not require child changesets when the epic itself is guardrail-sized.
-- If the epic has exactly one child changeset, explicit decomposition rationale
-  must be recorded before promotion.
+- Exactly one child changeset is a planning anti-pattern and must be resolved
+  before promotion.
 
 ## Steps
 
@@ -33,9 +33,10 @@ description: >-
    - Add `at:changeset` to the epic.
    - Keep execution state in status only (`deferred` now, `open` on promotion).
 1. If there is exactly one child changeset:
-   - Verify decomposition rationale is recorded in epic/child notes.
-   - If rationale is missing, keep the epic as executable changeset or add the
-     rationale before promotion.
+   - Do not promote until the anti-pattern is resolved.
+   - Resolve by either collapsing to the epic as executable changeset, or
+     decomposing into at least two child changesets for documented multi-step
+     execution needs.
 1. If the epic is not single-changeset sized, create only the minimum child
    changesets needed for execution and reviewability.
 1. Summarize the executable unit(s) for the user (child changesets or the epic
@@ -54,4 +55,4 @@ description: >-
   `open`.
 - If the epic has no child changesets, the epic is the executable leaf work unit
   (`at:changeset`) and status `open`.
-- Any one-child decomposition has explicit rationale in notes/description.
+- No one-child decomposition remains at promotion time.

--- a/src/atelier/skills/plan-split-tasks/SKILL.md
+++ b/src/atelier/skills/plan-split-tasks/SKILL.md
@@ -22,8 +22,9 @@ review-sized unit, keep it as the executable changeset.
 1. Confirm decomposition is necessary for scope, dependency sequencing, or
    reviewability.
 1. If decomposition would create exactly one child changeset, keep the epic as
-   the executable changeset unless explicit decomposition rationale is recorded
-   in notes/description.
+   the executable changeset.
+1. Split only when there are multiple executable/reviewable steps; true
+   multi-step execution should produce at least two child changesets.
 1. Create changeset beads under the epic:
    - `bd create --parent <epic_id> --type task --label at:changeset --title <title> --acceptance <acceptance>`
    - `bd update <new_changeset_id> --status deferred`
@@ -35,4 +36,4 @@ review-sized unit, keep it as the executable changeset.
 ## Verification
 
 - All executable work items are labeled `at:changeset` (never `at:subtask`).
-- One-child decompositions include explicit rationale.
+- No one-child decompositions are present.

--- a/src/atelier/templates/AGENTS.planner.md.tmpl
+++ b/src/atelier/templates/AGENTS.planner.md.tmpl
@@ -108,8 +108,9 @@ If code changes are needed, create beads and leave implementation to workers.
   changeset (no child changesets required).
 - Split into child changesets only when scope, dependencies, or reviewability
   require it.
-- Treat "exactly one child changeset" as an anti-pattern unless explicit
-  decomposition rationale is recorded.
+- Treat "exactly one child changeset" as an anti-pattern and resolve it before
+  promotion (collapse to parent, or split into 2+ children when multi-step work
+  is truly required).
 - Use the guardrails in the `plan-changesets` skill.
 - Validate guardrails with `plan-changeset-guardrails`.
 - Keep changesets reviewable and human-sized.

--- a/tests/atelier/skills/test_plan_changeset_guardrails_script.py
+++ b/tests/atelier/skills/test_plan_changeset_guardrails_script.py
@@ -56,7 +56,7 @@ def test_evaluate_guardrails_flags_one_child_without_rationale() -> None:
     assert any("one-child anti-pattern" in item for item in report.violations)
 
 
-def test_evaluate_guardrails_allows_one_child_with_rationale() -> None:
+def test_evaluate_guardrails_flags_one_child_even_with_rationale() -> None:
     module = _load_script_module()
     epic = {
         "id": "at-epic",
@@ -71,8 +71,8 @@ def test_evaluate_guardrails_allows_one_child_with_rationale() -> None:
         target_changesets=[child],
     )
 
-    assert "with explicit rationale" in str(report.path_summary)
-    assert not any("one-child anti-pattern" in item for item in report.violations)
+    assert "actionable anti-pattern" in str(report.path_summary)
+    assert any("one-child anti-pattern" in item for item in report.violations)
 
 
 def test_evaluate_guardrails_flags_large_changeset_without_approval() -> None:

--- a/tests/atelier/test_planner_agents_template.py
+++ b/tests/atelier/test_planner_agents_template.py
@@ -24,7 +24,7 @@ def test_planner_agents_template_contains_core_sections() -> None:
     assert "mail-send" in content
     assert "epic-list" in content
     assert "one child changeset" in content
-    assert "decomposition rationale" in content
+    assert 'Treat "exactly one child changeset" as an anti-pattern' in content
     assert "Do not claim or keep assignee ownership" in content
     assert "concrete issue, create or update a deferred bead immediately" in content
     assert "Create or update deferred beads immediately" in content

--- a/tests/atelier/test_skills.py
+++ b/tests/atelier/test_skills.py
@@ -203,11 +203,11 @@ def test_packaged_skill_docs_include_yaml_frontmatter() -> None:
         assert text.startswith("---\n"), f"{name} SKILL.md missing YAML frontmatter"
 
 
-def test_plan_changesets_skill_requires_rationale_for_one_child_split() -> None:
+def test_plan_changesets_skill_rejects_one_child_split() -> None:
     skill = skills.load_packaged_skills()["plan-changesets"]
     text = skill.files["SKILL.md"].decode("utf-8")
     assert "one child changeset" in text
-    assert "decomposition rationale" in text
+    assert "always a planning anti-pattern" in text
     assert "Default new changesets to `status=deferred`" in text
 
 
@@ -216,14 +216,14 @@ def test_plan_changeset_guardrails_skill_mentions_checker_script() -> None:
     text = skill.files["SKILL.md"].decode("utf-8")
     assert "scripts/check_guardrails.py" in text
     assert "one child changeset" in text
-    assert "decomposition rationale" in text
+    assert "actionable violation" in text
 
 
-def test_plan_promote_epic_skill_requires_one_child_rationale() -> None:
+def test_plan_promote_epic_skill_blocks_one_child_split() -> None:
     skill = skills.load_packaged_skills()["plan-promote-epic"]
     text = skill.files["SKILL.md"].decode("utf-8")
     assert "exactly one child changeset" in text
-    assert "decomposition rationale" in text
+    assert "planning anti-pattern" in text
 
 
 def test_plan_create_epic_skill_captures_drafts_without_approval() -> None:


### PR DESCRIPTION
# Summary

- Enforce planner policy that one-child epic decomposition is an anti-pattern.
- Keep single executable units on the parent epic and require 2+ child changesets for true multi-step work.

# Changes

- Updated planner skill guidance in `plan-changesets`, `plan-promote-epic`, and `plan-split-tasks` to disallow one-child decomposition.
- Updated `plan-changeset-guardrails` docs and checker logic so a one-child split is always reported as an actionable violation with remediation.
- Updated planner template guidance (`AGENTS.planner.md.tmpl`) to align with the no-single-child rule.
- Updated skill/template/script tests to validate the stricter policy.

# Testing

- `just format`
- `just lint`
- `UV_PYTHON=3.11 just test`

## Tickets
- Fixes #267

# Risks / Rollout

- Existing planned epics that currently use one-child decomposition may now be flagged and require planner remediation.

# Notes

- Guardrail output now treats one-child decomposition as an actionable planning violation.
