### PR TITLE
Fix worktree mapping migration after root-branch rename

### DIFF
--- a/src/atelier/worktrees.py
+++ b/src/atelier/worktrees.py
@@ -437,6 +437,48 @@ def _branch_exists(repo_root: Path, branch: str, *, git_path: str | None = None)
     return git.git_ref_exists(repo_root, remote_ref, git_path=git_path)
 
 
+def _materialize_branch_from_source(
+    repo_root: Path,
+    target_branch: str,
+    source_branch: str,
+    *,
+    git_path: str | None = None,
+) -> None:
+    """Create a missing target branch from an existing source branch."""
+    if _branch_exists(repo_root, target_branch, git_path=git_path):
+        return
+    local_source_ref = f"refs/heads/{source_branch}"
+    remote_source_ref = f"refs/remotes/origin/{source_branch}"
+    source_ref = (
+        source_branch
+        if git.git_ref_exists(repo_root, local_source_ref, git_path=git_path)
+        else (
+            f"origin/{source_branch}"
+            if git.git_ref_exists(repo_root, remote_source_ref, git_path=git_path)
+            else None
+        )
+    )
+    if source_ref is None:
+        die(
+            "worktree mapping migration blocked: "
+            f"unable to create {target_branch!r} because source root branch "
+            f"{source_branch!r} does not exist locally or on origin."
+        )
+    exec_util.run_command(
+        git.git_command(
+            [
+                "-C",
+                str(repo_root),
+                "branch",
+                target_branch,
+                source_ref,
+            ],
+            git_path=git_path,
+        ),
+        capture_output=True,
+    )
+
+
 def _checkout_branch_for_mapping_migration(
     worktree_path: Path,
     root_branch: str,
@@ -494,6 +536,7 @@ def reconcile_worktree_mapping_root_branch(
             return current_mapping
 
         mapped_path = _resolve_mapping_worktree_path(project_dir, current_mapping)
+        should_checkout_new_root = False
         if mapped_path.exists():
             if not (mapped_path / ".git").exists():
                 die(
@@ -516,24 +559,35 @@ def reconcile_worktree_mapping_root_branch(
                         f"{mapped_path} has local changes on {old_root!r}. "
                         "Commit/stash/discard changes, then rerun."
                     )
-                if not _branch_exists(repo_root, new_root, git_path=git_path):
-                    die(
-                        "worktree mapping migration blocked: "
-                        f"target root branch {new_root!r} does not exist "
-                        f"(current mapping root is {old_root!r})."
-                    )
-                _checkout_branch_for_mapping_migration(
-                    mapped_path,
-                    new_root,
-                    repo_root=repo_root,
-                    git_path=git_path,
-                )
+                should_checkout_new_root = True
             elif current_branch != new_root:
                 die(
                     "worktree mapping migration blocked: "
                     f"{mapped_path} is on {current_branch!r}, expected {old_root!r} "
                     f"or {new_root!r}. Resolve branch state manually, then rerun."
                 )
+
+        if not _branch_exists(repo_root, new_root, git_path=git_path):
+            if not _branch_exists(repo_root, old_root, git_path=git_path):
+                die(
+                    "worktree mapping migration blocked: "
+                    f"target root branch {new_root!r} does not exist "
+                    f"(current mapping root is {old_root!r})."
+                )
+            _materialize_branch_from_source(
+                repo_root,
+                new_root,
+                old_root,
+                git_path=git_path,
+            )
+
+        if should_checkout_new_root:
+            _checkout_branch_for_mapping_migration(
+                mapped_path,
+                new_root,
+                repo_root=repo_root,
+                git_path=git_path,
+            )
 
         updated_changesets = dict(current_mapping.changesets)
         if updated_changesets.get(epic_id) == old_root:

--- a/tests/atelier/test_worktrees.py
+++ b/tests/atelier/test_worktrees.py
@@ -336,6 +336,113 @@ def test_ensure_worktree_mapping_reconcile_blocks_ambiguous_branch_state() -> No
                 )
 
 
+def test_ensure_worktree_mapping_reconcile_materializes_missing_new_root_from_old() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        project_dir = Path(tmp)
+        repo_root = Path(tmp) / "repo"
+        repo_root.mkdir(parents=True)
+        mapped_path = project_dir / "worktrees" / "epic"
+        mapped_path.mkdir(parents=True)
+        (mapped_path / ".git").write_text("gitdir: /tmp/gitdir", encoding="utf-8")
+
+        mapping_file = worktrees.mapping_path(project_dir, "epic")
+        mapping_file.parent.mkdir(parents=True, exist_ok=True)
+        worktrees.write_mapping(
+            mapping_file,
+            worktrees.WorktreeMapping(
+                epic_id="epic",
+                worktree_path="worktrees/epic",
+                root_branch="feat/old",
+                changesets={"epic": "feat/old", "epic.1": "feat/old-epic.1"},
+                changeset_worktrees={},
+            ),
+        )
+
+        refs = {"refs/heads/feat/old"}
+        recorded_commands: list[list[str]] = []
+
+        def fake_ref_exists(_repo: Path, ref: str, *, git_path: str | None = None) -> bool:
+            return ref in refs
+
+        def fake_run(cmd: list[str], *, capture_output: bool = False) -> None:
+            assert capture_output is True
+            recorded_commands.append(cmd)
+            if "branch" in cmd and "feat/new" in cmd:
+                refs.add("refs/heads/feat/new")
+
+        with (
+            patch("atelier.worktrees.git.git_current_branch", return_value="feat/old"),
+            patch("atelier.worktrees.git.git_status_porcelain", return_value=[]),
+            patch("atelier.worktrees.git.git_ref_exists", side_effect=fake_ref_exists),
+            patch("atelier.worktrees.exec_util.run_command", side_effect=fake_run),
+        ):
+            mapping = worktrees.ensure_worktree_mapping(
+                project_dir,
+                "epic",
+                "feat/new",
+                repo_root=repo_root,
+                git_path="git",
+            )
+
+        assert mapping.root_branch == "feat/new"
+        assert mapping.changesets["epic"] == "feat/new"
+        assert any("branch" in command and "feat/new" in command for command in recorded_commands)
+        assert any("checkout" in command and "feat/new" in command for command in recorded_commands)
+
+
+def test_ensure_worktree_mapping_reconcile_materializes_new_root_without_worktree_checkout() -> (
+    None
+):
+    with tempfile.TemporaryDirectory() as tmp:
+        project_dir = Path(tmp)
+        repo_root = Path(tmp) / "repo"
+        repo_root.mkdir(parents=True)
+
+        mapping_file = worktrees.mapping_path(project_dir, "epic")
+        mapping_file.parent.mkdir(parents=True, exist_ok=True)
+        worktrees.write_mapping(
+            mapping_file,
+            worktrees.WorktreeMapping(
+                epic_id="epic",
+                worktree_path="worktrees/epic",
+                root_branch="feat/old",
+                changesets={"epic": "feat/old"},
+                changeset_worktrees={},
+            ),
+        )
+
+        refs = {"refs/heads/feat/old"}
+        recorded_commands: list[list[str]] = []
+
+        def fake_ref_exists(_repo: Path, ref: str, *, git_path: str | None = None) -> bool:
+            return ref in refs
+
+        def fake_run(cmd: list[str], *, capture_output: bool = False) -> None:
+            assert capture_output is True
+            recorded_commands.append(cmd)
+            if "branch" in cmd and "feat/new" in cmd:
+                refs.add("refs/heads/feat/new")
+
+        with (
+            patch("atelier.worktrees.git.git_ref_exists", side_effect=fake_ref_exists),
+            patch("atelier.worktrees.exec_util.run_command", side_effect=fake_run),
+        ):
+            mapping = worktrees.ensure_worktree_mapping(
+                project_dir,
+                "epic",
+                "feat/new",
+                repo_root=repo_root,
+                git_path="git",
+            )
+
+        assert mapping.root_branch == "feat/new"
+        assert mapping.changesets["epic"] == "feat/new"
+        assert len(recorded_commands) == 1
+        command = recorded_commands[0]
+        assert "branch" in command
+        assert "feat/new" in command
+
+
 def test_reconcile_mapping_ownership_migrates_cross_epic_entries() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         project_dir = Path(tmp)


### PR DESCRIPTION
# Summary

- Make worktree mapping migration converge when an epic root branch name is renamed/normalized and the target branch has not been created yet.
- Prevent worker startup from failing during `prepare worktrees` in this rename scenario.

# Changes

- Add `_materialize_branch_from_source(...)` in `worktrees.py` to create a missing target root branch from the existing mapped root branch (local or origin) when migration is deterministic.
- Update `reconcile_worktree_mapping_root_branch(...)` to:
  - validate mapped worktree state as before,
  - materialize the new root branch when missing but old root exists,
  - checkout the new root when the mapped worktree is currently on the old root.
- Add regression coverage for renamed-root convergence in `tests/atelier/test_worktrees.py`:
  - migration with an existing mapped worktree (materialize + checkout),
  - migration when the mapped worktree path is absent (materialize without checkout).

# Testing

- `bash scripts/lint-gate.sh`
- `pytest -q tests/atelier/test_worktrees.py tests/atelier/worker/test_session_runner_flow.py::test_run_worker_once_blocks_changeset_on_non_recoverable_worktree_prep_error tests/atelier/worker/test_session_runner_flow.py::test_run_worker_once_retries_transient_prepare_worktree_failures_before_blocking`

## Tickets

- None

# Risks / Rollout

- Low: migration only takes the new fallback when target root is missing and source root exists.
- Existing blocking behavior is preserved for ambiguous branch states, dirty worktrees, and missing source roots.

# Notes

- PR scope is intentionally limited to root-branch migration convergence and regression tests.
