### PR TITLE
Align worker guidance with status-driven lifecycle semantics

### DIFF
--- a/src/atelier/templates/AGENTS.worker.md.tmpl
+++ b/src/atelier/templates/AGENTS.worker.md.tmpl
@@ -67,7 +67,7 @@ Skills link: ./skills
    - Update the bead to reflect the blocked status.
    - Stop immediately.
 7. If implementation is complete:
-   - Update changeset metadata and labels.
+   - Update changeset status and metadata.
    - Publish/persist via the `publish` skill.
    - In PR projects (`branch.pr_mode != none`), treat completion as:
      - PR created when policy allows PR creation, OR
@@ -111,7 +111,7 @@ Skills link: ./skills
 
 - Implement code in the assigned worktree.
 - Run required checks.
-- Update changeset metadata and labels.
+- Update changeset status and metadata.
 - Publish/persist according to project policy.
 - Send messages to the planner.
 

--- a/src/atelier/worker/prompts.py
+++ b/src/atelier/worker/prompts.py
@@ -36,7 +36,7 @@ def worker_opening_prompt(
             "acceptance criteria; do not mention internal bead IDs."
         ),
         (
-            "When done, update beads state/labels for this changeset. If blocked,"
+            "When done, update beads status/metadata for this changeset. If blocked,"
             " send NEEDS-DECISION with details and exit."
         ),
     ]
@@ -77,7 +77,7 @@ def worker_opening_prompt(
                     "Use github-prs skill scripts list_review_threads.py and "
                     "reply_inline_thread.py for deterministic inline handling."
                 ),
-                ("Do not reset lifecycle labels to ready while feedback remains unaddressed."),
+                ("Do not mark this changeset complete while review feedback remains unaddressed."),
             ]
         )
         if review_pr_url:

--- a/tests/atelier/test_worker_agents_template.py
+++ b/tests/atelier/test_worker_agents_template.py
@@ -17,3 +17,5 @@ def test_worker_agents_template_contains_core_sections() -> None:
     assert "Messaging Rules" in content
     assert "Finish" in content
     assert "Do not look for more" in content
+    assert "Update changeset status and metadata." in content
+    assert "Update changeset metadata and labels." not in content

--- a/tests/atelier/worker/test_prompts.py
+++ b/tests/atelier/worker/test_prompts.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from atelier.worker.prompts import worker_opening_prompt
+
+
+def test_worker_opening_prompt_uses_status_metadata_wording() -> None:
+    prompt = worker_opening_prompt(
+        project_enlistment="/repo",
+        workspace_branch="feature/test",
+        epic_id="at-epic",
+        changeset_id="at-epic.1",
+        changeset_title="Update worker prompt text",
+    )
+
+    assert "update beads status/metadata for this changeset" in prompt
+    assert "update beads state/labels for this changeset" not in prompt
+
+
+def test_worker_opening_prompt_review_feedback_avoids_label_reset_guidance() -> None:
+    prompt = worker_opening_prompt(
+        project_enlistment="/repo",
+        workspace_branch="feature/test",
+        epic_id="at-epic",
+        changeset_id="at-epic.1",
+        changeset_title="Update worker prompt text",
+        review_feedback=True,
+    )
+
+    assert (
+        "Do not mark this changeset complete while review feedback remains unaddressed." in prompt
+    )
+    assert (
+        "Do not reset lifecycle labels to ready while feedback remains unaddressed." not in prompt
+    )


### PR DESCRIPTION
# Summary

- Align worker-facing guidance with status-first lifecycle semantics by removing instructions to mutate lifecycle labels.

# Changes

- Update the worker AGENTS template to instruct changeset `status` and metadata updates instead of metadata/label mutation.
- Update worker opening prompt finalize guidance to say `status/metadata` instead of `state/labels`.
- Replace review-feedback guidance that previously told workers to reset lifecycle labels with guidance to keep changesets incomplete while feedback is unresolved.
- Add prompt/template regression tests to lock in the new wording.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #292

# Risks / Rollout

- Low risk: scoped to worker prompt/template text and assertion coverage.

# Notes

- No behavior or API changes outside worker instructions.
