### PR TITLE
Auto-confirm deterministic root-branch resume during worker startup

### DIFF
--- a/src/atelier/worker/session/runner.py
+++ b/src/atelier/worker/session/runner.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Protocol
 
 from ... import beads as beads_runtime
-from ... import changeset_fields, lifecycle
+from ... import changeset_fields, git, lifecycle
+from ... import exec as exec_util
 from ... import root_branch as root_branch_runtime
 from ...pr_strategy import PrStrategy
 from ..context import ChangesetSelectionContext, WorkerRunContext
@@ -31,6 +33,45 @@ _TRANSIENT_PREPARE_WORKTREES_MARKERS = (
     "resource temporarily unavailable",
     "timed out",
 )
+
+
+def _list_local_branches(*, repo_root: Path, git_path: str | None) -> tuple[str, ...]:
+    """Return local branch names from ``refs/heads``.
+
+    Returns an empty tuple when git cannot be executed or the branch list cannot
+    be read (fail-closed for startup auto-confirm decisions).
+    """
+    result = exec_util.try_run_command(
+        git.git_command(
+            [
+                "-C",
+                str(repo_root),
+                "for-each-ref",
+                "--format=%(refname:short)",
+                "refs/heads",
+            ],
+            git_path=git_path,
+        )
+    )
+    if result is None or result.returncode != 0:
+        return ()
+    branches = {
+        line.strip()
+        for line in (result.stdout or "").splitlines()
+        if isinstance(line, str) and line.strip()
+    }
+    return tuple(sorted(branches))
+
+
+def _deterministic_bead_suffix_candidates(
+    *, branches: tuple[str, ...], bead_id: str
+) -> tuple[str, ...]:
+    """Return branch names that end with ``-<bead-id>`` or ``-<bead-id>.<n>``."""
+    normalized_bead_id = bead_id.strip()
+    if not normalized_bead_id:
+        return ()
+    pattern = re.compile(rf"-{re.escape(normalized_bead_id)}(?:\.\d+)?$")
+    return tuple(sorted(branch for branch in branches if pattern.search(branch)))
 
 
 @dataclass(frozen=True)
@@ -666,6 +707,47 @@ def run_worker_once(
         if not root_branch_value:
             root_branch_value = lifecycle.extract_changeset_root_branch(epic_issue)
         suggested_root_branch = None
+        if not root_branch_value:
+            deterministic_candidates = _deterministic_bead_suffix_candidates(
+                branches=_list_local_branches(repo_root=repo_root, git_path=git_path),
+                bead_id=selected_epic,
+            )
+            if len(deterministic_candidates) == 1:
+                root_branch_value = deterministic_candidates[0]
+                persist_prompted_root_branch = True
+                if dry_run:
+                    control.dry_run_log(
+                        "Root branch auto-confirm would apply via bead-suffix rule: "
+                        f"{root_branch_value!r} (bead {selected_epic})."
+                    )
+                else:
+                    control.say(
+                        "Root branch auto-confirmed via bead-suffix rule: "
+                        f"{root_branch_value!r} (bead {selected_epic})."
+                    )
+            elif len(deterministic_candidates) > 1:
+                candidate_list = ", ".join(repr(name) for name in deterministic_candidates)
+                if dry_run:
+                    control.dry_run_log(
+                        "Root branch auto-confirm skipped: multiple local bead-suffix matches "
+                        f"for {selected_epic} ({candidate_list})."
+                    )
+                else:
+                    control.say(
+                        "Root branch auto-confirm skipped: multiple local bead-suffix matches "
+                        f"for {selected_epic} ({candidate_list})."
+                    )
+            else:
+                if dry_run:
+                    control.dry_run_log(
+                        "Root branch auto-confirm skipped: no local bead-suffix match for "
+                        f"{selected_epic}."
+                    )
+                else:
+                    control.say(
+                        "Root branch auto-confirm skipped: no local bead-suffix match for "
+                        f"{selected_epic}."
+                    )
         if not root_branch_value:
             suggested_root_branch = infra.branching.suggest_root_branch(
                 str(epic_issue.get("title") or selected_epic),

--- a/tests/atelier/worker/test_session_runner_flow.py
+++ b/tests/atelier/worker/test_session_runner_flow.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import datetime as dt
+import subprocess
 from contextlib import nullcontext
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import Mock, call
+from unittest.mock import Mock, call, patch
 
 from atelier import config
 from atelier.agent_home import AgentHome
@@ -332,6 +333,170 @@ def test_run_worker_once_forwards_epic_id_for_missing_root_branch_prompt() -> No
         "feat/collision-proof-startup-at-uuzc",
         beads_root=Path("/project/.atelier/.beads"),
         cwd=Path("/repo"),
+    )
+
+
+def test_run_worker_once_auto_confirms_unique_bead_suffix_root_branch() -> None:
+    agent = AgentHome(
+        name="worker",
+        agent_id="atelier/worker/codex/p1autoc",
+        role="worker",
+        path=Path("/tmp/worker"),
+        session_key="p1autoc",
+    )
+    deps = _build_runner_deps(
+        startup_result=StartupContractResult(
+            epic_id="at-uuzc",
+            changeset_id=None,
+            should_exit=False,
+            reason="selected_auto",
+        ),
+        preview_agent=agent,
+    )
+    deps.infra.beads.claim_epic = Mock(
+        return_value={"id": "at-uuzc", "title": "Collision proof startup"}
+    )
+    deps.infra.beads.extract_workspace_root_branch = Mock(return_value="")
+    deps.lifecycle.extract_changeset_root_branch = lambda _issue: ""
+    deps.infra.root_branch.prompt_root_branch = Mock(
+        side_effect=AssertionError("prompt_root_branch should not be called")
+    )
+    local_refs = subprocess.CompletedProcess(
+        args=["git", "for-each-ref"],
+        returncode=0,
+        stdout="feat/collision-proof-startup-at-uuzc.1\n",
+        stderr="",
+    )
+
+    with patch("atelier.exec.try_run_command", return_value=local_refs):
+        summary = runner.run_worker_once(
+            SimpleNamespace(epic_id=None, queue=False, yes=False, reconcile=False),
+            run_context=WorkerRunContext(mode="auto", dry_run=False, session_key="p1autoc"),
+            deps=deps,
+        )
+
+    assert summary.started is False
+    assert summary.reason == "no_ready_changesets"
+    assert summary.epic_id == "at-uuzc"
+    deps.infra.beads.update_workspace_root_branch.assert_called_once_with(
+        "at-uuzc",
+        "feat/collision-proof-startup-at-uuzc.1",
+        beads_root=Path("/project/.atelier/.beads"),
+        cwd=Path("/repo"),
+    )
+    assert any(
+        "auto-confirmed via bead-suffix rule" in str(call.args[0])
+        for call in deps.control._say.call_args_list
+    )
+
+
+def test_run_worker_once_multiple_bead_suffix_matches_fall_back_to_prompt() -> None:
+    agent = AgentHome(
+        name="worker",
+        agent_id="atelier/worker/codex/p1multi",
+        role="worker",
+        path=Path("/tmp/worker"),
+        session_key="p1multi",
+    )
+    deps = _build_runner_deps(
+        startup_result=StartupContractResult(
+            epic_id="at-uuzc",
+            changeset_id=None,
+            should_exit=False,
+            reason="selected_auto",
+        ),
+        preview_agent=agent,
+    )
+    deps.infra.beads.claim_epic = Mock(
+        return_value={"id": "at-uuzc", "title": "Collision proof startup"}
+    )
+    deps.infra.beads.extract_workspace_root_branch = Mock(return_value="")
+    deps.lifecycle.extract_changeset_root_branch = lambda _issue: ""
+    deps.infra.root_branch.prompt_root_branch = Mock(
+        return_value="feat/collision-proof-startup-at-uuzc.2"
+    )
+    local_refs = subprocess.CompletedProcess(
+        args=["git", "for-each-ref"],
+        returncode=0,
+        stdout=("feat/collision-proof-startup-at-uuzc\nfeat/collision-proof-startup-at-uuzc.1\n"),
+        stderr="",
+    )
+
+    with patch("atelier.exec.try_run_command", return_value=local_refs):
+        summary = runner.run_worker_once(
+            SimpleNamespace(epic_id=None, queue=False, yes=False, reconcile=False),
+            run_context=WorkerRunContext(mode="auto", dry_run=False, session_key="p1multi"),
+            deps=deps,
+        )
+
+    assert summary.started is False
+    assert summary.reason == "no_ready_changesets"
+    assert summary.epic_id == "at-uuzc"
+    deps.infra.root_branch.prompt_root_branch.assert_called_once()
+    deps.infra.beads.update_workspace_root_branch.assert_called_once_with(
+        "at-uuzc",
+        "feat/collision-proof-startup-at-uuzc.2",
+        beads_root=Path("/project/.atelier/.beads"),
+        cwd=Path("/repo"),
+    )
+    assert any(
+        "multiple local bead-suffix matches" in str(call.args[0])
+        for call in deps.control._say.call_args_list
+    )
+
+
+def test_run_worker_once_nonmatching_suffix_falls_back_to_prompt() -> None:
+    agent = AgentHome(
+        name="worker",
+        agent_id="atelier/worker/codex/p1nomatch",
+        role="worker",
+        path=Path("/tmp/worker"),
+        session_key="p1nomatch",
+    )
+    deps = _build_runner_deps(
+        startup_result=StartupContractResult(
+            epic_id="at-uuzc",
+            changeset_id=None,
+            should_exit=False,
+            reason="selected_auto",
+        ),
+        preview_agent=agent,
+    )
+    deps.infra.beads.claim_epic = Mock(
+        return_value={"id": "at-uuzc", "title": "Collision proof startup"}
+    )
+    deps.infra.beads.extract_workspace_root_branch = Mock(return_value="")
+    deps.lifecycle.extract_changeset_root_branch = lambda _issue: ""
+    deps.infra.root_branch.prompt_root_branch = Mock(
+        return_value="feat/collision-proof-startup-at-uuzc"
+    )
+    local_refs = subprocess.CompletedProcess(
+        args=["git", "for-each-ref"],
+        returncode=0,
+        stdout="feat/unrelated\n",
+        stderr="",
+    )
+
+    with patch("atelier.exec.try_run_command", return_value=local_refs):
+        summary = runner.run_worker_once(
+            SimpleNamespace(epic_id=None, queue=False, yes=False, reconcile=False),
+            run_context=WorkerRunContext(mode="auto", dry_run=False, session_key="p1nomatch"),
+            deps=deps,
+        )
+
+    assert summary.started is False
+    assert summary.reason == "no_ready_changesets"
+    assert summary.epic_id == "at-uuzc"
+    deps.infra.root_branch.prompt_root_branch.assert_called_once()
+    deps.infra.beads.update_workspace_root_branch.assert_called_once_with(
+        "at-uuzc",
+        "feat/collision-proof-startup-at-uuzc",
+        beads_root=Path("/project/.atelier/.beads"),
+        cwd=Path("/repo"),
+    )
+    assert any(
+        "no local bead-suffix match for at-uuzc" in str(call.args[0])
+        for call in deps.control._say.call_args_list
     )
 
 


### PR DESCRIPTION
## Summary

- Auto-confirm worker root-branch selection during startup when there is exactly one local branch that deterministically matches the active work item's bead-suffix form.

## Changes

- Added startup convergence logic in `worker/session/runner.py` to:
  - enumerate local branches from `refs/heads`
  - detect deterministic matches ending in `-<bead-id>` or `-<bead-id>.<n>`
  - auto-select the branch when the match is unique and persist it without prompting
  - emit explicit diagnostics when auto-confirm applies, when matches are ambiguous, and when no deterministic local match exists
- Preserved existing prompt/fail-closed behavior for non-unique or missing deterministic matches.
- Added regression tests for:
  - unique deterministic auto-confirm
  - ambiguous multi-match fallback to prompt
  - non-matching suffix fallback to prompt

## Testing

- `just format`
- `just lint`
- `PYTHONPATH="$(cd /Users/scott/Library/Application\ Support/atelier/projects/atelier-c262f379/agents/worker/codex/p39592-t1772490732074477000/worktree && pwd)/src" just test`

## Tickets
- Addresses #427

## Risks / Rollout

- Low risk. The behavior change is scoped to startup root-branch resolution when metadata is missing and now prefers deterministic recovery when safe.

## Notes

- Branch ownership conflict checks and existing startup fail-closed paths are unchanged.
