### PR TITLE
Require at:epic label for executable epic identity

### DIFF
--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -3475,7 +3475,11 @@ def claim_epic(
         die(f"epic not found: {epic_id}")
     issue = issues[0]
     claimability = _evaluate_epic_claimability(issue)
-    is_executable_work = claimability.role.is_epic
+    is_executable_work = lifecycle.is_executable_epic_identity(
+        labels=_issue_labels(issue),
+        issue_type=lifecycle.issue_payload_type(issue),
+        parent_id=_issue_parent_id(issue),
+    )
     if is_executable_work and not claimability.claimable:
         detail = ", ".join(claimability.reasons)
         die(

--- a/src/atelier/lifecycle.py
+++ b/src/atelier/lifecycle.py
@@ -245,6 +245,34 @@ def infer_work_role(
     )
 
 
+def is_executable_epic_identity(
+    *,
+    labels: set[str],
+    issue_type: object,
+    parent_id: object,
+) -> bool:
+    """Return whether an issue has executable epic identity.
+
+    Epic execution identity is strict: top-level work beads must also carry the
+    ``at:epic`` label.
+
+    Args:
+        labels: Normalized issue labels.
+        issue_type: Raw issue type value.
+        parent_id: Raw parent issue identifier.
+
+    Returns:
+        ``True`` when the issue is top-level work and includes ``at:epic``.
+    """
+    role = infer_work_role(
+        labels=labels,
+        issue_type=issue_type,
+        parent_id=parent_id,
+        has_work_children=False,
+    )
+    return role.is_epic and "at:epic" in labels
+
+
 def evaluate_runnable_leaf(
     *,
     status: object,
@@ -322,6 +350,8 @@ def evaluate_epic_claimability(
         reasons.append("not-work-bead")
     if not role.is_epic:
         reasons.append("not-top-level-work")
+    if "at:epic" not in labels:
+        reasons.append("missing-at:epic-label")
     if canonical_status not in ACTIVE_LIFECYCLE_STATUSES:
         reasons.append(f"status={canonical_status or 'missing'}")
     return EpicClaimEvaluation(

--- a/src/atelier/worker/selection.py
+++ b/src/atelier/worker/selection.py
@@ -60,7 +60,11 @@ def has_planner_executable_assignee(issue: dict[str, object]) -> bool:
 
 def has_executable_identity(issue: dict[str, object]) -> bool:
     """Return whether an issue is top-level executable work identity."""
-    return evaluate_epic_claimability(issue).role.is_epic
+    return lifecycle.is_executable_epic_identity(
+        labels=issue_labels(issue),
+        issue_type=issue_type(issue),
+        parent_id=issue_parent_id(issue),
+    )
 
 
 def planner_owned_executable_issues(issues: list[dict[str, object]]) -> list[dict[str, object]]:

--- a/tests/atelier/test_lifecycle.py
+++ b/tests/atelier/test_lifecycle.py
@@ -239,3 +239,41 @@ def test_is_active_root_branch_owner_rejects_unknown_status_even_with_epic_label
         )
         is False
     )
+
+
+def test_is_executable_epic_identity_requires_epic_label() -> None:
+    assert (
+        lifecycle.is_executable_epic_identity(
+            labels={"at:epic"},
+            issue_type="epic",
+            parent_id=None,
+        )
+        is True
+    )
+    assert (
+        lifecycle.is_executable_epic_identity(
+            labels=set(),
+            issue_type="epic",
+            parent_id=None,
+        )
+        is False
+    )
+
+
+def test_evaluate_epic_claimability_requires_epic_label() -> None:
+    unlabeled = lifecycle.evaluate_epic_claimability(
+        status="open",
+        labels=set(),
+        issue_type="epic",
+        parent_id=None,
+    )
+    assert unlabeled.claimable is False
+    assert "missing-at:epic-label" in unlabeled.reasons
+
+    labeled = lifecycle.evaluate_epic_claimability(
+        status="open",
+        labels={"at:epic"},
+        issue_type="epic",
+        parent_id=None,
+    )
+    assert labeled.claimable is True

--- a/tests/atelier/worker/test_selection.py
+++ b/tests/atelier/worker/test_selection.py
@@ -31,7 +31,7 @@ def test_filter_epics_uses_status_contract_for_unassigned_and_assigned() -> None
     assert [item["id"] for item in assigned] == ["at-3"]
 
 
-def test_filter_epics_accepts_issue_type_identity_without_labels() -> None:
+def test_filter_epics_requires_at_epic_label_for_executable_identity() -> None:
     issues = [
         {
             "id": "at-typed-epic",
@@ -49,7 +49,32 @@ def test_filter_epics_accepts_issue_type_identity_without_labels() -> None:
         skip_draft=True,
     )
 
-    assert [item["id"] for item in ready] == ["at-typed-epic"]
+    assert ready == []
+
+
+def test_has_executable_identity_requires_at_epic_label() -> None:
+    assert (
+        selection.has_executable_identity(
+            {
+                "id": "at-epic",
+                "status": "open",
+                "issue_type": "epic",
+                "labels": ["at:epic"],
+            }
+        )
+        is True
+    )
+    assert (
+        selection.has_executable_identity(
+            {
+                "id": "at-unlabeled",
+                "status": "open",
+                "issue_type": "epic",
+                "labels": [],
+            }
+        )
+        is False
+    )
 
 
 def test_sort_by_created_at_orders_oldest_first() -> None:
@@ -227,6 +252,21 @@ def test_select_epic_from_ready_changesets_skips_planner_owned_epic() -> None:
         issues=issues,
         ready_changesets=ready_changesets,
         is_actionable=lambda issue_id: issue_id == "at-epic",
+    )
+
+    assert selected is None
+
+
+def test_select_epic_from_ready_changesets_skips_unlabeled_top_level_work() -> None:
+    issues: list[dict[str, object]] = []
+    ready_changesets = [
+        {"id": "at-unlabeled", "status": "open", "issue_type": "epic", "labels": []},
+    ]
+
+    selected = selection.select_epic_from_ready_changesets(
+        issues=issues,
+        ready_changesets=ready_changesets,
+        is_actionable=lambda issue_id: issue_id == "at-unlabeled",
     )
 
     assert selected is None

--- a/tests/atelier/worker/test_session_next_changeset.py
+++ b/tests/atelier/worker/test_session_next_changeset.py
@@ -237,7 +237,12 @@ def test_next_changeset_service_accepts_issue_type_leaf_without_changeset_label(
     }
     service = FakeNextChangesetService(
         issues_by_id={
-            "at-epic": {"id": "at-epic", "status": "open", "issue_type": "epic", "labels": []},
+            "at-epic": {
+                "id": "at-epic",
+                "status": "open",
+                "issue_type": "epic",
+                "labels": ["at:epic"],
+            },
             issue_type_changeset["id"]: issue_type_changeset,
         },
         ready_changesets=[],


### PR DESCRIPTION
## Summary
- Enforce strict executable epic identity so top-level work must include the `at:epic` label.
- Route worker selection/startup and claimability checks through the same strict epic identity helper.
- Prevent unlabeled top-level work from being selected as executable epic work.

## Acceptance Criteria
- Epic claimability/identity requires a top-level work node with `at:epic`.
- Unlabeled top-level tasks/features are not treated as executable epics by startup selection.
- Lifecycle and selection regressions cover the strict identity requirement while preserving non-work exclusions.

## Testing
- `just format`
- `just lint`
- `just test`
