### PR TITLE
Fix epic discovery limits in worker startup and status queries

### DIFF
--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -1976,9 +1976,9 @@ def list_epics(
 ) -> list[dict[str, object]]:
     """List epic beads for the epic pool.
 
-    Uses --label at:epic and --all to avoid default list caps and ensure full
-    enumeration. Startup, status, and related commands must use this for
-    deterministic epic pool counts.
+    Uses --label at:epic, --all, and --limit 0 to avoid default list caps and
+    ensure full enumeration. Startup, status, and related commands must use
+    this for deterministic epic pool counts.
 
     Args:
         beads_root: Root directory for the Beads planning store.
@@ -1990,7 +1990,7 @@ def list_epics(
     Returns:
         Epic issue payloads from Beads. Non-dict entries are discarded.
     """
-    args = ["list", "--label", "at:epic", "--all"]
+    args = ["list", "--label", "at:epic", "--all", "--limit", "0"]
     issues = run_bd_json(args, beads_root=beads_root, cwd=cwd)
     result = [i for i in issues if isinstance(i, dict)]
     if not include_closed:

--- a/src/atelier/worker/session/runner.py
+++ b/src/atelier/worker/session/runner.py
@@ -90,7 +90,7 @@ def _find_active_root_branch_conflicts(
     repo_root: Path,
 ) -> list[dict[str, object]]:
     issues = beads.run_bd_json(
-        ["list", "--label", "at:epic", "--all"],
+        ["list", "--label", "at:epic", "--all", "--limit", "0"],
         beads_root=beads_root,
         cwd=repo_root,
     )

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -2137,8 +2137,8 @@ def test_list_child_changesets_uses_graph_inference() -> None:
     )
 
 
-def test_list_epics_uses_at_epic_and_all() -> None:
-    """Regression: list_epics must use --label at:epic --all to avoid default caps."""
+def test_list_epics_uses_at_epic_all_and_unbounded_limit() -> None:
+    """Regression: list_epics must bypass default caps with explicit limit."""
     with patch("atelier.beads.run_bd_json", return_value=[]) as run_json:
         beads.list_epics(beads_root=Path("/beads"), cwd=Path("/repo"), include_closed=True)
     called_args = run_json.call_args.args[0]
@@ -2146,6 +2146,8 @@ def test_list_epics_uses_at_epic_and_all() -> None:
     assert "--label" in called_args
     assert "at:epic" in called_args
     assert "--all" in called_args
+    assert "--limit" in called_args
+    assert "0" in called_args
 
 
 def test_list_epics_finds_epic_beyond_default_window() -> None:
@@ -2153,7 +2155,7 @@ def test_list_epics_finds_epic_beyond_default_window() -> None:
     epic = {"id": "at-epic", "status": "open", "labels": ["at:epic"]}
 
     def fake_run(args: list[str], *, beads_root: Path, cwd: Path) -> list[dict[str, object]]:
-        if "at:epic" in args and "--all" in args:
+        if "at:epic" in args and "--all" in args and "--limit" in args and "0" in args:
             return [epic]
         return []
 

--- a/tests/atelier/worker/test_session_runner_flow.py
+++ b/tests/atelier/worker/test_session_runner_flow.py
@@ -249,7 +249,7 @@ def test_run_worker_once_blocks_on_active_root_branch_conflict() -> None:
     deps.infra.beads.claim_epic = Mock(return_value={"id": "at-epic", "title": "Epic"})
 
     def run_bd_json(args: list[str], *, beads_root: Path, cwd: Path) -> list[dict[str, object]]:  # noqa: ARG001
-        if args == ["list", "--label", "at:epic", "--all"]:
+        if args == ["list", "--label", "at:epic", "--all", "--limit", "0"]:
             return [
                 {
                     "id": "at-owner",


### PR DESCRIPTION
## Summary
- switch epic pool enumeration to an explicit unbounded query (`--label at:epic --all --limit 0`) so startup/status flows do not miss eligible epics behind the default `bd list` window
- apply the same explicit epic query contract to worker startup root-branch conflict checks
- update regressions to assert the explicit epic query contract in shared helper and startup flow tests

## Acceptance Criteria
- startup epic selection does not miss eligible epics due to default list caps
- no-eligible behavior now uses counts from the full epic pool returned by explicit epic queries
- startup/status epic enumeration paths use consistent `at:epic` query semantics with explicit limits

## Testing
- `just test`
- `just format`
- `just lint`

## Tickets
- Fixes #284
- Addresses #282
