### PR TITLE
Scale worker startup epic selection with active-epic reconciliation

### DIFF
--- a/src/atelier/worker/work_startup_runtime.py
+++ b/src/atelier/worker/work_startup_runtime.py
@@ -566,7 +566,7 @@ class _StartupContractService(worker_startup.StartupContractService):
         return beads.list_epics(
             beads_root=self._beads_root,
             cwd=self._repo_root,
-            include_closed=True,
+            include_closed=False,
         )
 
     def show_issue(self, issue_id: str) -> dict[str, object] | None:

--- a/tests/atelier/worker/test_runtime.py
+++ b/tests/atelier/worker/test_runtime.py
@@ -299,6 +299,26 @@ def test_startup_service_no_eligible_summary_does_not_queue_message() -> None:
     assert emitted[0] == "No eligible epics available."
 
 
+def test_startup_service_lists_only_non_closed_epics() -> None:
+    service = work_startup_runtime._StartupContractService(  # pyright: ignore[reportPrivateUsage]
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    with patch(
+        "atelier.worker.work_startup_runtime.beads.list_epics",
+        return_value=[{"id": "at-1"}],
+    ) as list_epics:
+        issues = service.list_epics()
+
+    assert issues == [{"id": "at-1"}]
+    list_epics.assert_called_once_with(
+        beads_root=Path("/beads"),
+        cwd=Path("/repo"),
+        include_closed=False,
+    )
+
+
 def test_startup_service_reports_planner_owned_executable_violations() -> None:
     emitted: list[str] = []
     issues = [


### PR DESCRIPTION
# Summary

- Reduce worker startup cost in the "Select epic" stage by reconciling only active executable epics, instead of reconciling historical closed/deferred/non-executable issues.

# Changes

- Added `_is_startup_reconciliation_candidate(...)` in startup selection flow to gate expensive reconciliation to claimable executable epics in eligible active statuses.
- Updated startup runtime epic listing to exclude closed epics (`include_closed=False`) for normal worker runs.
- Added regression coverage to ensure startup reconciliation only touches active epics and preserves expected selection outcomes.
- Added runtime service coverage to verify closed epics are excluded at the Beads query boundary.

# Testing

- `pytest -q tests/atelier/worker/test_session_startup.py tests/atelier/worker/test_runtime.py`
- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #306

# Risks / Rollout

- Low risk; selection order and explicit-epic handling are unchanged.
- Change is scoped to startup reconciliation candidate filtering and runtime epic query options.

# Notes

- Explicit epic runs still reconcile via direct issue lookup and continue to honor existing lifecycle behavior.
