### PR TITLE
Fix merged-PR integration proof replay in worker finalize

### DIFF
--- a/src/atelier/prs.py
+++ b/src/atelier/prs.py
@@ -298,7 +298,8 @@ def lookup_github_pr_status(repo: str, head: str, *, refresh: bool = False) -> G
                 repo,
                 "--json",
                 "number,url,state,baseRefName,headRefName,title,body,labels,isDraft,"
-                "mergedAt,closedAt,updatedAt,reviewDecision,mergeable,mergeStateStatus,"
+                "mergedAt,mergeCommit,closedAt,updatedAt,reviewDecision,mergeable,"
+                "mergeStateStatus,"
                 "reviewRequests,comments,reviews",
             ]
         )

--- a/tests/atelier/test_prs.py
+++ b/tests/atelier/test_prs.py
@@ -83,6 +83,20 @@ def test_lookup_github_pr_status_reports_found_payload() -> None:
     assert result.error is None
 
 
+def test_lookup_github_pr_status_requests_merge_commit_field() -> None:
+    with (
+        patch("atelier.prs._gh_available", return_value=True),
+        patch("atelier.prs._find_latest_pr_number", return_value=42),
+        patch("atelier.prs._run_json", return_value={"number": 42, "state": "OPEN"}) as run_json,
+    ):
+        result = prs.lookup_github_pr_status("org/repo", "feature/test")
+
+    assert result.outcome == "found"
+    request = run_json.call_args.args[0]
+    json_fields = request[request.index("--json") + 1]
+    assert "mergeCommit" in json_fields
+
+
 def test_lookup_github_pr_status_prefers_open_pr_over_newer_closed_pr() -> None:
     with (
         patch("atelier.prs._gh_available", return_value=True),

--- a/tests/atelier/worker/test_integration.py
+++ b/tests/atelier/worker/test_integration.py
@@ -70,6 +70,104 @@ def test_changeset_integration_signal_rejects_merged_pr_without_branch_proof() -
     assert integrated_sha is None
 
 
+def test_changeset_integration_signal_strict_mode_uses_pr_merge_commit_reachability() -> None:
+    issue = {
+        "description": (
+            "changeset.root_branch: feat/root\n"
+            "changeset.parent_branch: main\n"
+            "changeset.work_branch: feat/work\n"
+        )
+    }
+    merge_sha = "abcdef1234567890abcdef1234567890abcdef12"
+
+    def fake_branch_ref_for_lookup(
+        _repo_root: Path, branch: str, *, git_path: str | None = None
+    ) -> str | None:
+        del git_path
+        if branch == "main":
+            return "origin/main"
+        return None
+
+    def fake_is_ancestor(
+        _repo_root: Path,
+        ancestor: str,
+        descendant: str,
+        *,
+        git_path: str | None = None,
+    ) -> bool:
+        del git_path
+        return ancestor == merge_sha and descendant == "origin/main"
+
+    with (
+        patch(
+            "atelier.worker.integration.branch_ref_for_lookup",
+            side_effect=fake_branch_ref_for_lookup,
+        ),
+        patch("atelier.worker.integration.git.git_rev_parse", return_value=merge_sha),
+        patch("atelier.worker.integration.git.git_is_ancestor", side_effect=fake_is_ancestor),
+        patch("atelier.worker.integration.git.git_branch_fully_applied", return_value=False),
+        patch("atelier.worker.integration._refresh_origin_refs", return_value=False),
+    ):
+        ok, integrated_sha = integration.changeset_integration_signal(
+            issue,
+            repo_slug="org/repo",
+            repo_root=Path("/repo"),
+            lookup_pr_payload=lambda _repo, _branch: {
+                "baseRefName": "main",
+                "mergedAt": "2026-03-01T00:00:00Z",
+                "mergeCommit": {"oid": merge_sha},
+            },
+            require_target_branch_proof=True,
+        )
+
+    assert ok is True
+    assert integrated_sha == merge_sha
+
+
+def test_changeset_integration_signal_strict_mode_rejects_unreachable_pr_merge_commit() -> None:
+    issue = {
+        "description": (
+            "changeset.root_branch: feat/root\n"
+            "changeset.parent_branch: main\n"
+            "changeset.work_branch: feat/work\n"
+        )
+    }
+    merge_sha = "abcdef1234567890abcdef1234567890abcdef12"
+
+    def fake_branch_ref_for_lookup(
+        _repo_root: Path, branch: str, *, git_path: str | None = None
+    ) -> str | None:
+        del git_path
+        if branch == "main":
+            return "origin/main"
+        return None
+
+    with (
+        patch(
+            "atelier.worker.integration.branch_ref_for_lookup",
+            side_effect=fake_branch_ref_for_lookup,
+        ),
+        patch("atelier.worker.integration.git.git_rev_parse", return_value=merge_sha),
+        patch("atelier.worker.integration.git.git_is_ancestor", return_value=False),
+        patch("atelier.worker.integration.git.git_branch_fully_applied", return_value=False),
+        patch("atelier.worker.integration._refresh_origin_refs", return_value=False),
+    ):
+        ok, integrated_sha = integration.changeset_integration_signal(
+            issue,
+            repo_slug="org/repo",
+            repo_root=Path("/repo"),
+            lookup_pr_payload=lambda _repo, _branch: {
+                "baseRefName": "main",
+                "mergedAt": "2026-03-01T00:00:00Z",
+                "mergeCommit": {"oid": merge_sha},
+            },
+            require_target_branch_proof=True,
+        )
+
+    assert ok is False
+    assert integrated_sha is None
+
+
 def test_changeset_integration_signal_strict_mode_uses_origin_target_ref() -> None:
     issue = {
         "description": (


### PR DESCRIPTION
# Summary

- Fix worker integration-proof replay so merged PRs are not falsely blocked when the PR merge commit is already reachable from the target branch.

# Changes

- Added strict-mode merge-commit extraction in worker integration logic and treat merged PR merge-commit reachability as authoritative integration evidence.
- Preserved strict behavior by still rejecting merged PRs when the merge commit is not reachable from the target branch.
- Updated GitHub PR status lookup to request `mergeCommit` metadata from `gh pr view`.
- Added deterministic regression tests for merged PR replay with stale/missing source refs, unreachable merge commits, and mergeCommit field coverage.

# Testing

- `pytest tests/atelier/worker/test_integration.py tests/atelier/test_prs.py tests/atelier/worker/test_finalize_pipeline.py`
- `just test`
- `just format`
- `just lint`

# Tickets

- Fixes #393

# Risks / Rollout

- Low risk; changes are scoped to strict integration-proof decision logic and covered with targeted regressions plus full repository checks.

# Notes

- This change prefers merged PR + reachable merge commit evidence before fail-closed finalize outcomes.
