### PR TITLE
Fix Claude worker launch defaults for print + stream-json

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,16 +181,16 @@ Example:
         "claude": ["--model", "opus"]
       },
       "worker": {
-        "claude": ["--print", "--output-format=stream-json"]
+        "claude": ["--print", "--output-format=stream-json", "--verbose"]
       }
     }
   }
 }
 ```
 
-Claude worker sessions default to print-mode with `--output-format=stream-json`
-unless explicitly overridden, while planner Claude sessions remain interactive
-by default.
+Claude worker sessions default to print-mode with
+`--output-format=stream-json --verbose` unless explicitly overridden, while
+planner Claude sessions remain interactive by default.
 
 ## Workspace identity environment variables
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -100,8 +100,9 @@ Key fields include:
 Launch option precedence is deterministic: role-scoped launch options override
 legacy global options for the same flag.
 
-Claude worker launches default to `--print --output-format=stream-json` unless
-explicitly overridden by worker-scoped options.
+Claude worker launches default to
+`--print --output-format=stream-json --verbose` unless explicitly overridden by
+worker-scoped options.
 
 Agent sessions inherit identity env vars:
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -100,8 +100,9 @@ Agent launch options:
 - `agent.launch_options.planner.<agent>` and
   `agent.launch_options.worker.<agent>` provide role-scoped overrides.
 - No migration is required; existing `agent.options` config continues to work.
-- For Claude workers, Atelier defaults to `--print --output-format=stream-json`
-  unless worker-scoped options override those flags.
+- For Claude workers, Atelier defaults to
+  `--print --output-format=stream-json --verbose` unless worker-scoped options
+  override those flags.
 
 Branch prefix:
 

--- a/src/atelier/agents.py
+++ b/src/atelier/agents.py
@@ -384,6 +384,25 @@ def merge_cli_options(*groups: Sequence[str]) -> list[str]:
     return merged
 
 
+def _claude_output_format(options: Sequence[str]) -> str | None:
+    """Return the configured Claude output format from option tokens."""
+    for index, token in enumerate(options):
+        if token.startswith("--output-format="):
+            return token.split("=", 1)[1] or None
+        if token == "--output-format" and index + 1 < len(options):
+            return options[index + 1]
+    return None
+
+
+def _claude_requires_verbose(options: Sequence[str]) -> bool:
+    """Return whether Claude stream-json print mode requires ``--verbose``."""
+    return (
+        "--print" in options
+        and _claude_output_format(options) == "stream-json"
+        and "--verbose" not in options
+    )
+
+
 def resolve_launch_options(
     *,
     agent_name: str,
@@ -420,6 +439,8 @@ def resolve_launch_options(
     merged = merge_cli_options(base_options, scoped_options)
     if normalized_role == "worker" and normalized_agent == "claude":
         merged = merge_cli_options(_CLAUDE_WORKER_DEFAULT_OPTIONS, merged)
+        if _claude_requires_verbose(merged):
+            merged = merge_cli_options(merged, ("--verbose",))
     return merged
 
 

--- a/tests/atelier/test_agents.py
+++ b/tests/atelier/test_agents.py
@@ -215,6 +215,32 @@ class TestAgentSpec:
         )
         assert "--print" in resolved
         assert "--output-format=stream-json" in resolved
+        assert "--verbose" in resolved
+
+    def test_resolve_launch_options_adds_verbose_for_stream_json_split_tokens(self) -> None:
+        resolved = agents.resolve_launch_options(
+            agent_name="claude",
+            role="worker",
+            global_options={"claude": ["--model", "sonnet"]},
+            launch_options={"worker": {"claude": ["--output-format", "stream-json"]}},
+        )
+        assert "--print" in resolved
+        assert "--output-format" in resolved
+        assert "stream-json" in resolved
+        assert "--verbose" in resolved
+
+    def test_resolve_launch_options_does_not_force_verbose_when_output_format_is_not_stream_json(
+        self,
+    ) -> None:
+        resolved = agents.resolve_launch_options(
+            agent_name="claude",
+            role="worker",
+            global_options={"claude": ["--model", "sonnet"]},
+            launch_options={"worker": {"claude": ["--output-format=json"]}},
+        )
+        assert "--print" in resolved
+        assert "--output-format=json" in resolved
+        assert "--verbose" not in resolved
 
     def test_resolve_launch_options_keeps_claude_planner_interactive(self) -> None:
         resolved = agents.resolve_launch_options(

--- a/tests/atelier/worker/test_session_agent.py
+++ b/tests/atelier/worker/test_session_agent.py
@@ -20,9 +20,9 @@ class _FakeAgentSpec:
         self.yolo_flags = yolo_flags
 
     def build_start_command(
-        self, _agent_home: Path, _options: list[str], prompt: str
+        self, _agent_home: Path, options: list[str], prompt: str
     ) -> tuple[list[str], Path]:
-        return ["codex", prompt], Path("/tmp/agent")
+        return [self.name, *options, prompt], Path("/tmp/agent")
 
 
 class _TestControl:
@@ -276,6 +276,56 @@ def test_prepare_agent_session_adds_claude_worker_print_defaults(monkeypatch) ->
 
     assert "--print" in prep.agent_options
     assert "--output-format=stream-json" in prep.agent_options
+    assert "--verbose" in prep.agent_options
+
+
+def test_prepare_agent_session_claude_worker_output_override_avoids_forced_verbose(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        session_agent.agents,
+        "get_agent",
+        lambda _name: _FakeAgentSpec(name="claude"),
+    )
+    project_config = _project_config().model_copy(
+        update={
+            "agent": _project_config().agent.model_copy(
+                update={
+                    "default": "claude",
+                    "options": {"claude": ["--model", "sonnet"]},
+                    "launch_options": {"worker": {"claude": ["--output-format=json"]}},
+                }
+            )
+        }
+    )
+    agent = agent_home.AgentHome(
+        name="claude",
+        agent_id="atelier/worker/claude/p100",
+        role="worker",
+        path=Path("/tmp/agent-home"),
+    )
+
+    prep = session_agent.prepare_agent_session(
+        project_config=project_config,
+        project_data_dir=Path("/project-data"),
+        repo_root=Path("/repo"),
+        beads_root=Path("/beads"),
+        agent=agent,
+        changeset_worktree_path=Path("/worktree"),
+        selected_epic="at-epic",
+        changeset_id="at-epic.1",
+        root_branch_value="feat/root",
+        enlistment_path=Path("/repo"),
+        yes=True,
+        yolo=False,
+        dry_run=True,
+        session_control=_TestControl(),
+        command_ops=_TestCommandOps(),
+    )
+
+    assert "--print" in prep.agent_options
+    assert "--output-format=json" in prep.agent_options
+    assert "--verbose" not in prep.agent_options
 
 
 def test_start_agent_session_dry_run_returns_none() -> None:
@@ -302,6 +352,35 @@ def test_start_agent_session_dry_run_returns_none() -> None:
 
     assert result is None
     assert any("Agent command:" in msg for msg in control.logs)
+
+
+def test_start_agent_session_dry_run_logs_claude_worker_compatible_flags() -> None:
+    control = _TestControl()
+    agent = agent_home.AgentHome(
+        name="claude",
+        agent_id="atelier/worker/claude/p100",
+        role="worker",
+        path=Path("/tmp/agent-home"),
+    )
+    spec = _FakeAgentSpec(name="claude", display_name="Claude")
+
+    result = session_agent.start_agent_session(
+        dry_run=True,
+        agent=agent,
+        agent_spec=spec,
+        agent_options=["--print", "--output-format=stream-json", "--verbose"],
+        opening_prompt="hello",
+        env={},
+        command_ops=_TestCommandOps(),
+        session_control=control,
+        blocked_handler=_TestBlockedHandler(),
+    )
+
+    assert result is None
+    command_logs = [msg for msg in control.logs if msg.startswith("Agent command:")]
+    assert len(command_logs) == 1
+    assert "--output-format=stream-json" in command_logs[0]
+    assert "--verbose" in command_logs[0]
 
 
 def test_start_agent_session_runs_codex_success(monkeypatch) -> None:


### PR DESCRIPTION
# Summary

Fix Claude worker startup failures caused by incompatible default launch flags when
running in print mode with `stream-json` output.

# Changes

- Added Claude worker launch-option compatibility handling so `--verbose` is
  injected when `--print` and `--output-format=stream-json` are both active.
- Kept behavior scoped to Claude worker sessions; planner Claude sessions and
  Codex worker sessions are unchanged.
- Added regression tests for launch-option resolution and worker session command
  construction, including role-scoped override scenarios.
- Updated user docs to reflect the compatible Claude worker default flags.

# Testing

- `PYTHONPATH=src just format`
- `PYTHONPATH=src just lint`
- `PYTHONPATH=src just test`

## Tickets
- Fixes #440

# Risks / Rollout

- Low risk: change is limited to Claude worker option resolution and covered by
  unit tests.

# Notes

- Role-scoped worker overrides can still change output format; `--verbose` is
  only enforced when `stream-json` + `--print` is active.
