### PR TITLE
Fix Claude SessionStart startup hook path resolution

### DIFF
--- a/src/atelier/agent_home.py
+++ b/src/atelier/agent_home.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import threading
@@ -612,6 +613,7 @@ done
         if not hook_path.exists() or hook_path.read_text(encoding="utf-8") != hook_body:
             write_text_atomic(hook_path, hook_body, mode=0o755)
 
+        hook_command = shlex.quote(str(hook_path))
         settings_path = claude_dir / CLAUDE_SETTINGS_FILENAME
         settings_payload = {
             "hooks": {
@@ -621,8 +623,7 @@ done
                         "hooks": [
                             {
                                 "type": "command",
-                                "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/"
-                                "append_agentsmd_context.sh",
+                                "command": hook_command,
                             }
                         ],
                     }

--- a/tests/atelier/test_agent_home.py
+++ b/tests/atelier/test_agent_home.py
@@ -1,5 +1,7 @@
 import json
 import os
+import shlex
+import subprocess
 import tempfile
 import threading
 import time
@@ -249,6 +251,80 @@ def test_ensure_claude_compat_writes_files() -> None:
 
         settings_path = agent_path / agent_home.CLAUDE_DIRNAME / agent_home.CLAUDE_SETTINGS_FILENAME
         assert settings_path.exists()
+        payload = json.loads(settings_path.read_text(encoding="utf-8"))
+        command = payload["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        assert command == shlex.quote(str(hook_path))
+
+
+def test_ensure_claude_compat_session_start_command_uses_agent_home_hook() -> None:
+    with tempfile.TemporaryDirectory(prefix="agent home ") as tmp:
+        root = Path(tmp)
+        agent_path = root / "agent home" / "worker"
+        agent_path.mkdir(parents=True)
+        project_dir = root / "project"
+        project_dir.mkdir(parents=True)
+        (project_dir / "AGENTS.md").write_text("# Project instructions\n", encoding="utf-8")
+        content = "# Agent Instructions\nRule: test\n"
+
+        agent_home.ensure_claude_compat(agent_path, content)
+
+        assert not (project_dir / ".claude" / "hooks" / agent_home.CLAUDE_HOOK_SCRIPT).exists()
+        hook_path = (
+            agent_path
+            / agent_home.CLAUDE_DIRNAME
+            / agent_home.CLAUDE_HOOKS_DIRNAME
+            / agent_home.CLAUDE_HOOK_SCRIPT
+        )
+        settings_path = agent_path / agent_home.CLAUDE_DIRNAME / agent_home.CLAUDE_SETTINGS_FILENAME
+        payload = json.loads(settings_path.read_text(encoding="utf-8"))
+        command = payload["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+
+        result = subprocess.run(
+            ["/bin/bash", "-lc", command],
+            cwd=project_dir,
+            env={**os.environ, "CLAUDE_PROJECT_DIR": str(project_dir)},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0
+        assert command == shlex.quote(str(hook_path))
+
+
+def test_ensure_claude_compat_rewrites_stale_project_relative_hook_command() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        agent_path = root / "agent"
+        agent_path.mkdir(parents=True)
+        claude_dir = agent_path / agent_home.CLAUDE_DIRNAME
+        claude_dir.mkdir(parents=True, exist_ok=True)
+        settings_path = claude_dir / agent_home.CLAUDE_SETTINGS_FILENAME
+        stale_command = "$CLAUDE_PROJECT_DIR/.claude/hooks/append_agentsmd_context.sh"
+        stale_payload = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "startup",
+                        "hooks": [{"type": "command", "command": stale_command}],
+                    }
+                ]
+            }
+        }
+        settings_path.write_text(json.dumps(stale_payload, indent=2) + "\n", encoding="utf-8")
+
+        agent_home.ensure_claude_compat(agent_path, "# Agent Instructions\nRule: test\n")
+
+        payload = json.loads(settings_path.read_text(encoding="utf-8"))
+        command = payload["hooks"]["SessionStart"][0]["hooks"][0]["command"]
+        hook_path = (
+            agent_path
+            / agent_home.CLAUDE_DIRNAME
+            / agent_home.CLAUDE_HOOKS_DIRNAME
+            / agent_home.CLAUDE_HOOK_SCRIPT
+        )
+        assert command == shlex.quote(str(hook_path))
+        assert command != stale_command
 
 
 def test_ensure_claude_compat_serializes_concurrent_rewrites(


### PR DESCRIPTION
# Summary

- Fix Claude SessionStart startup hook resolution so Claude settings invoke the hook script installed in the active agent home instead of assuming a project-local `.claude/hooks` directory.

# Changes

- Updated `ensure_claude_compat` to generate the SessionStart command from the resolved agent-home hook path.
- Shell-quoted the generated hook command so paths containing spaces execute reliably.
- Added regression tests that verify:
- settings generation points to the installed agent-home hook
- startup command invocation succeeds even when the repo root has no `.claude/hooks`
- stale project-relative hook commands are rewritten to the corrected path

# Testing

- `uv run pytest tests/atelier/test_agent_home.py -q`
- `just format`
- `just lint`
- `just test`

# Tickets

- Fixes #422

# Risks / Rollout

- Low risk. The change is scoped to Claude compatibility settings generation and preserves existing hook installation behavior.

# Notes

- Existing agent homes are reconciled by `ensure_claude_compat` because stale settings payloads are rewritten when they differ from the corrected command payload.
