### PR TITLE
Gate sequential PR creation on fully integrated dependencies

### DIFF
--- a/src/atelier/worker/finalization/pr_gate.py
+++ b/src/atelier/worker/finalization/pr_gate.py
@@ -582,7 +582,11 @@ def attempt_create_pr(
     render_changeset_pr_body: Callable[[dict[str, object]], str],
 ) -> tuple[bool, str]:
     base_branch = changeset_base_branch(
-        issue, beads_root=beads_root, repo_root=repo_root, git_path=git_path
+        issue,
+        repo_slug=repo_slug,
+        beads_root=beads_root,
+        repo_root=repo_root,
+        git_path=git_path,
     )
     if not base_branch:
         return False, "missing PR base branch metadata"


### PR DESCRIPTION
## Summary
This update enforces sequential DAG behavior by requiring integrated evidence across all declared dependencies before downstream PR creation.

It also hardens join-node base selection so ambiguous dependency lineage fails closed unless an explicit heritage integration parent is available.

## Changes
- Require all dependencies to report integrated evidence before sequential PR creation proceeds.
- Fail closed for blocked or ambiguous dependency lineage instead of defaulting to the repository default branch.
- Use the same PR integration signal source for both PR-gate preflight and base-branch resolution.
- Forward repository context through PR creation base resolution to keep gating and base selection consistent.
- Add regressions covering lineage fallback hardening and signal consistency.

## Acceptance Criteria Coverage
- Sequential PR creation evaluates all declared dependencies.
- PR creation is blocked until every dependency is integrated.
- Once dependencies are integrated, base branch resolution uses the expected integration parent.

## Tickets
- Fixes #243

## Validation
- `UV_PYTHON=3.11 uv run pytest tests/atelier/worker/test_pr_gate.py tests/atelier/worker/test_work_finalization_state.py`
- `UV_PYTHON=3.11 just format`
- `UV_PYTHON=3.11 just lint`
- `UV_PYTHON=3.11 just test`
