### PR TITLE
Add regression matrix for sequential DAG and anomaly flows

### DIFF
--- a/tests/atelier/commands/test_status.py
+++ b/tests/atelier/commands/test_status.py
@@ -879,6 +879,137 @@ def test_status_sequential_collapses_transitive_duplicate_dependency_parents() -
         assert by_id["cs-3"]["pr_gate_reason"] == "blocked:pr-open"
 
 
+def test_status_sequential_blocks_when_non_parent_dependency_not_integrated() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        project_root = root / "project"
+        repo_root = root / "repo"
+        project_root.mkdir(parents=True, exist_ok=True)
+        repo_root.mkdir(parents=True, exist_ok=True)
+
+        project_config = config.ProjectConfig.model_validate(
+            {"project": {"enlistment": str(repo_root), "origin": "github.com/org/repo"}}
+        )
+        epic = {
+            "id": "epic-1",
+            "title": "Epic",
+            "status": "open",
+            "labels": ["at:epic"],
+            "description": "workspace.pr_strategy: sequential\n",
+        }
+        changesets = [
+            {
+                "id": "cs-1",
+                "title": "Ancestor",
+                "labels": [],
+                "description": "changeset.work_branch: alpha-cs-1\n",
+                "type": "task",
+            },
+            {
+                "id": "cs-2",
+                "title": "Frontier Parent",
+                "labels": [],
+                "description": "changeset.work_branch: alpha-cs-2\n",
+                "dependencies": ["cs-1"],
+                "type": "task",
+            },
+            {
+                "id": "cs-3",
+                "title": "Child",
+                "labels": [],
+                "description": (
+                    "changeset.root_branch: alpha\n"
+                    "changeset.parent_branch: alpha\n"
+                    "changeset.work_branch: alpha-cs-3\n"
+                ),
+                "dependencies": ["cs-1", "cs-2"],
+                "type": "task",
+            },
+        ]
+
+        def fake_run_bd_json(
+            args: list[str], *, beads_root: Path, cwd: Path
+        ) -> list[dict[str, object]]:
+            if args[:3] == ["list", "--label", "at:epic"]:
+                return [epic]
+            if args[:3] == ["list", "--label", "at:agent"]:
+                return []
+            if args[:3] == ["list", "--label", "at:message"]:
+                return []
+            if args and args[0] == "list" and "--parent" in args:
+                parent_id = args[args.index("--parent") + 1]
+                if parent_id == "epic-1":
+                    return list(changesets)
+                return []
+            if args and args[0] == "ready" and "--parent" in args:
+                return []
+            return []
+
+        def fake_load_mapping(path: Path) -> WorktreeMapping | None:
+            if path.name == "epic-1.json":
+                return WorktreeMapping(
+                    epic_id="epic-1",
+                    worktree_path="worktrees/epic-1",
+                    root_branch="alpha",
+                    changesets={
+                        "cs-1": "alpha-cs-1",
+                        "cs-2": "alpha-cs-2",
+                        "cs-3": "alpha-cs-3",
+                    },
+                    changeset_worktrees={},
+                )
+            return None
+
+        def fake_pr_payload(_repo_slug: str, branch: str) -> dict[str, object] | None:
+            if branch == "alpha-cs-1":
+                return {"state": "CLOSED", "closedAt": "2026-02-25T00:00:00Z"}
+            if branch == "alpha-cs-2":
+                return {
+                    "state": "MERGED",
+                    "mergedAt": "2026-02-25T00:00:00Z",
+                    "isDraft": False,
+                }
+            if branch == "alpha-cs-3":
+                return {"state": "OPEN", "isDraft": True}
+            return None
+
+        with (
+            patch(
+                "atelier.commands.status.resolve_current_project_with_repo_root",
+                return_value=(project_root, project_config, str(repo_root), repo_root),
+            ),
+            patch(
+                "atelier.commands.status.beads.run_bd_command",
+                return_value=DummyResult(),
+            ),
+            patch(
+                "atelier.commands.status.beads.run_bd_json",
+                side_effect=fake_run_bd_json,
+            ),
+            patch(
+                "atelier.commands.status.worktrees.load_mapping",
+                side_effect=fake_load_mapping,
+            ),
+            patch(
+                "atelier.commands.status.git.git_ref_exists",
+                return_value=True,
+            ),
+            patch(
+                "atelier.commands.status.prs.lookup_github_pr_status",
+                side_effect=_lookup_status_payload(fake_pr_payload),
+            ),
+        ):
+            buffer = io.StringIO()
+            with patch("sys.stdout", buffer):
+                status_cmd(SimpleNamespace(format="json"))
+
+        payload = json.loads(buffer.getvalue())
+        details = payload["epics"][0]["changeset_details"]
+        by_id = {detail["id"]: detail for detail in details}
+        assert by_id["cs-3"]["pr_allowed"] is False
+        assert by_id["cs-3"]["pr_gate_reason"] == "blocked:dependency-not-integrated"
+
+
 def test_status_at_kid_dag_allows_only_frontier_changeset_after_parent_merge() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)

--- a/tests/atelier/test_pr_strategy.py
+++ b/tests/atelier/test_pr_strategy.py
@@ -1,3 +1,5 @@
+import pytest
+
 from atelier import pr_strategy
 
 
@@ -47,3 +49,23 @@ def test_pr_strategy_decision_sequential_allows_when_parent_merged() -> None:
     decision = pr_strategy.pr_strategy_decision("sequential", parent_state="merged")
     assert decision.allow_pr is True
     assert decision.reason == "parent:merged"
+
+
+@pytest.mark.parametrize(
+    ("strategy", "parent_state", "allow_pr", "reason"),
+    [
+        ("parallel", "closed", True, "strategy:parallel"),
+        ("parallel", "pr-open", True, "strategy:parallel"),
+        ("on-ready", "pushed", False, "blocked:pushed"),
+        ("on-ready", "pr-open", True, "parent:pr-open"),
+    ],
+)
+def test_pr_strategy_decision_preserves_parallel_and_on_ready_behavior(
+    strategy: str,
+    parent_state: str,
+    allow_pr: bool,
+    reason: str,
+) -> None:
+    decision = pr_strategy.pr_strategy_decision(strategy, parent_state=parent_state)
+    assert decision.allow_pr is allow_pr
+    assert decision.reason == reason


### PR DESCRIPTION
# Summary

Expand regression coverage for sequential DAG dependency gating and lifecycle-anomaly handling so PR gate, startup selection, finalize, reconcile, and status surfaces stay behaviorally aligned.

# Changes

- Add startup selection regressions for join-node dependencies to require integrated evidence from every upstream dependency before selecting downstream work.
- Add reconcile regressions for join dependencies so downstream finalize is blocked until all dependency integration signals are present.
- Add finalize pipeline coverage for `dependency-not-integrated` stack-integrity failures and planner notification messaging.
- Add status command regression coverage for sequential join graphs where a non-parent dependency is closed-not-merged, asserting `blocked:dependency-not-integrated`.
- Add PR gate and PR strategy regressions that preserve non-sequential (`parallel` and `on-ready`) behavior while sequential dependency gates remain strict.

# Testing

- `UV_PYTHON=3.11 just test`
- `UV_PYTHON=3.11 just format`
- `UV_PYTHON=3.11 just lint`

## Tickets

- Fixes #240

# Risks / Rollout

- Low risk; this changeset is test-only and tightens regression coverage around existing sequential gating behavior.
