### PR TITLE
Prevent false missing integration blocks on merged changesets

### DIFF
--- a/src/atelier/worker/integration.py
+++ b/src/atelier/worker/integration.py
@@ -247,11 +247,16 @@ def changeset_integration_signal(
         for branch in (work_branch, root_branch):
             if branch and branch not in source_branches:
                 source_branches.append(branch)
-        source_refs: list[str] = []
-        for source_branch in source_branches:
-            source_ref = branch_ref_for_lookup(repo_root, source_branch, git_path=git_path)
-            if source_ref and source_ref not in source_refs:
-                source_refs.append(source_ref)
+
+        def source_refs_for_branches() -> list[str]:
+            refs: list[str] = []
+            for source_branch in source_branches:
+                source_ref = branch_ref_for_lookup(repo_root, source_branch, git_path=git_path)
+                if source_ref and source_ref not in refs:
+                    refs.append(source_ref)
+            return refs
+
+        source_refs = source_refs_for_branches()
 
         def prove_against_targets(current_target_refs: list[str]) -> tuple[bool, str | None]:
             if integrated_sha_candidates and current_target_refs:
@@ -300,6 +305,7 @@ def changeset_integration_signal(
                 git_path=git_path,
                 require_remote_tracking=True,
             )
+            source_refs = source_refs_for_branches()
             proven, integrated_sha = prove_against_targets(refreshed_target_refs)
             if proven:
                 return True, integrated_sha


### PR DESCRIPTION
## Summary
This change prevents worker finalize from incorrectly blocking merged changesets when local target-branch state is stale.

## What changed
- Strict integration proof now requires authoritative `origin/<target>` refs instead of accepting local-only target refs.
- If required remote-tracking target refs are missing locally, the worker performs a one-time `git fetch --no-tags origin` refresh and retries proof.
- The retry path now recomputes source branch refs after refresh so newly fetched `origin/<source>` refs are considered.
- Integration checks still require actual target-branch reachability (or patch-equivalence); merged PR state alone is not treated as proof.

## Why
Merged changesets could be blocked with a false "missing integration signal" when a worker had stale or incomplete local refs. This created unnecessary manual planner recovery even though integration was already reflected in remote branch history.

## Acceptance criteria coverage
- Finalize proof succeeds when merge commits are reachable from authoritative target-branch state, including after explicit refresh.
- Runtime distinguishes stale-local-ref mismatch recovery (refresh + retry) from true non-integration.
- Regression coverage includes the edge case where source and target remote refs are absent pre-refresh and present post-refresh.

## Tests
- `pytest -q tests/atelier/worker/test_integration.py`
- Full pre-push suite (`pytest` + shell tests) via repository hooks

Closes #355
