### PR TITLE
Prevent cross-project Dolt database collisions on shared endpoints

### DIFF
--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -636,6 +636,55 @@ def _local_dolt_database_candidates(beads_root: Path) -> tuple[str, ...]:
     return tuple(sorted(candidates))
 
 
+def _project_config_payload(project_dir: Path) -> dict[str, object] | None:
+    for config_path in (
+        paths.project_config_sys_path(project_dir),
+        paths.project_config_legacy_path(project_dir),
+    ):
+        payload = config.load_json(config_path)
+        if isinstance(payload, dict):
+            return payload
+    return None
+
+
+def _prefix_collision_owner(beads_root: Path, *, prefix: str) -> Path | None:
+    current_project_dir = beads_root.parent.resolve()
+    project_dirs_root = paths.projects_root()
+    if current_project_dir.parent != project_dirs_root.resolve():
+        return None
+    owners: set[Path] = {current_project_dir}
+    if not project_dirs_root.exists():
+        return None
+    for candidate in sorted(project_dirs_root.iterdir()):
+        if not candidate.is_dir():
+            continue
+        payload = _project_config_payload(candidate)
+        if payload is None:
+            continue
+        if config.resolve_beads_prefix(payload) != prefix:
+            continue
+        owners.add(candidate.resolve())
+    if len(owners) <= 1:
+        return None
+    return sorted(owners, key=str)[0]
+
+
+def _prefix_collision_ownership_error(beads_root: Path) -> str | None:
+    prefix = configured_issue_prefix(beads_root=beads_root)
+    owner = _prefix_collision_owner(beads_root, prefix=prefix)
+    if owner is None:
+        return None
+    current_project_dir = beads_root.parent.resolve()
+    if owner == current_project_dir:
+        return None
+    return (
+        "dolt server ownership mismatch: beads.prefix collision for "
+        f"{prefix!r}. Prefix is already claimed by {owner}; current project is "
+        f"{current_project_dir}. Configure a unique prefix with "
+        "`atelier config --prompt` and rerun."
+    )
+
+
 def _ambiguous_dolt_database_detail(
     *,
     beads_root: Path,
@@ -2147,8 +2196,10 @@ def _resolve_dolt_server_runtime(beads_root: Path) -> DoltServerRuntime:
     expected_database = _default_dolt_database_name(beads_root)
     local_candidates = _local_dolt_database_candidates(beads_root)
     configured_database = _normalize_dolt_database_name(payload.get("dolt_database"))
-    ownership_error: str | None = None
-    if local_candidates and expected_database not in local_candidates:
+    ownership_error = _prefix_collision_ownership_error(beads_root)
+    if ownership_error is not None:
+        pass
+    elif local_candidates and expected_database not in local_candidates:
         choices = ", ".join(local_candidates)
         remediation = _dolt_database_remediation(expected_database=expected_database)
         ownership_error = (

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -1192,13 +1192,24 @@ def test_run_bd_command_covers_dolt_lifecycle_paths_across_projects(
     assert restart_calls == [recovering_beads_root, failing_beads_root]
 
 
-def test_run_bd_command_accepts_shared_endpoint_with_prefix_database(
+def test_run_bd_command_fails_closed_when_prefix_claimed_by_other_project(
     tmp_path: Path,
 ) -> None:
-    project_a_beads = tmp_path / "project-a" / ".beads"
-    project_b_beads = tmp_path / "project-b" / ".beads"
+    projects_root = tmp_path / "projects"
+    project_a = projects_root / "project-a"
+    project_b = projects_root / "project-b"
+    project_a_beads = project_a / ".beads"
+    project_b_beads = project_b / ".beads"
     for beads_root in (project_a_beads, project_b_beads):
         (beads_root / "dolt").mkdir(parents=True)
+    (project_a / "config.sys.json").write_text(
+        json.dumps({"beads": {"prefix": "at"}}),
+        encoding="utf-8",
+    )
+    (project_b / "config.sys.json").write_text(
+        json.dumps({"beads": {"prefix": "at"}}),
+        encoding="utf-8",
+    )
     repo_a = tmp_path / "repo-a"
     repo_b = tmp_path / "repo-b"
     repo_a.mkdir()
@@ -1236,25 +1247,30 @@ def test_run_bd_command_accepts_shared_endpoint_with_prefix_database(
                 stdout="[]",
                 stderr="",
             )
-        if argv == ["bd", "list", "--json"] and request.cwd == repo_b:
-            return exec_util.CommandResult(
-                argv=request.argv,
-                returncode=0,
-                stdout="[]",
-                stderr="",
-            )
         raise AssertionError(f"unexpected command: cwd={request.cwd} argv={argv}")
+
+    def fake_die(message: str, code: int = 1) -> None:
+        del code
+        raise RuntimeError(message)
 
     with (
         patch("atelier.beads.bd_invocation.ensure_supported_bd_version"),
         patch("atelier.beads.exec.run_with_runner", side_effect=fake_run_with_runner),
+        patch("atelier.beads.paths.projects_root", return_value=projects_root),
+        patch("atelier.beads._startup_state_diagnostics", return_value="startup-diag"),
+        patch("atelier.beads.die", side_effect=fake_die),
     ):
         result_a = beads.run_bd_command(["list", "--json"], beads_root=project_a_beads, cwd=repo_a)
-        result_b = beads.run_bd_command(["list", "--json"], beads_root=project_b_beads, cwd=repo_b)
+        with pytest.raises(RuntimeError) as excinfo:
+            beads.run_bd_command(["list", "--json"], beads_root=project_b_beads, cwd=repo_b)
 
     assert result_a.returncode == 0
-    assert result_b.returncode == 0
     assert expected_a == expected_b == "beads_at"
+    message = str(excinfo.value)
+    assert "dolt server preflight failed before running bd command" in message
+    assert "beads.prefix collision for 'at'" in message
+    assert "claimed by" in message
+    assert (repo_b, ["bd", "list", "--json"]) not in calls
 
 
 def test_run_bd_command_rejects_changeset_in_progress_with_open_dependencies(


### PR DESCRIPTION
# Summary

- Prevent cross-project Beads mutations when multiple projects share the same Dolt server endpoint by enforcing a deterministic project-scoped runtime database.

# Changes

- Switched default Dolt runtime database naming to `beads_<prefix>_<project-hash>` so projects with the same prefix on a shared endpoint do not collide.
- Updated runtime metadata normalization to converge `dolt_database` to the project-scoped expected database and rerun normalization after issue-prefix updates.
- Enforced fail-closed ownership checks when metadata or active runtime database diverges from the project-scoped expected database.
- Added explicit remediation guidance in mismatch diagnostics for both runtime health checks and startup reconciliation paths.
- Expanded regression coverage for shared-endpoint multi-project isolation and prefix-change metadata reconciliation.

# Testing

- `just format`
- `just lint`
- `just test`

# Tickets

- Fixes #421

# Risks / Rollout

- Projects with stale or cross-project `dolt_database` metadata now fail closed until metadata/server database are reconciled to the expected project-scoped database.

# Notes

- Existing local Dolt database directories are not auto-migrated; ownership follows the deterministic project-scoped database contract.
