### PR TITLE
Deduplicate stale NEEDS-DECISION queue notifications

### DIFF
--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -5618,7 +5618,11 @@ def _closed_active_pr_condition_still_blocking(
     if not thread_id:
         return True
     if thread_id not in thread_issue_cache:
-        thread_issues = run_bd_json(["show", thread_id], beads_root=beads_root, cwd=cwd)
+        thread_issues, _error = run_bd_json_read_only(
+            ["show", thread_id],
+            beads_root=beads_root,
+            cwd=cwd,
+        )
         thread_issue_cache[thread_id] = thread_issues[0] if thread_issues else None
     thread_issue = thread_issue_cache.get(thread_id)
     if not isinstance(thread_issue, dict):

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -3981,12 +3981,11 @@ def test_list_queue_messages_auto_resolves_stale_closed_active_pr_lifecycle() ->
         del beads_root, cwd
         if args[:1] == ["list"]:
             return [queue_issue]
-        if args[:2] == ["show", "at-epic.1"]:
-            return [thread_issue]
         return []
 
     with (
         patch("atelier.beads.run_bd_json", side_effect=fake_run_json),
+        patch("atelier.beads.run_bd_json_read_only", return_value=([thread_issue], None)),
         patch("atelier.beads.run_bd_command") as run_command,
     ):
         queued = beads.list_queue_messages(beads_root=Path("/beads"), cwd=Path("/repo"))
@@ -4030,12 +4029,11 @@ def test_list_queue_messages_keeps_latest_active_closed_pr_lifecycle_notificatio
         del beads_root, cwd
         if args[:1] == ["list"]:
             return [older, newer]
-        if args[:2] == ["show", "at-epic.1"]:
-            return [thread_issue]
         return []
 
     with (
         patch("atelier.beads.run_bd_json", side_effect=fake_run_json),
+        patch("atelier.beads.run_bd_json_read_only", return_value=([thread_issue], None)),
         patch("atelier.beads.run_bd_command") as run_command,
     ):
         queued = beads.list_queue_messages(beads_root=Path("/beads"), cwd=Path("/repo"))
@@ -4047,6 +4045,40 @@ def test_list_queue_messages_keeps_latest_active_closed_pr_lifecycle_notificatio
         cwd=Path("/repo"),
         allow_failure=True,
     )
+
+
+def test_list_queue_messages_tolerates_missing_thread_issue() -> None:
+    queue_issue = {
+        "id": "msg-closed-active",
+        "title": "NEEDS-DECISION: Closed changeset has active PR lifecycle (at-epic.1)",
+        "created_at": "2026-03-02T02:00:00Z",
+        "description": "---\nqueue: planner\nthread: at-epic.1\n---\n\nBody\n",
+        "assignee": None,
+    }
+
+    def fake_run_json(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> list[dict[str, object]]:
+        del beads_root, cwd
+        if args[:1] == ["list"]:
+            return [queue_issue]
+        return []
+
+    with (
+        patch("atelier.beads.run_bd_json", side_effect=fake_run_json),
+        patch(
+            "atelier.beads.run_bd_json_read_only",
+            return_value=([], "command failed: bd show at-epic.1 --json (exit 1)"),
+        ),
+        patch("atelier.beads.run_bd_command") as run_command,
+    ):
+        queued = beads.list_queue_messages(beads_root=Path("/beads"), cwd=Path("/repo"))
+
+    assert [item["id"] for item in queued] == ["msg-closed-active"]
+    run_command.assert_not_called()
 
 
 def test_mark_message_read_updates_labels() -> None:


### PR DESCRIPTION
# Summary

Collapse duplicate `NEEDS-DECISION` queue noise and auto-resolve stale notifications once the underlying changeset state has already been reconciled.

# Changes

- Deduplicate queue messages by `thread + reason` for unread `NEEDS-DECISION` notifications and keep only the latest actionable message.
- Auto-mark superseded duplicate queue messages as read so startup triage does not repeatedly surface the same condition.
- Suppress and auto-resolve stale `Closed changeset has active PR lifecycle` notifications when the referenced changeset is no longer in that state.
- Add regression tests for duplicate collapse, repeated closed+active lifecycle notifications, and post-reconciliation cleanup.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets

- Fixes #379

# Risks / Rollout

- Low risk: behavior is scoped to queue message listing and stale unread cleanup for specific `NEEDS-DECISION` conditions.

# Notes

- Deduplication is applied without changing planner orchestration flows.
