### PR TITLE
Normalize hybrid label-store identity metadata and diagnostics

### DIFF
--- a/src/atelier/commands/gc.py
+++ b/src/atelier/commands/gc.py
@@ -172,6 +172,12 @@ def gc(args: object) -> None:
             repo_root=repo_root,
         )
     )
+    actions.extend(
+        gc_labels.collect_backfill_epic_identity_labels(
+            beads_root=beads_root,
+            repo_root=repo_root,
+        )
+    )
     for label, detail in [
         ("at:changeset", "changeset role inferred from graph"),
         ("at:subtask", "subtask role inferred from graph"),

--- a/tests/atelier/commands/test_gc.py
+++ b/tests/atelier/commands/test_gc.py
@@ -382,6 +382,10 @@ def test_gc_logs_action_lifecycle_in_dry_run() -> None:
             return_value=[],
         ),
         patch(
+            "atelier.gc.labels.collect_backfill_epic_identity_labels",
+            return_value=[],
+        ),
+        patch(
             "atelier.gc.labels.collect_normalize_epic_labels",
             return_value=[],
         ),


### PR DESCRIPTION
## Summary
- add a shared Beads helper to detect top-level work items missing `at:epic` identity metadata in hybrid label stores
- add GC migration normalization that backfills missing `at:epic` labels for active top-level work
- add status diagnostics and counts that clearly report identity metadata gaps without changing lifecycle authority
- expand regression coverage for hybrid label behavior across discovery, selection, claim, finalize, and status reporting paths

## Acceptance Criteria Coverage
- mixed stores with and without `at:changeset` are handled consistently through graph/status semantics and explicit identity-gap detection
- legacy label-heavy records do not change lifecycle outcomes; deprecated labels remain non-authoritative
- regression matrix now covers discovery, selection, claim normalization, finalize, and status diagnostics under hybrid data
- operator diagnostics explicitly flag top-level work missing `at:epic`

## Testing
- `just test`
- `just format`
- `just lint`
