### PR TITLE
Prevent plan-changesets create from mutating existing changesets

### DIFF
--- a/src/atelier/skills/plan-changesets/scripts/create_changeset.py
+++ b/src/atelier/skills/plan-changesets/scripts/create_changeset.py
@@ -35,7 +35,11 @@ def _command_detail(result: subprocess.CompletedProcess[str]) -> str:
 
 
 def _list_child_issue_ids(*, epic_id: str, beads_root: Path, cwd: Path) -> set[str]:
-    issues = beads.run_bd_json(["list", "--parent", epic_id], beads_root=beads_root, cwd=cwd)
+    issues = beads.run_bd_json(
+        ["list", "--parent", epic_id, "--limit", "0"],
+        beads_root=beads_root,
+        cwd=cwd,
+    )
     ids: set[str] = set()
     for issue in issues:
         issue_id = issue.get("id")

--- a/tests/atelier/skills/test_plan_changesets_script.py
+++ b/tests/atelier/skills/test_plan_changesets_script.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -328,6 +329,97 @@ def test_create_changeset_uses_new_child_id_when_create_output_is_noisy(
         command for command in commands if command[:3] == ["update", "at-202", "--status"]
     ]
     assert status_commands == [["update", "at-202", "--status", "deferred"]]
+
+
+def test_create_changeset_lists_all_children_for_large_epic(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+    commands: list[list[str]] = []
+    list_calls = 0
+    context = SimpleNamespace(
+        project_dir=tmp_path / "project",
+        beads_root=tmp_path / ".beads",
+    )
+    existing_ids = [f"at-{index}" for index in range(200, 255)]
+    created_id = "at-255"
+
+    monkeypatch.setattr(module.auto_export, "resolve_auto_export_context", lambda: context)
+
+    def fake_run_bd(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+        allow_failure: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal list_calls
+        commands.append(args)
+        assert beads_root == context.beads_root
+        assert cwd == context.project_dir
+        if args[:2] == ["list", "--parent"]:
+            list_calls += 1
+            ids = existing_ids if list_calls == 1 else [*existing_ids, created_id]
+            has_unbounded_limit = False
+            if "--limit" in args:
+                limit_index = args.index("--limit")
+                has_unbounded_limit = limit_index + 1 < len(args) and args[limit_index + 1] == "0"
+            if not has_unbounded_limit:
+                ids = ids[:50]
+            payload = json.dumps([{"id": issue_id} for issue_id in ids])
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=payload,
+                stderr="",
+            )
+        if args and args[0] == "create":
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout=f"warning: existing {existing_ids[-1]} still open\n{created_id}\n",
+                stderr="",
+            )
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(module.beads, "run_bd_command", fake_run_bd)
+    monkeypatch.setattr(
+        module.auto_export,
+        "auto_export_issue",
+        lambda issue_id, *, context: module.auto_export.AutoExportResult(
+            status="skipped",
+            issue_id=issue_id,
+            provider=None,
+            message="auto-export disabled for test",
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "create_changeset.py",
+            "--epic-id",
+            "at-epic",
+            "--title",
+            "Large epic create output",
+            "--acceptance",
+            "Acceptance text",
+        ],
+    )
+
+    module.main()
+
+    list_commands = [command for command in commands if command[:2] == ["list", "--parent"]]
+    status_commands = [
+        command for command in commands if command[:3] == ["update", created_id, "--status"]
+    ]
+    assert len(list_commands) == 2
+    assert all(
+        "--limit" in command and command[command.index("--limit") + 1] == "0"
+        for command in list_commands
+    )
+    assert status_commands == [["update", created_id, "--status", "deferred"]]
 
 
 def test_create_changeset_fails_when_create_does_not_add_new_child(


### PR DESCRIPTION
# Summary

Prevent `plan-changesets` create flow from mutating existing changesets when create output is noisy, ambiguous, or large-epic child listing is paginated.

# Changes

- Snapshot epic child IDs before running `bd create` and re-list children afterward.
- Use unbounded child listing (`bd list --parent <epic> --limit 0`) so creation identity checks always see all existing children, including epics with more than 50 changesets.
- Resolve the created changeset ID only from newly added child IDs; fail fast when no new ID or ambiguous IDs are detected.
- Block status/notes mutations when create does not produce exactly one new child ID.
- Include compact `bd create` stdout/stderr excerpts in ambiguous and no-new-child errors to speed triage when CLI output formats drift.
- Add regression coverage for noisy output containing existing IDs, no-new-child failures, ambiguous multi-new-child responses, and >50-child epic pagination.

# Acceptance Criteria Mapping

- Create either produces a new child ID or exits with no side effects on existing children.
- Target ID is verified as newly created in the current invocation before any status/notes updates.
- Output parsing tolerates warnings/noise and cannot accidentally select existing IDs.
- Regression tests reproduce overwrite-risk patterns and prove existing changesets remain unchanged.

# Testing

- `pytest -q tests/atelier/skills/test_plan_changesets_script.py`
- `just format`
- `just lint`
- `just test` (passes in pre-push hook on Python 3.11)

## Tickets

- Fixes #336

# Risks / Rollout

- Low risk: changes are scoped to the `plan-changesets` create script path and covered by focused regression tests.
