### PR TITLE
Polish epic-identity guardrail docs formatting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,7 +113,8 @@ Do not add hidden behavior or implicit defaults.
 When code writes local external state that can be touched by multiple agents or
 processes, it must be designed to avoid corruption by default.
 
-- Prefer atomic write primitives where available (for example: temp-file + fsync + atomic rename, atomic ref updates, or compare-and-swap style updates).
+- Prefer atomic write primitives where available (for example: temp-file + fsync
+  \+ atomic rename, atomic ref updates, or compare-and-swap style updates).
 - If atomic writes are not available, require explicit read-after-write
   verification and bounded retries before reporting success.
 - Make write operations idempotent where practical so retries do not duplicate

--- a/docs/dogfood.md
+++ b/docs/dogfood.md
@@ -35,9 +35,8 @@ source of truth and that changesets remain reviewable.
 
 ## Self-Updating Worker Supervisor
 
-For Atelier-on-Atelier development, use
-`scripts/atelier-work.py` to run one-shot worker cycles while
-refreshing the local checkout between cycles.
+For Atelier-on-Atelier development, use `scripts/atelier-work.py` to run
+one-shot worker cycles while refreshing the local checkout between cycles.
 
 Example:
 
@@ -50,7 +49,8 @@ scripts/atelier-work.py \
 
 Defaults:
 
-- install runs after update (`just install`); use `--install COMMAND` to override or `--no-install` to skip
+- install runs after update (`just install`); use `--install COMMAND` to
+  override or `--no-install` to skip
 - update policy is fast-forward-only (`--update-policy ff-only`)
 - worker command runs once (`atelier work --run-mode once`)
 - dry-run mode (`--dry-run`) prints planned update/install/worker actions


### PR DESCRIPTION
# Summary

- Keep planner guardrail documentation readable and policy-compliant by applying canonical 80-column markdown wrapping.

# Changes

- Wrapped long prose lines in `AGENTS.md` without changing policy meaning.
- Wrapped long prose lines in `docs/dogfood.md` without changing workflow behavior.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets
- Addresses #362

# Risks / Rollout

- Low risk: documentation-only formatting updates.
