### PR TITLE
Fix inactive-worker reroute epic creation for current bd CLI

### DIFF
--- a/src/atelier/skills/mail-send/scripts/send_message.py
+++ b/src/atelier/skills/mail-send/scripts/send_message.py
@@ -108,8 +108,6 @@ def _create_reroute_epic(
             "epic",
             "--label",
             "at:epic",
-            "--status",
-            "open",
             "--title",
             title,
             "--acceptance",

--- a/tests/atelier/skills/test_mail_send_script.py
+++ b/tests/atelier/skills/test_mail_send_script.py
@@ -77,7 +77,7 @@ def test_dispatch_message_reroutes_when_worker_inactive() -> None:
     create_message.assert_not_called()
 
 
-def test_create_reroute_epic_writes_diagnostics_and_open_status() -> None:
+def test_create_reroute_epic_writes_diagnostics_without_status_flag() -> None:
     module = _load_script_module()
     captured_args: list[str] = []
 
@@ -103,8 +103,7 @@ def test_create_reroute_epic_writes_diagnostics_and_open_status() -> None:
     assert created["id"] == "at-epic-9"
     assert "--label" in captured_args
     assert "at:epic" in captured_args
-    assert "--status" in captured_args
-    assert captured_args[captured_args.index("--status") + 1] == "open"
+    assert "--status" not in captured_args
     description = captured_args[captured_args.index("--description") + 1]
     assert "routing.decision: rerouted_inactive_worker" in description
     assert "routing.inactive_worker: atelier/worker/codex/p22" in description


### PR DESCRIPTION
## Summary
Planner dispatch rerouting for inactive workers now creates executable reroute epics without using unsupported `bd create` flags.

## What Changed
- Removed `--status open` from reroute epic creation in the mail-send dispatch script.
- Kept reroute diagnostics/metadata behavior unchanged.
- Updated regression coverage to assert reroute creation does not pass a status flag.

## Acceptance Criteria Mapping
- Inactive-worker dispatch creates reroute executable work without CLI flag errors.
- Mail-send reroute flow remains compatible with the current `bd` CLI profile.
- Regression coverage verifies the inactive recipient reroute path.

## Verification
- `pytest tests/atelier/skills/test_mail_send_script.py`
- `just format`
- `just lint`
- `UV_PYTHON=/Users/scott/code/atelier/.venv/bin/python3.11 just test`

## Tickets
- Part of #238
