### PR TITLE
Continue implicit worker runs after local epic failures

### DIFF
--- a/src/atelier/worker/session/runner.py
+++ b/src/atelier/worker/session/runner.py
@@ -462,6 +462,13 @@ def run_worker_once(
                 )
             agent_bead_id_required = agent_bead_id
         claim_conflict_excluded_epics: set[str] = set()
+        raw_excluded_epics = getattr(args, "implicit_excluded_epic_ids", ())
+        if isinstance(raw_excluded_epics, (list, tuple, set)):
+            claim_conflict_excluded_epics = {
+                str(epic_id).strip()
+                for epic_id in raw_excluded_epics
+                if isinstance(epic_id, str) and str(epic_id).strip()
+            }
         startup_result: StartupContractResult
         selected_epic: str
         epic_issue: dict[str, object]


### PR DESCRIPTION
## Summary
- continue non-watch implicit `atelier work` runs after a single epic-local startup or finalize failure
- carry an in-memory excluded-epic list into startup selection so failed epics are skipped during the same invocation
- preserve fail-closed behavior when the same epic continues failing despite exclusion and keep explicit-epic behavior unchanged

## What Changed
- added runtime skip classification for implicit epic-local failures in `worker/runtime.py`
- threaded implicit exclusion hints into `run_worker_once` startup context in `worker/session/runner.py`
- added runtime tests for continuation after one failed epic and for deterministic fail-closed fallback on repeated failures

## Validation
- `just test`
- `just format`
- `just lint`
