### PR TITLE
Auto-import legacy Beads data on first startup operations

### DIFF
--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -891,7 +891,18 @@ def _format_semver(version: tuple[int, int, int]) -> str:
     return f"{version[0]}.{version[1]}.{version[2]}"
 
 
+_STARTUP_AUTO_MIGRATION_TRIGGER_COMMANDS = frozenset(
+    {"blocked", "list", "prime", "ready", "show", "stats"}
+)
+
+
 def _is_startup_auto_migration_command(args: list[str]) -> bool:
+    if not args:
+        return False
+    return args[0].strip().lower() in _STARTUP_AUTO_MIGRATION_TRIGGER_COMMANDS
+
+
+def _should_emit_startup_auto_migration_diagnostic(args: list[str]) -> bool:
     if not args:
         return False
     return args[0].strip().lower() == "prime"
@@ -1770,7 +1781,7 @@ def run_bd_command(
         die(str(exc))
     _attempt_startup_auto_migration(args=args, beads_root=beads_root, cwd=cwd, env=env)
     _normalize_dolt_runtime_metadata_once(beads_root=beads_root)
-    if _is_startup_auto_migration_command(args):
+    if _should_emit_startup_auto_migration_diagnostic(args):
         _emit_startup_auto_migration_diagnostic(beads_root)
     preflight_error = _ensure_dolt_server_preflight(
         args=args,

--- a/src/atelier/commands/gc.py
+++ b/src/atelier/commands/gc.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .. import config
+from .. import beads, config
 from ..gc import GcAction
 from ..gc import agents as gc_agents
 from ..gc import hooks as gc_hooks
@@ -21,6 +21,7 @@ def gc(args: object) -> None:
     project_root, project_config, _enlistment, repo_root = resolve_current_project_with_repo_root()
     project_data_dir = config.resolve_project_data_dir(project_root, project_config)
     beads_root = config.resolve_beads_root(project_data_dir, repo_root)
+    beads.run_bd_command(["prime"], beads_root=beads_root, cwd=repo_root)
 
     stale_hours = getattr(args, "stale_hours", 24.0)
     try:

--- a/src/atelier/skills/import-legacy-tickets/SKILL.md
+++ b/src/atelier/skills/import-legacy-tickets/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: import-legacy-tickets
+description: >-
+  Trigger startup legacy Beads import/migration on demand and report whether
+  migration was performed or skipped.
+---
+
+# Import legacy tickets
+
+## Inputs
+
+- beads_dir: Optional Beads store path.
+
+## Steps
+
+1. Run:
+   - `python3 skills/import-legacy-tickets/scripts/import_legacy_tickets.py`
+   - or
+     `python3 skills/import-legacy-tickets/scripts/import_legacy_tickets.py --beads-dir "<path>"`
+1. Return the script output verbatim so operators can see migration/import
+   diagnostics and startup state before/after.
+
+## Verification
+
+- Startup migration/import flow was executed through Atelier Beads runtime.
+- Output clearly states one of: `migrated`, `skipped`, or `blocked`.
+- Output includes startup-state diagnostics for before and after execution.

--- a/src/atelier/skills/import-legacy-tickets/scripts/import_legacy_tickets.py
+++ b/src/atelier/skills/import-legacy-tickets/scripts/import_legacy_tickets.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Run startup legacy-ticket migration/import and print explicit diagnostics."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from atelier import beads, config
+from atelier.commands.resolve import resolve_current_project_with_repo_root
+
+_MISSING_DOLT = "missing_dolt_with_legacy_sqlite"
+_INSUFFICIENT_DOLT = "insufficient_dolt_vs_legacy_data"
+_HEALTHY_DOLT = "healthy_dolt"
+
+
+def _resolve_context(*, beads_dir: str | None) -> tuple[Path, Path]:
+    repo_env = os.environ.get("ATELIER_PROJECT", "").strip()
+    beads_env = str(beads_dir or "").strip() or os.environ.get("BEADS_DIR", "").strip()
+    repo_root = Path(repo_env).resolve() if repo_env else Path.cwd()
+    if beads_env:
+        return Path(beads_env).expanduser().resolve(), repo_root
+    project_root, project_config, _enlistment, repo_root = resolve_current_project_with_repo_root()
+    project_data_dir = config.resolve_project_data_dir(project_root, project_config)
+    return config.resolve_beads_root(project_data_dir, repo_root), repo_root
+
+
+def _status_reason(state: beads.StartupBeadsState) -> str:
+    if not state.has_legacy_sqlite:
+        return "no recoverable legacy SQLite startup state detected"
+    if state.classification == _MISSING_DOLT:
+        return "legacy SQLite data exists but Dolt backend is missing"
+    if state.classification == _INSUFFICIENT_DOLT:
+        dolt_total = state.dolt_issue_total if state.dolt_issue_total is not None else "unavailable"
+        legacy_total = (
+            state.legacy_issue_total if state.legacy_issue_total is not None else "unavailable"
+        )
+        return f"active Dolt issue count ({dolt_total}) is below legacy SQLite issue count ({legacy_total})"
+    if state.classification == _HEALTHY_DOLT:
+        return "active Dolt issue count already covers legacy SQLite issue count"
+    return "no recoverable legacy SQLite startup state detected"
+
+
+def _migration_verified(
+    *,
+    before: beads.StartupBeadsState,
+    after: beads.StartupBeadsState,
+) -> bool:
+    if after.classification != _HEALTHY_DOLT or after.migration_eligible:
+        return False
+    if after.dolt_issue_total is None:
+        return False
+    if before.legacy_issue_total is None:
+        return True
+    return after.dolt_issue_total >= before.legacy_issue_total
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--beads-dir",
+        default="",
+        help="beads root path (defaults to BEADS_DIR env var or project config)",
+    )
+    args = parser.parse_args()
+
+    beads_root, repo_root = _resolve_context(beads_dir=args.beads_dir)
+    if not beads_root.exists():
+        print(f"error: beads dir not found: {beads_root}", file=sys.stderr)
+        raise SystemExit(1)
+
+    before = beads.detect_startup_beads_state(beads_root=beads_root, cwd=repo_root)
+    beads.run_bd_command(["prime"], beads_root=beads_root, cwd=repo_root)
+    after = beads.detect_startup_beads_state(beads_root=beads_root, cwd=repo_root)
+
+    if before.migration_eligible and _migration_verified(before=before, after=after):
+        status = "migrated"
+        reason = _status_reason(before)
+    elif before.migration_eligible:
+        status = "blocked"
+        reason = "legacy migration remained unresolved after startup prime"
+    else:
+        status = "skipped"
+        reason = _status_reason(before)
+
+    print(f"Beads startup auto-upgrade {status}: {reason}")
+    print("before=" + beads.format_startup_beads_diagnostics(before))
+    print("after=" + beads.format_startup_beads_diagnostics(after))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/atelier/skills/test_import_legacy_tickets_script.py
+++ b/tests/atelier/skills/test_import_legacy_tickets_script.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import atelier.beads as beads
+
+
+def _load_script():
+    scripts_dir = (
+        Path(__file__).resolve().parents[3] / "src/atelier/skills/import-legacy-tickets/scripts"
+    )
+    path = scripts_dir / "import_legacy_tickets.py"
+    spec = importlib.util.spec_from_file_location("test_import_legacy_tickets_script", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _state(
+    *,
+    classification: str,
+    migration_eligible: bool,
+    has_dolt_store: bool,
+    has_legacy_sqlite: bool,
+    dolt_issue_total: int | None,
+    legacy_issue_total: int | None,
+    reason: str,
+) -> beads.StartupBeadsState:
+    return beads.StartupBeadsState(
+        classification=classification,
+        migration_eligible=migration_eligible,
+        has_dolt_store=has_dolt_store,
+        has_legacy_sqlite=has_legacy_sqlite,
+        dolt_issue_total=dolt_issue_total,
+        legacy_issue_total=legacy_issue_total,
+        reason=reason,
+    )
+
+
+def test_main_runs_prime_and_reports_skipped_status(monkeypatch, capsys, tmp_path: Path) -> None:
+    module = _load_script()
+    before = _state(
+        classification="startup_state_unknown",
+        migration_eligible=False,
+        has_dolt_store=True,
+        has_legacy_sqlite=False,
+        dolt_issue_total=6,
+        legacy_issue_total=None,
+        reason="legacy_sqlite_missing",
+    )
+    after = before
+    state_reads = iter([before, after])
+    calls: list[tuple[list[str], Path, Path]] = []
+
+    beads_root = tmp_path / "beads"
+    repo_root = tmp_path / "repo"
+    beads_root.mkdir()
+    repo_root.mkdir()
+    monkeypatch.setattr(module, "_resolve_context", lambda **_kwargs: (beads_root, repo_root))
+    monkeypatch.setattr(
+        module.beads,
+        "detect_startup_beads_state",
+        lambda **_kwargs: next(state_reads),
+    )
+    monkeypatch.setattr(
+        module.beads,
+        "run_bd_command",
+        lambda args, *, beads_root, cwd: calls.append((args, beads_root, cwd)),
+    )
+    monkeypatch.setattr(
+        module.beads,
+        "format_startup_beads_diagnostics",
+        lambda state: f"classification={state.classification}",
+    )
+    monkeypatch.setattr(module.sys, "argv", ["import_legacy_tickets.py"])
+
+    module.main()
+
+    output = capsys.readouterr().out.strip().splitlines()
+    assert output[0] == (
+        "Beads startup auto-upgrade skipped: no recoverable legacy SQLite startup state detected"
+    )
+    assert output[1] == "before=classification=startup_state_unknown"
+    assert output[2] == "after=classification=startup_state_unknown"
+    assert calls == [(["prime"], beads_root, repo_root)]
+
+
+def test_main_reports_migrated_when_recoverable_state_is_resolved(
+    monkeypatch, capsys, tmp_path: Path
+) -> None:
+    module = _load_script()
+    before = _state(
+        classification="missing_dolt_with_legacy_sqlite",
+        migration_eligible=True,
+        has_dolt_store=False,
+        has_legacy_sqlite=True,
+        dolt_issue_total=None,
+        legacy_issue_total=4,
+        reason="legacy_sqlite_has_data_while_dolt_is_unavailable",
+    )
+    after = _state(
+        classification="healthy_dolt",
+        migration_eligible=False,
+        has_dolt_store=True,
+        has_legacy_sqlite=True,
+        dolt_issue_total=4,
+        legacy_issue_total=4,
+        reason="dolt_issue_total_is_healthy",
+    )
+    state_reads = iter([before, after])
+
+    beads_root = tmp_path / "beads"
+    repo_root = tmp_path / "repo"
+    beads_root.mkdir()
+    repo_root.mkdir()
+    monkeypatch.setattr(module, "_resolve_context", lambda **_kwargs: (beads_root, repo_root))
+    monkeypatch.setattr(
+        module.beads,
+        "detect_startup_beads_state",
+        lambda **_kwargs: next(state_reads),
+    )
+    monkeypatch.setattr(module.beads, "run_bd_command", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        module.beads,
+        "format_startup_beads_diagnostics",
+        lambda state: f"classification={state.classification}",
+    )
+    monkeypatch.setattr(module.sys, "argv", ["import_legacy_tickets.py"])
+
+    module.main()
+
+    output = capsys.readouterr().out.strip().splitlines()
+    assert output[0] == (
+        "Beads startup auto-upgrade migrated: legacy SQLite data exists but Dolt backend is missing"
+    )

--- a/tests/atelier/test_skills.py
+++ b/tests/atelier/test_skills.py
@@ -18,6 +18,7 @@ def test_packaged_skills_include_core_set() -> None:
         "external-sync",
         "external-close",
         "beads",
+        "import-legacy-tickets",
         "claim-epic",
         "epic-claim",
         "epic-list",
@@ -65,6 +66,7 @@ def test_install_workspace_skills_writes_skill_docs() -> None:
             "external-sync",
             "external-close",
             "beads",
+            "import-legacy-tickets",
             "claim-epic",
             "epic-claim",
             "epic-list",
@@ -96,6 +98,7 @@ def test_packaged_planning_skills_include_scripts() -> None:
     assert "scripts/create_changeset.py" in definitions["plan-changesets"].files
     assert "scripts/create_epic.py" in definitions["plan-create-epic"].files
     assert "scripts/refresh_overview.py" in definitions["planner-startup-check"].files
+    assert "scripts/import_legacy_tickets.py" in definitions["import-legacy-tickets"].files
     assert "scripts/send_message.py" in definitions["mail-send"].files
 
 


### PR DESCRIPTION
# Summary

- Auto-import legacy Beads SQLite data during first startup operations so planner/worker/status/open/list/gc paths recover legacy epics deterministically.
- Add an on-demand `import-legacy-tickets` skill that runs the same startup migration flow and reports whether migration was migrated/skipped/blocked with diagnostics.

# Changes

- Expanded startup migration triggers in `atelier.beads.run_bd_command` to include startup read commands (`list`, `show`, `ready`, `blocked`, `stats`) while keeping automatic migration diagnostics emission scoped to `prime`.
- Added `bd prime` at the start of `atelier gc` so GC performs startup migration/import before normal GC behavior.
- Refactored `skills/epic-list/scripts/list_epics.py` to resolve project/beads context and use Atelier planner APIs instead of raw `bd` subprocess invocations.
- Added packaged skill `import-legacy-tickets` with `scripts/import_legacy_tickets.py` for explicit, operator-friendly migration/import execution and before/after diagnostics.
- Added regression tests for non-prime migration trigger behavior, GC startup priming, epic-list context usage, new skill packaging, and the new import-legacy skill script behavior.

# Testing

- `just test`
- `just format`
- `just lint`

# Tickets

- Fixes #302

# Risks / Rollout

- Startup reads now evaluate migration eligibility on additional `bd` commands, which could surface migration blockers earlier on first access.
- `epic-list` now resolves project context through Atelier helpers; execution from non-project directories still exits with a clear context/beads path error.

# Notes

- PR intentionally keeps diagnostic emission for formatted startup outputs stable by only auto-emitting migration diagnostics on `bd prime`.
