### PR TITLE
Harden worker startup against transient Beads read failures in global review scan

### DIFF
--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -2749,6 +2749,53 @@ def run_bd_json(args: list[str], *, beads_root: Path, cwd: Path) -> list[dict[st
     return []
 
 
+def run_bd_json_read_only(
+    args: list[str], *, beads_root: Path, cwd: Path
+) -> tuple[list[dict[str, object]], str | None]:
+    """Run a read-only bd JSON query without exiting on command failure.
+
+    Args:
+        args: `bd` arguments without the leading binary name.
+        beads_root: Root directory for the Beads store.
+        cwd: Working directory for the command.
+
+    Returns:
+        Tuple containing parsed payload and optional failure detail. Failures
+        include the exact command, exit code, and stderr/stdout detail when
+        present.
+    """
+    cmd = list(args)
+    if "--json" not in cmd:
+        cmd.append("--json")
+    command_text = " ".join(["bd", *cmd])
+    result = run_bd_command(cmd, beads_root=beads_root, cwd=cwd, allow_failure=True)
+    if result.returncode != 0:
+        detail_parts: list[str] = []
+        stderr_text = result.stderr.strip() if result.stderr else ""
+        stdout_text = result.stdout.strip() if result.stdout else ""
+        if stderr_text:
+            detail_parts.append(f"stderr: {stderr_text}")
+        if stdout_text:
+            detail_parts.append(f"stdout: {stdout_text}")
+        detail = "\n".join(detail_parts)
+        message = f"command failed: {command_text} (exit {result.returncode})"
+        if detail:
+            message = f"{message}\n{detail}"
+        return [], message
+    raw = result.stdout.strip() if result.stdout else ""
+    if not raw:
+        return [], None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return [], f"command failed: {command_text}\nfailed to parse bd json output: {exc}"
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)], None
+    if isinstance(payload, dict):
+        return [payload], None
+    return [], None
+
+
 def parse_issue_records(issues: list[dict[str, object]], *, source: str) -> list[BeadsIssueRecord]:
     """Validate Beads issue payloads while preserving raw issue mappings."""
     records: list[BeadsIssueRecord] = []

--- a/src/atelier/worker/review.py
+++ b/src/atelier/worker/review.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .. import beads, changeset_fields, lifecycle, prs
+from .. import log as atelier_log
 from .models_boundary import BeadsIssueBoundary
 
 
@@ -24,6 +25,10 @@ class MergeConflictSelection:
     changeset_id: str
     observed_at: str | None
     pr_url: str | None
+
+
+_GLOBAL_SCAN_ACTIVE_STATUSES = frozenset({"open", "in_progress", "blocked"})
+_GLOBAL_SCAN_QUERY_MAX_ATTEMPTS = 3
 
 
 def _feedback_cursor(issue: dict[str, object]):
@@ -141,6 +146,193 @@ def _records_for_epic_changesets(
     return client, records
 
 
+def _emit_global_scan_diagnostic(
+    message: str,
+    *,
+    emit_diagnostic: Callable[[str], None] | None,
+) -> None:
+    atelier_log.warning(message)
+    if emit_diagnostic is not None:
+        emit_diagnostic(message)
+
+
+def _read_query_with_retry(
+    *,
+    args: list[str],
+    beads_root: Path,
+    repo_root: Path,
+    startup_stage: str,
+    subject: str,
+    emit_diagnostic: Callable[[str], None] | None,
+) -> list[dict[str, object]] | None:
+    """Run a read-only Beads query with bounded retries.
+
+    Command and stdout/stderr detail come from
+    :func:`beads.run_bd_json_read_only`.
+    """
+    last_error: str | None = None
+    for attempt in range(1, _GLOBAL_SCAN_QUERY_MAX_ATTEMPTS + 1):
+        payload, error = beads.run_bd_json_read_only(
+            args,
+            beads_root=beads_root,
+            cwd=repo_root,
+        )
+        if error is None:
+            return payload
+        last_error = error
+        if attempt < _GLOBAL_SCAN_QUERY_MAX_ATTEMPTS:
+            atelier_log.warning(
+                "startup stage="
+                f"{startup_stage} retry={attempt}/{_GLOBAL_SCAN_QUERY_MAX_ATTEMPTS} "
+                f"subject={subject}"
+            )
+    detail = last_error or "unknown read failure"
+    _emit_global_scan_diagnostic(
+        (
+            f"Startup stage {startup_stage}: skipping {subject} after "
+            f"{_GLOBAL_SCAN_QUERY_MAX_ATTEMPTS} failed read-only Beads attempts.\n"
+            f"{detail}"
+        ),
+        emit_diagnostic=emit_diagnostic,
+    )
+    return None
+
+
+def _list_work_children_read_only(
+    *,
+    parent_id: str,
+    beads_root: Path,
+    repo_root: Path,
+    startup_stage: str,
+    emit_diagnostic: Callable[[str], None] | None,
+) -> list[dict[str, object]] | None:
+    raw = _read_query_with_retry(
+        args=["list", "--parent", parent_id],
+        beads_root=beads_root,
+        repo_root=repo_root,
+        startup_stage=startup_stage,
+        subject=f"candidate family {parent_id}",
+        emit_diagnostic=emit_diagnostic,
+    )
+    if raw is None:
+        return None
+    return [
+        issue
+        for issue in raw
+        if isinstance(issue, dict)
+        and lifecycle.is_work_issue(
+            labels=lifecycle.normalized_labels(issue.get("labels")),
+            issue_type=lifecycle.issue_payload_type(issue),
+        )
+    ]
+
+
+def _list_descendant_changesets_read_only(
+    *,
+    epic_id: str,
+    beads_root: Path,
+    repo_root: Path,
+    startup_stage: str,
+    emit_diagnostic: Callable[[str], None] | None,
+) -> tuple[list[dict[str, object]], bool] | None:
+    descendants: list[dict[str, object]] = []
+    seen: set[str] = set()
+    queue = [epic_id]
+    has_root_work_children = False
+    while queue:
+        current = queue.pop(0)
+        work_children = _list_work_children_read_only(
+            parent_id=current,
+            beads_root=beads_root,
+            repo_root=repo_root,
+            startup_stage=startup_stage,
+            emit_diagnostic=emit_diagnostic,
+        )
+        if work_children is None:
+            return None
+        if current == epic_id:
+            has_root_work_children = bool(work_children)
+        for issue in work_children:
+            issue_id = issue.get("id")
+            if not isinstance(issue_id, str) or not issue_id.strip():
+                continue
+            normalized_issue_id = issue_id.strip()
+            if normalized_issue_id in seen:
+                continue
+            seen.add(normalized_issue_id)
+            grandchild_work = _list_work_children_read_only(
+                parent_id=normalized_issue_id,
+                beads_root=beads_root,
+                repo_root=repo_root,
+                startup_stage=startup_stage,
+                emit_diagnostic=emit_diagnostic,
+            )
+            if grandchild_work is None:
+                return None
+            if not grandchild_work:
+                descendants.append(issue)
+            queue.append(normalized_issue_id)
+    return descendants, has_root_work_children
+
+
+def _global_changeset_records(
+    *,
+    beads_root: Path,
+    repo_root: Path,
+    startup_stage: str,
+    emit_diagnostic: Callable[[str], None] | None,
+) -> tuple[list[beads.BeadsIssueRecord], dict[str, str]]:
+    epics = _read_query_with_retry(
+        args=["list", "--label", "at:epic", "--all", "--limit", "0"],
+        beads_root=beads_root,
+        repo_root=repo_root,
+        startup_stage=startup_stage,
+        subject="active epic index",
+        emit_diagnostic=emit_diagnostic,
+    )
+    if epics is None:
+        return [], {}
+    active_epics = [
+        issue
+        for issue in epics
+        if lifecycle.canonical_lifecycle_status(issue.get("status")) in _GLOBAL_SCAN_ACTIVE_STATUSES
+    ]
+    records: list[beads.BeadsIssueRecord] = []
+    epic_by_changeset: dict[str, str] = {}
+    for epic in active_epics:
+        epic_id = str(epic.get("id") or "").strip()
+        if not epic_id:
+            continue
+        descendants_result = _list_descendant_changesets_read_only(
+            epic_id=epic_id,
+            beads_root=beads_root,
+            repo_root=repo_root,
+            startup_stage=startup_stage,
+            emit_diagnostic=emit_diagnostic,
+        )
+        if descendants_result is None:
+            continue
+        descendants, has_root_work_children = descendants_result
+        if descendants:
+            descendant_records = beads.parse_issue_records(
+                descendants,
+                source=f"{startup_stage}:descendants:{epic_id}",
+            )
+            for record in descendant_records:
+                records.append(record)
+                epic_by_changeset.setdefault(record.issue.id, epic_id)
+            continue
+        if has_root_work_children:
+            continue
+        epic_record = beads.parse_issue_records(
+            [epic],
+            source=f"{startup_stage}:standalone_epic:{epic_id}",
+        )[0]
+        records.append(epic_record)
+        epic_by_changeset.setdefault(epic_record.issue.id, epic_id)
+    return records, epic_by_changeset
+
+
 def _conflict_selection_candidates(
     *,
     records: list[beads.BeadsIssueRecord],
@@ -234,27 +426,23 @@ def select_global_review_feedback_changeset(
     beads_root: Path,
     repo_root: Path,
     resolve_epic_id_for_changeset: Callable[[dict[str, object]], str | None],
+    emit_diagnostic: Callable[[str], None] | None = None,
 ) -> ReviewFeedbackSelection | None:
     """Select the oldest unresolved review-feedback candidate globally."""
     if not repo_slug:
         return None
-    client = beads.create_client(beads_root=beads_root, cwd=repo_root)
-    changesets = beads.list_all_changesets(
+    del resolve_epic_id_for_changeset
+    records, epic_by_changeset = _global_changeset_records(
         beads_root=beads_root,
-        cwd=repo_root,
-        include_closed=False,
-    )
-    records = beads.parse_issue_records(
-        changesets,
-        source="select_global_review_feedback_changeset:list_changesets",
+        repo_root=repo_root,
+        startup_stage="global-review-feedback",
+        emit_diagnostic=emit_diagnostic,
     )
     candidates = _selection_candidates(
         records=records,
-        load_record=lambda issue_id: client.show_issue(
-            issue_id, source="select_global_review_feedback_changeset:show"
-        ),
+        load_record=lambda _issue_id: None,
         repo_slug=repo_slug,
-        resolve_epic_id=resolve_epic_id_for_changeset,
+        resolve_epic_id=lambda issue: epic_by_changeset.get(str(issue.get("id") or "").strip()),
     )
     return candidates[0] if candidates else None
 
@@ -292,26 +480,22 @@ def select_global_conflicted_changeset(
     beads_root: Path,
     repo_root: Path,
     resolve_epic_id_for_changeset: Callable[[dict[str, object]], str | None],
+    emit_diagnostic: Callable[[str], None] | None = None,
 ) -> MergeConflictSelection | None:
     """Select the oldest merge-conflicted changeset globally."""
     if not repo_slug:
         return None
-    client = beads.create_client(beads_root=beads_root, cwd=repo_root)
-    changesets = beads.list_all_changesets(
+    del resolve_epic_id_for_changeset
+    records, epic_by_changeset = _global_changeset_records(
         beads_root=beads_root,
-        cwd=repo_root,
-        include_closed=False,
-    )
-    records = beads.parse_issue_records(
-        changesets,
-        source="select_global_conflicted_changeset:list_changesets",
+        repo_root=repo_root,
+        startup_stage="global-merge-conflict",
+        emit_diagnostic=emit_diagnostic,
     )
     candidates = _conflict_selection_candidates(
         records=records,
-        load_record=lambda issue_id: client.show_issue(
-            issue_id, source="select_global_conflicted_changeset:show"
-        ),
+        load_record=lambda _issue_id: None,
         repo_slug=repo_slug,
-        resolve_epic_id=resolve_epic_id_for_changeset,
+        resolve_epic_id=lambda issue: epic_by_changeset.get(str(issue.get("id") or "").strip()),
     )
     return candidates[0] if candidates else None

--- a/src/atelier/worker/work_startup_runtime.py
+++ b/src/atelier/worker/work_startup_runtime.py
@@ -381,6 +381,7 @@ def select_global_review_feedback_changeset(
         repo_slug=repo_slug,
         beads_root=beads_root,
         repo_root=repo_root,
+        emit_diagnostic=say,
         resolve_epic_id_for_changeset=(
             lambda issue: (
                 resolve_epic_id_for_changeset(issue, beads_root=beads_root, repo_root=repo_root)
@@ -411,6 +412,7 @@ def select_global_conflicted_changeset(
         repo_slug=repo_slug,
         beads_root=beads_root,
         repo_root=repo_root,
+        emit_diagnostic=say,
         resolve_epic_id_for_changeset=(
             lambda issue: (
                 resolve_epic_id_for_changeset(issue, beads_root=beads_root, repo_root=repo_root)

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -325,6 +325,49 @@ def test_run_bd_json_retries_embedded_backend_panic_with_explicit_db(
     ]
 
 
+def test_run_bd_json_read_only_returns_payload_without_error() -> None:
+    with patch(
+        "atelier.beads.run_bd_command",
+        return_value=CompletedProcess(
+            args=["bd", "show", "at-1", "--json"],
+            returncode=0,
+            stdout='[{"id":"at-1","status":"open","labels":[]}]',
+            stderr="",
+        ),
+    ):
+        payload, error = beads.run_bd_json_read_only(
+            ["show", "at-1"],
+            beads_root=Path("/beads"),
+            cwd=Path("/repo"),
+        )
+
+    assert payload == [{"id": "at-1", "status": "open", "labels": []}]
+    assert error is None
+
+
+def test_run_bd_json_read_only_includes_command_and_stream_details_on_failure() -> None:
+    with patch(
+        "atelier.beads.run_bd_command",
+        return_value=CompletedProcess(
+            args=["bd", "list", "--parent", "at-1", "--json"],
+            returncode=1,
+            stdout="db timeout",
+            stderr="TLS timeout",
+        ),
+    ):
+        payload, error = beads.run_bd_json_read_only(
+            ["list", "--parent", "at-1"],
+            beads_root=Path("/beads"),
+            cwd=Path("/repo"),
+        )
+
+    assert payload == []
+    assert error is not None
+    assert "command failed: bd list --parent at-1 --json (exit 1)" in error
+    assert "stderr: TLS timeout" in error
+    assert "stdout: db timeout" in error
+
+
 def test_run_bd_json_attempts_doctor_fix_after_repeated_embedded_panic(
     tmp_path: Path,
 ) -> None:

--- a/tests/atelier/worker/test_review.py
+++ b/tests/atelier/worker/test_review.py
@@ -209,28 +209,55 @@ def test_select_review_feedback_changeset_pr_160_closed_then_reopened_sequence()
     assert reopened_selection.changeset_id == "at-1.60"
 
 
-def test_select_global_review_feedback_changeset_uses_resolver() -> None:
-    issues = [
-        {
-            "id": "at-2.1",
-            "labels": [],
-            "status": "in_progress",
-            "description": "changeset.work_branch: feat/c\npr_state: in-review\n",
-        }
-    ]
-    issue_records = beads.parse_issue_records(
-        issues, source="test_select_global_review_feedback_changeset_uses_resolver"
-    )
-    record_by_id = {record.issue.id: record for record in issue_records}
+def test_select_global_review_feedback_changeset_retries_and_skips_failed_family() -> None:
+    attempts: dict[tuple[str, ...], int] = {}
 
+    def fake_read_query(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> tuple[list[dict[str, object]], str | None]:
+        del beads_root, cwd
+        key = tuple(args)
+        attempts[key] = attempts.get(key, 0) + 1
+        if key == ("list", "--label", "at:epic", "--all", "--limit", "0"):
+            return (
+                [
+                    {"id": "at-1", "labels": ["at:epic"], "status": "open"},
+                    {"id": "at-2", "labels": ["at:epic"], "status": "in_progress"},
+                    {"id": "at-3", "labels": ["at:epic"], "status": "deferred"},
+                ],
+                None,
+            )
+        if key == ("list", "--parent", "at-1"):
+            return (
+                [
+                    {
+                        "id": "at-1.1",
+                        "labels": [],
+                        "parent_id": "at-1",
+                        "issue_type": "task",
+                        "status": "in_progress",
+                        "description": "changeset.work_branch: feat/a\npr_state: in-review\n",
+                    }
+                ],
+                None,
+            )
+        if key == ("list", "--parent", "at-1.1"):
+            return ([], None)
+        if key == ("list", "--parent", "at-2"):
+            return (
+                [],
+                ("command failed: bd list --parent at-2 --json (exit 1)\nstderr: TLS timeout"),
+            )
+        raise AssertionError(f"unexpected query: {args}")
+
+    emitted: list[str] = []
     with (
         patch(
-            "atelier.worker.review.beads.list_all_changesets",
-            return_value=issues,
-        ),
-        patch(
-            "atelier.worker.review.beads.BeadsClient.show_issue",
-            side_effect=lambda issue_id, *, source: record_by_id.get(issue_id),
+            "atelier.worker.review.beads.run_bd_json_read_only",
+            side_effect=fake_read_query,
         ),
         patch(
             "atelier.worker.review.prs.lookup_github_pr_status",
@@ -249,21 +276,27 @@ def test_select_global_review_feedback_changeset_uses_resolver() -> None:
             "atelier.worker.review.prs.latest_feedback_timestamp_with_inline_comments",
             return_value="2026-02-20T12:00:00Z",
         ),
-        patch(
-            "atelier.worker.review.prs.unresolved_review_thread_count",
-            return_value=1,
-        ),
+        patch("atelier.worker.review.prs.unresolved_review_thread_count", return_value=1),
     ):
         selection = review.select_global_review_feedback_changeset(
             repo_slug="org/repo",
             beads_root=Path("/beads"),
             repo_root=Path("/repo"),
-            resolve_epic_id_for_changeset=lambda issue: "at-2",
+            resolve_epic_id_for_changeset=lambda _issue: (_ for _ in ()).throw(
+                AssertionError("resolver should not be called during active global scan")
+            ),
+            emit_diagnostic=emitted.append,
         )
 
     assert selection is not None
-    assert selection.epic_id == "at-2"
-    assert selection.changeset_id == "at-2.1"
+    assert selection.epic_id == "at-1"
+    assert selection.changeset_id == "at-1.1"
+    assert attempts[("list", "--parent", "at-2")] == 3
+    assert ("list", "--parent", "at-3") not in attempts
+    assert len(emitted) == 1
+    assert "Startup stage global-review-feedback" in emitted[0]
+    assert "bd list --parent at-2 --json" in emitted[0]
+    assert "stderr: TLS timeout" in emitted[0]
 
 
 def test_select_review_feedback_changeset_invalid_issue_payload_fails() -> None:
@@ -445,6 +478,77 @@ def test_select_conflicted_changeset_includes_standalone_epic_changeset() -> Non
     assert selection.epic_id == "at-standalone"
     assert selection.changeset_id == "at-standalone"
     assert selection.pr_url == "https://github.com/org/repo/pull/44"
+
+
+def test_select_global_conflicted_changeset_uses_active_epic_scan() -> None:
+    attempts: dict[tuple[str, ...], int] = {}
+
+    def fake_read_query(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> tuple[list[dict[str, object]], str | None]:
+        del beads_root, cwd
+        key = tuple(args)
+        attempts[key] = attempts.get(key, 0) + 1
+        if key == ("list", "--label", "at:epic", "--all", "--limit", "0"):
+            return (
+                [
+                    {"id": "at-1", "labels": ["at:epic"], "status": "open"},
+                    {"id": "at-2", "labels": ["at:epic"], "status": "deferred"},
+                ],
+                None,
+            )
+        if key == ("list", "--parent", "at-1"):
+            return (
+                [
+                    {
+                        "id": "at-1.1",
+                        "labels": [],
+                        "parent_id": "at-1",
+                        "issue_type": "task",
+                        "status": "in_progress",
+                        "updated_at": "2026-02-20T10:00:00Z",
+                        "description": "changeset.work_branch: feat/a\npr_state: in-review\n",
+                    }
+                ],
+                None,
+            )
+        if key == ("list", "--parent", "at-1.1"):
+            return ([], None)
+        raise AssertionError(f"unexpected query: {args}")
+
+    with (
+        patch(
+            "atelier.worker.review.beads.run_bd_json_read_only",
+            side_effect=fake_read_query,
+        ),
+        patch(
+            "atelier.worker.review.prs.read_github_pr_status",
+            return_value={
+                "state": "OPEN",
+                "isDraft": False,
+                "url": "https://github.com/org/repo/pull/44",
+                "updatedAt": "2026-02-20T10:00:00Z",
+                "mergeStateStatus": "DIRTY",
+            },
+        ),
+    ):
+        selection = review.select_global_conflicted_changeset(
+            repo_slug="org/repo",
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+            resolve_epic_id_for_changeset=lambda _issue: (_ for _ in ()).throw(
+                AssertionError("resolver should not be called during active global scan")
+            ),
+        )
+
+    assert selection is not None
+    assert selection.epic_id == "at-1"
+    assert selection.changeset_id == "at-1.1"
+    assert selection.pr_url == "https://github.com/org/repo/pull/44"
+    assert ("list", "--parent", "at-2") not in attempts
 
 
 def test_select_conflicted_changeset_skips_unknown_mergeability() -> None:


### PR DESCRIPTION
# Summary

- Harden worker startup global review scans so a transient read-only Beads query does not terminate startup.
- Limit global review and conflict scans to active epics (`open`, `in_progress`, `blocked`) so deferred trees are not traversed.

# Changes

- Added `beads.run_bd_json_read_only(...)` for non-fatal read-only JSON queries that return structured command + stdout/stderr failure detail.
- Reworked global scan paths in `atelier.worker.review` to:
  - traverse active epic families directly,
  - retry read-only Beads queries with bounded attempts,
  - skip only failed candidate families after retries,
  - emit startup-stage diagnostics that include failing command/detail.
- Wired startup runtime global-scan calls to surface diagnostics through worker output.
- Added regression tests for retry/skip behavior, deferred-epic exclusion, and global conflict scan active-epic traversal.
- Added tests for the new Beads read-only helper failure/success behavior.

# Testing

- `pytest -q tests/atelier/worker/test_review.py tests/atelier/test_beads.py`
- `just test`
- `just format`
- `just lint`

## Tickets

- Fixes #401

# Risks / Rollout

- Startup now degrades per-family on transient read errors during global scans; payload-validation and integrity errors remain fail-closed.

# Notes

- No lifecycle-policy broadening was introduced beyond read-retry/skip handling in global scan paths.
