### PR TITLE
Use graph parentage when mapping ready changesets to epics

### DIFF
--- a/src/atelier/worker/selection.py
+++ b/src/atelier/worker/selection.py
@@ -188,7 +188,11 @@ def select_epic_from_ready_changesets(
         if not isinstance(issue_id, str) or not issue_id:
             continue
         candidate = issue_id
-        if "." in issue_id:
+        parent_id = issue_parent_id(changeset)
+        if parent_id and parent_id in known_epics:
+            candidate = parent_id
+        elif "." in issue_id:
+            # Compatibility fallback for legacy dotted child identifiers.
             maybe_epic = issue_id.split(".", 1)[0]
             if maybe_epic in known_epics:
                 candidate = maybe_epic


### PR DESCRIPTION
# Summary

Map ready changesets to their epic using graph parentage metadata during startup fallback, instead of relying on dotted ID patterns.

# Changes

- Prefer parsed `parent` lineage when resolving the epic for global ready changesets.
- Keep dotted child-ID prefix parsing only as a compatibility fallback.
- Add regression tests covering:
  - non-dotted child IDs with graph parent metadata,
  - mixed dotted and non-dotted child formats,
  - parent-child dependency payload variants using both `dependency_type` and `type`.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #289

# Risks / Rollout

- Low risk: selection logic still preserves legacy dotted-ID behavior as fallback.
- Rollout follows normal PR review and merge flow.

# Notes

- Scope is limited to ready-changeset epic mapping and targeted regression coverage.
