### PR TITLE
Prevent worker instructions from closing active PR changesets

### DIFF
--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -2131,14 +2131,15 @@ def list_epics(
     return result
 
 
-def _strip_unsupported_export_from_addendum(text: str) -> str:
-    """Remove lines referencing bd export or bd sync --export (unsupported/deprecated)."""
+def _strip_unsupported_commands_from_addendum(text: str) -> str:
+    """Remove lines referencing unsupported/deprecated Beads commands."""
     if not text:
         return text
+    blocked_substrings = ("bd export", "sync --export", "bd dolt commit")
     out: list[str] = []
     for line in text.splitlines():
         lower = line.lower()
-        if "bd export" in lower or "sync --export" in lower:
+        if any(token in lower for token in blocked_substrings):
             continue
         out.append(line)
     return "\n".join(out).strip()
@@ -2152,9 +2153,9 @@ def prime_addendum(*, beads_root: Path, cwd: Path) -> str | None:
     agent AGENTS.md so the planner or worker sees up-to-date Beads guidance.
     Injection is done elsewhere via agent_home.apply_beads_prime_addendum():
     the planner syncs it during plan, and the worker syncs it at session start.
-    Lines that reference unsupported or deprecated commands (bd export,
-    bd sync --export) are stripped before return so agents are not told to
-    run unavailable commands.
+    Lines that reference unsupported or deprecated commands (`bd export`,
+    `bd sync --export`, `bd dolt commit`) are stripped before return so agents
+    are not told to run unavailable commands.
     """
     env = beads_env(beads_root)
     command = ["bd", "prime", "--full"]
@@ -2173,7 +2174,7 @@ def prime_addendum(*, beads_root: Path, cwd: Path) -> str | None:
     if result.returncode != 0:
         return None
     output = (result.stdout or "").strip()
-    output = _strip_unsupported_export_from_addendum(output)
+    output = _strip_unsupported_commands_from_addendum(output)
     return output or None
 
 

--- a/src/atelier/commands/plan.py
+++ b/src/atelier/commands/plan.py
@@ -598,7 +598,9 @@ def run_planner(args: object) -> None:
                 prime_addendum = beads.prime_addendum(beads_root=beads_root, cwd=project_data_dir)
                 updated_content = planner_agents_path.read_text(encoding="utf-8")
                 next_content = agent_home.apply_beads_prime_addendum(
-                    updated_content, prime_addendum
+                    updated_content,
+                    prime_addendum,
+                    role=policy.ROLE_PLANNER,
                 )
                 if next_content != updated_content:
                     planner_agents_path.write_text(next_content, encoding="utf-8")

--- a/src/atelier/templates/AGENTS.worker.md.tmpl
+++ b/src/atelier/templates/AGENTS.worker.md.tmpl
@@ -84,10 +84,14 @@ Skills link: ./skills
 - Use canonical lifecycle statuses only:
   - `deferred`, `open`, `in_progress`, `blocked`, `closed`.
 - `cs:*` lifecycle labels are not execution gates.
-- In PR projects, do not close a changeset after only pushing a branch when PR
-  policy allows opening a PR now.
 - Keep `pr_state` accurate in bead metadata (`pushed`, `draft-pr`, `pr-open`,
   `in-review`, `approved`, `merged`, `closed`).
+- In PR projects, treat `pushed`, `draft-pr`, `pr-open`, `in-review`, and
+  `approved` as active lifecycle states; do not set `status=closed` in those
+  states.
+- Set `status=closed` only when terminal proof exists:
+  - PR lifecycle is terminal (`pr_state=merged` or `pr_state=closed`), OR
+  - non-PR integration is proven (`changeset.integrated_sha` recorded).
 - For PR feedback runs, inline review comments must be answered inline and then
   resolved; do not post a new top-level PR comment in place of an inline reply.
   Use the `github-prs` skill scripts (`list_review_threads.py`,

--- a/src/atelier/worker/prompts.py
+++ b/src/atelier/worker/prompts.py
@@ -44,6 +44,12 @@ def worker_opening_prompt(
             "acceptance criteria; do not mention internal bead IDs."
         ),
         (
+            "Do not set status=closed while PR lifecycle is active "
+            "(`pushed`,`draft-pr`,`pr-open`,`in-review`,`approved`). "
+            "Close only when PR is terminal (`merged`/`closed`) or non-PR "
+            "integration proof exists (`changeset.integrated_sha`)."
+        ),
+        (
             "When done, update beads status/metadata for this changeset and required "
             "ancestor lifecycle state only. If blocked, send NEEDS-DECISION with "
             "details and exit."

--- a/src/atelier/worker/session/agent.py
+++ b/src/atelier/worker/session/agent.py
@@ -196,7 +196,11 @@ def prepare_agent_session(
             )
             prime_addendum = beads.prime_addendum(beads_root=beads_root, cwd=project_data_dir)
             updated_content = worker_agents_path.read_text(encoding="utf-8")
-            next_content = agent_home.apply_beads_prime_addendum(updated_content, prime_addendum)
+            next_content = agent_home.apply_beads_prime_addendum(
+                updated_content,
+                prime_addendum,
+                role=policy.ROLE_WORKER,
+            )
             if next_content != updated_content:
                 worker_agents_path.write_text(next_content, encoding="utf-8")
             updated_content = worker_agents_path.read_text(encoding="utf-8")

--- a/tests/atelier/test_agent_home.py
+++ b/tests/atelier/test_agent_home.py
@@ -274,3 +274,32 @@ def test_apply_beads_prime_addendum_replaces_existing_block() -> None:
     assert "old" not in updated
     assert "new" in updated
     assert updated.count("ATELIER_BEADS_PRIME_START") == 1
+
+
+def test_apply_beads_prime_addendum_worker_role_replaces_generic_prime_guidance() -> None:
+    content = "# Worker Context\n\nBase instructions.\n"
+    addendum = (
+        "# Beads Workflow Context\n\n"
+        "# 🚨 SESSION CLOSE PROTOCOL 🚨\n\n"
+        "```\n"
+        "[ ] bd close at-123\n"
+        "```\n"
+        "Run `bd ready` for backlog triage.\n"
+    )
+
+    updated = agent_home.apply_beads_prime_addendum(content, addendum, role="worker")
+
+    assert "Worker Runtime Context" in updated
+    assert "bd close at-123" not in updated
+    assert "SESSION CLOSE PROTOCOL" not in updated
+    assert "assigned epic/changeset bead is the only execution scope" in updated
+
+
+def test_apply_beads_prime_addendum_planner_role_keeps_addendum_body() -> None:
+    content = "# Planner Context\n\nBase instructions.\n"
+    addendum = "# Beads Workflow Context\n\n- Use bd ready."
+
+    updated = agent_home.apply_beads_prime_addendum(content, addendum, role="planner")
+
+    assert "Use bd ready." in updated
+    assert "Worker Runtime Context" not in updated

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -1958,14 +1958,15 @@ def test_prime_addendum_returns_prime_output_without_rewriting() -> None:
     assert value == stdout.strip()
 
 
-def test_prime_addendum_strips_unsupported_export_command_lines() -> None:
-    """Lines referencing bd export or bd sync --export are removed (unsupported/deprecated)."""
+def test_prime_addendum_strips_unsupported_command_lines() -> None:
+    """Unsupported/deprecated command lines are removed from prime addendum output."""
     stdout = (
         "## Beads Workflow Context\n\n"
         "```\n"
         "[ ] bd export\n"
         "[ ] bd sync --flush-only\n"
         "[ ] bd sync --export\n"
+        "[ ] bd dolt commit\n"
         "```\n"
         "- Use bd ready.\n"
     )
@@ -1982,6 +1983,7 @@ def test_prime_addendum_strips_unsupported_export_command_lines() -> None:
     assert value is not None
     assert "bd export" not in value
     assert "sync --export" not in value
+    assert "bd dolt commit" not in value
     assert "bd sync --flush-only" in value
     assert "Use bd ready" in value
 

--- a/tests/atelier/test_worker_agents_template.py
+++ b/tests/atelier/test_worker_agents_template.py
@@ -21,3 +21,5 @@ def test_worker_agents_template_contains_core_sections() -> None:
     assert "committable artifacts (code/config/docs/tests)" in content
     assert "Do not mutate sibling/unclaimed work-bead lifecycle state." in content
     assert "Update changeset metadata and labels." not in content
+    assert "do not set `status=closed`" in content
+    assert "Set `status=closed` only when terminal proof exists" in content

--- a/tests/atelier/worker/test_prompts.py
+++ b/tests/atelier/worker/test_prompts.py
@@ -16,6 +16,8 @@ def test_worker_opening_prompt_uses_status_metadata_wording() -> None:
     assert "update beads state/labels for this changeset" not in prompt
     assert "implement only committable changeset artifacts" in prompt
     assert "planner owns non-commit orchestration" in prompt
+    assert "Do not set status=closed while PR lifecycle is active" in prompt
+    assert "Close only when PR is terminal (`merged`/`closed`)" in prompt
 
 
 def test_worker_opening_prompt_review_feedback_avoids_label_reset_guidance() -> None:


### PR DESCRIPTION
## Summary
- replace worker-injected Beads runtime addendum content with a worker-safe guidance block that avoids backlog workflow/closure instructions
- tighten worker prompt and worker AGENTS template language so active PR lifecycle states cannot be marked `status=closed`
- require terminal proof for close guidance (`pr_state=merged|closed` or non-PR `changeset.integrated_sha` evidence)
- expand prime-addendum sanitization to drop unsupported `bd dolt commit` guidance

## Testing
- `pytest tests/atelier/test_agent_home.py tests/atelier/test_beads.py tests/atelier/worker/test_prompts.py tests/atelier/test_worker_agents_template.py`
- `just format`
- `just lint`
- `just test`
