### PR TITLE
Show deferred changesets in planner startup overview

### DIFF
--- a/tests/atelier/skills/test_planner_startup_refresh_script.py
+++ b/tests/atelier/skills/test_planner_startup_refresh_script.py
@@ -155,3 +155,52 @@ def test_render_startup_overview_lists_claim_state_and_sorts_messages(monkeypatc
             },
         ),
     ]
+
+
+def test_render_startup_overview_caps_deferred_epic_scan(monkeypatch) -> None:
+    module = _load_script()
+    monkeypatch.setenv("ATELIER_STARTUP_DEFERRED_EPIC_SCAN_LIMIT", "1")
+    monkeypatch.setattr(module.beads, "list_inbox_messages", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(module.beads, "list_queue_messages", lambda **_kwargs: [])
+    scanned_epics: list[str] = []
+
+    def _fake_list_descendant_changesets(parent_id: str, **_kwargs):
+        scanned_epics.append(parent_id)
+        return [{"id": f"{parent_id}.1", "title": "Deferred child", "status": "deferred"}]
+
+    monkeypatch.setattr(
+        module.beads, "list_descendant_changesets", _fake_list_descendant_changesets
+    )
+    monkeypatch.setattr(
+        module.planner_overview,
+        "list_epics",
+        lambda **_kwargs: [
+            {"id": "at-1", "title": "Epic one", "status": "open"},
+            {"id": "at-2", "title": "Epic two", "status": "in_progress"},
+            {"id": "at-3", "title": "Epic three", "status": "blocked"},
+        ],
+    )
+    monkeypatch.setattr(
+        module.planner_overview,
+        "render_epics",
+        lambda issues, *, show_drafts: "Epics by state:\n- at-1 [open] Example",
+    )
+
+    rendered = module._render_startup_overview(
+        "atelier/planner/example",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    assert scanned_epics == ["at-1"]
+    assert rendered.splitlines() == [
+        "Planner startup overview",
+        "No unread messages.",
+        "No queued messages.",
+        "Deferred changesets under open/in-progress/blocked epics:",
+        "- at-1 [open] Epic one",
+        "  - at-1.1 [deferred] Deferred child",
+        "Deferred changeset scan limited to first 1 active epics; skipped 2.",
+        "Epics by state:",
+        "- at-1 [open] Example",
+    ]


### PR DESCRIPTION
# Summary

Improve planner startup diagnostics so deferred descendant changesets are visible without manual child queries, including when the parent epic is currently blocked.

# Changes

- add a deferred-changeset summary section to planner startup overview refresh output
- group deferred descendant changesets under active epics (`open`, `in_progress`, and `blocked`)
- keep existing `epic-list --show-drafts` rendering unchanged
- extend startup refresh tests for empty-state messaging, deferred filtering, sorting, blocked-epic coverage, and descendant query arguments

# Testing

- `pytest -q tests/atelier/skills/test_planner_startup_refresh_script.py`
- pre-push hook suite (includes `pytest` and shell checks)

# Tickets

- Fixes #329

# Risks / Rollout

- planner startup overview now performs descendant lookup calls for active epics only

# Notes

- no lifecycle gating semantics were changed; this is reporting-only
