### PR TITLE
Remove runtime ready-work dependency on at:changeset labels

### DIFF
--- a/tests/atelier/worker/test_selection.py
+++ b/tests/atelier/worker/test_selection.py
@@ -214,14 +214,17 @@ def test_select_epic_from_ready_changesets_uses_epic_for_child_issue() -> None:
     assert selected == "at-epic"
 
 
-def test_select_epic_from_ready_changesets_uses_graph_parent_for_non_dotted_child_id() -> None:
+@pytest.mark.parametrize("parent_value", [{"id": "at-epic"}, "at-epic"])
+def test_select_epic_from_ready_changesets_uses_graph_parent_for_non_dotted_child_id(
+    parent_value: object,
+) -> None:
     issues = [
         {"id": "at-epic", "status": "open", "labels": ["at:epic"], "assignee": None},
     ]
     ready_changesets = [
         {
             "id": "cs-ready-1",
-            "parent": {"id": "at-epic"},
+            "parent": parent_value,
             "created_at": "2026-02-20T00:00:00+00:00",
         },
     ]

--- a/tests/atelier/worker/test_session_startup.py
+++ b/tests/atelier/worker/test_session_startup.py
@@ -1038,6 +1038,31 @@ def test_run_startup_contract_skips_unlabeled_ready_changeset_fallback() -> None
     assert result.reason == "no_eligible_epics"
 
 
+def test_run_startup_contract_ready_fallback_uses_parent_graph_identity() -> None:
+    issues = [{"id": "at-ready", "status": "open", "labels": ["at:epic"], "assignee": None}]
+
+    result = _run_startup(
+        list_epics=lambda: issues,
+        mode="prompt",
+        select_epic_prompt=lambda **_kwargs: None,
+        ready_changesets_global=lambda: [
+            {
+                "id": "leaf-work",
+                "parent": "at-ready",
+                "status": "open",
+                "issue_type": "task",
+                "labels": [],
+            }
+        ],
+        next_changeset=lambda **kwargs: (
+            {"id": "leaf-work"} if kwargs.get("epic_id") == "at-ready" else None
+        ),
+    )
+
+    assert result.reason == "selected_ready_changeset"
+    assert result.epic_id == "at-ready"
+
+
 def test_run_startup_contract_selects_auto_epic() -> None:
     issues = [{"id": "at-auto", "status": "open", "labels": ["at:epic"]}]
 


### PR DESCRIPTION
## Summary
- Removes runtime assumptions that executable leaf work must carry the `at:changeset` label.
- Routes global ready-work fallback through graph parent identity first, so unlabeled/non-dotted leaf IDs still resolve to the correct epic.

## What Changed
- Updated ready-work epic selection to resolve candidate epic IDs in this order:
  1. graph parent metadata (`parent` / `parent_id` via boundary parsing)
  2. direct ID match when the item itself is an actionable epic
  3. dotted-ID compatibility fallback for legacy stores
- Preserved fail-closed behavior for non-actionable or ambiguous candidates.
- Expanded regressions for:
  - non-dotted leaf IDs using parent metadata
  - mixed leaf ID formats
  - parent-child dependency metadata shapes
  - startup fallback behavior for unlabeled top-level work vs unlabeled leaf work with a valid parent epic

## Acceptance Criteria Mapping
- Startup/ready selection now infers executable routing from graph shape and identity, not `at:changeset` label presence.
- Mixed stores remain deterministic when some executable leaf work lacks `at:changeset`.
- Label usage here remains compatibility-oriented and non-authoritative for runtime execution gating.
- Regression coverage includes explicit fallback scenarios across startup and selection paths.

## Testing
- `just test`
- `just format`
- `just lint`

## Tickets
- Fixes #285
