### PR TITLE
fix(root-branch): make default epic root branch suggestions collision-proof

### DIFF
--- a/src/atelier/root_branch.py
+++ b/src/atelier/root_branch.py
@@ -32,12 +32,13 @@ def prompt_root_branch(
     *,
     title: str,
     branch_prefix: str,
+    epic_id: str | None = None,
     beads_root: Path,
     repo_root: Path,
     assume_yes: bool = False,
 ) -> str:
     """Prompt for a root branch name with validation and uniqueness checks."""
-    suggested = branching.suggest_root_branch(title, branch_prefix)
+    suggested = branching.suggest_root_branch(title, branch_prefix, bead_id=epic_id)
     while True:
         if assume_yes:
             root_branch = branching.normalize_root_branch(suggested or "")

--- a/src/atelier/worker/ports.py
+++ b/src/atelier/worker/ports.py
@@ -157,7 +157,13 @@ class BeadsService(Protocol):
 class BranchingService(Protocol):
     """Branch naming and existence helpers."""
 
-    def suggest_root_branch(self, title: str, prefix: str) -> str: ...
+    def suggest_root_branch(
+        self,
+        title: str,
+        prefix: str,
+        *,
+        bead_id: str | None = None,
+    ) -> str: ...
 
 
 class ConfigService(Protocol):
@@ -194,6 +200,7 @@ class RootBranchService(Protocol):
         *,
         title: str,
         branch_prefix: str,
+        epic_id: str | None = None,
         beads_root: Path,
         repo_root: Path,
         assume_yes: bool = False,

--- a/src/atelier/worker/session/runner.py
+++ b/src/atelier/worker/session/runner.py
@@ -628,6 +628,7 @@ def run_worker_once(
             suggested_root_branch = infra.branching.suggest_root_branch(
                 str(epic_issue.get("title") or selected_epic),
                 project_config.branch.prefix,
+                bead_id=selected_epic,
             )
             if dry_run:
                 control.dry_run_log("Root branch missing; would prompt for root branch selection.")
@@ -638,6 +639,7 @@ def run_worker_once(
                 root_branch_value = infra.root_branch.prompt_root_branch(
                     title=str(epic_issue.get("title") or selected_epic),
                     branch_prefix=project_config.branch.prefix,
+                    epic_id=selected_epic,
                     beads_root=beads_root,
                     repo_root=repo_root,
                     assume_yes=assume_yes,

--- a/tests/atelier/test_branching.py
+++ b/tests/atelier/test_branching.py
@@ -1,0 +1,30 @@
+import atelier.branching as branching
+
+
+def test_suggest_root_branch_appends_bead_id_suffix() -> None:
+    branch = branching.suggest_root_branch(
+        "Startup deterministic",
+        "scott/",
+        bead_id="at-uuzc",
+    )
+
+    assert branch == "scott/startup-deterministic-at-uuzc"
+
+
+def test_suggest_root_branch_truncates_title_but_preserves_suffix() -> None:
+    branch = branching.suggest_root_branch(
+        "Make default epic root branches collision proof under startup assume yes mode",
+        "",
+        bead_id="at-ua3a",
+        max_len=30,
+    )
+
+    assert branch.endswith("-at-ua3a")
+    assert len(branch) <= 30
+    assert branch.startswith("make-default-epic-root")
+
+
+def test_suggest_root_branch_without_bead_id_matches_legacy_behavior() -> None:
+    branch = branching.suggest_root_branch("Hello World", "scott/")
+
+    assert branch == "scott/hello-world"

--- a/tests/atelier/test_root_branch.py
+++ b/tests/atelier/test_root_branch.py
@@ -70,3 +70,59 @@ def test_prompt_root_branch_assume_yes_fails_when_active_owner_exists() -> None:
                 repo_root=Path("/repo"),
                 assume_yes=True,
             )
+
+
+def test_prompt_root_branch_assume_yes_uses_epic_suffix_for_unique_default() -> None:
+    looked_up_branches: list[str] = []
+
+    def fake_find_epics_by_root_branch(
+        root_branch: str, *, beads_root: Path, cwd: Path
+    ) -> list[dict[str, object]]:
+        del beads_root, cwd
+        looked_up_branches.append(root_branch)
+        return []
+
+    with (
+        patch(
+            "atelier.root_branch.beads.find_epics_by_root_branch",
+            side_effect=fake_find_epics_by_root_branch,
+        ),
+        patch("atelier.root_branch.git.git_ref_exists", return_value=False),
+    ):
+        resolved = root_branch.prompt_root_branch(
+            title="Example Root Branch",
+            branch_prefix="scott/",
+            epic_id="at-uuzc",
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+            assume_yes=True,
+        )
+
+    assert resolved == "scott/example-root-branch-at-uuzc"
+    assert looked_up_branches == ["scott/example-root-branch-at-uuzc"]
+
+
+def test_prompt_root_branch_allows_interactive_reuse_when_confirmed() -> None:
+    reusable = [
+        {
+            "id": "at-closed",
+            "status": "closed",
+            "labels": ["at:epic"],
+            "title": "Closed epic",
+        }
+    ]
+    with (
+        patch("atelier.root_branch.prompt", return_value="feat/reused"),
+        patch("atelier.root_branch.beads.find_epics_by_root_branch", return_value=reusable),
+        patch("atelier.root_branch.confirm", return_value=True),
+        patch("atelier.root_branch.git.git_ref_exists", return_value=False),
+    ):
+        resolved = root_branch.prompt_root_branch(
+            title="Ignored",
+            branch_prefix="feat/",
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+            assume_yes=False,
+        )
+
+    assert resolved == "feat/reused"


### PR DESCRIPTION
# Summary

- Make auto-suggested epic root branches collision-proof by suffixing them with the epic id.

# Changes

- Updated `suggest_root_branch` to accept an optional bead id suffix and preserve that suffix when truncating long title slugs.
- Threaded epic id through worker startup root-branch resolution so default suggestions use the suffix in both dry-run logs and interactive/non-interactive prompts.
- Added regression tests for suffix generation/truncation, `--yes` default resolution, and interactive confirmation-based reuse of explicitly provided branches.

# Testing

- `pytest tests/atelier/test_branching.py tests/atelier/test_root_branch.py`
- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #389

# Risks / Rollout

- Low risk: behavior changes only when deriving default root-branch suggestions.

# Notes

- Explicitly entered root branches are still reusable when the operator confirms in interactive mode.
