### PR TITLE
Fix implicit worker continuation after decision-required finalize failures

### DIFF
--- a/src/atelier/worker/runtime.py
+++ b/src/atelier/worker/runtime.py
@@ -486,8 +486,13 @@ def run_worker_sessions(
         try:
             # Deep-clone args so nested mutable fields cannot leak across loop iterations.
             iteration_args = copy.deepcopy(args)
-        except Exception:
-            # Fallback keeps behavior for uncommon non-deepcopyable args objects.
+        except (TypeError, copy.Error) as exc:
+            # Preserve behavior for uncommon non-deepcopyable args objects, but keep a
+            # diagnostic breadcrumb when we must fall back to shallow copy semantics.
+            atelier_log.debug(
+                "Falling back to shallow args copy after deepcopy failure: "
+                f"{type(exc).__name__}: {exc}"
+            )
             iteration_args = copy.copy(args)
         if explicit_epic_requested:
             setattr(iteration_args, "epic_id", explicit_epic_id)


### PR DESCRIPTION
# Summary

- Keep implicit worker runs moving after finalize returns a decision-required failure by skipping the failed epic for the current loop and continuing selection.
- Preserve fail-closed behavior when the run was started with an explicit epic.
- Prevent worker runtime retries from mutating caller-owned args objects.

# Changes

- Capture explicit-epic mode once at session start and normalize retry arguments per loop iteration.
- Build a per-iteration args clone before each `run_worker_once` call so implicit/explicit overrides and downstream mutations do not leak to caller state.
- Replace the implicit continuation boolean helper with a structured decision result and add runtime debug telemetry that records why continuation was or was not applied.
- Expand runtime tests to cover:
  - implicit skip-and-continue after stack-integrity finalize failure
  - explicit stack-integrity finalize failure remains fail-closed
  - repeated same-epic failure remains fail-closed
  - implicit retries clear transient epic argument carryover
  - caller args stay unchanged across implicit retry loops

# Testing

- `just test`
- `just format`
- `just lint`

## Tickets
- Fixes #337

# Risks / Rollout

- Low risk: changes are constrained to worker runtime loop control and covered by targeted plus full-suite tests.

# Notes

- No behavior changes to queue-only runs.
