### PR TITLE
Make atelier open changeset-centric with deterministic selection

### DIFF
--- a/src/atelier/cli.py
+++ b/src/atelier/cli.py
@@ -462,7 +462,7 @@ def open_command(
     workspace_name: Annotated[
         str | None,
         typer.Argument(
-            help="workspace branch to open (prompted when omitted)",
+            help="changeset id (preferred) or workspace/branch alias to open",
             autocompletion=_workspace_only_shell_complete,
         ),
     ] = None,

--- a/src/atelier/commands/open.py
+++ b/src/atelier/commands/open.py
@@ -10,7 +10,7 @@ import shutil
 from dataclasses import dataclass
 from pathlib import Path
 
-from .. import beads, branching, config, exec, lifecycle, term, workspace, worktrees
+from .. import beads, branching, changesets, config, exec, lifecycle, term, workspace, worktrees
 from .. import command as command_util
 from ..io import die, select
 from .resolve import resolve_current_project_with_repo_root
@@ -20,25 +20,31 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - optional dependency
     shellingham = None
 
-
-def _workspace_choice_label(issue: dict[str, object], root_branch: str) -> str:
-    status = issue.get("status") or "unknown"
-    title = issue.get("title") or ""
-    issue_id = issue.get("id") or ""
-    return f"{root_branch} [{status}] {title} ({issue_id})"
-
-
-@dataclass(frozen=True)
-class _WorkspaceSelection:
-    issue: dict[str, object]
-    root_branch: str
-    workspace_branch: str
-    worktree_relpath: str | None = None
+_OPENABLE_CHANGESET_STATUSES = frozenset({"open", "in_progress", "blocked"})
 
 
 def _issue_id(issue: dict[str, object]) -> str:
     value = issue.get("id")
     return str(value).strip() if value is not None else ""
+
+
+def _issue_status(issue: dict[str, object]) -> str:
+    canonical = lifecycle.canonical_lifecycle_status(issue.get("status"))
+    if canonical:
+        return canonical
+    raw = str(issue.get("status") or "").strip()
+    return raw or "unknown"
+
+
+@dataclass(frozen=True)
+class _WorkspaceSelection:
+    epic_issue: dict[str, object]
+    changeset_issue: dict[str, object]
+    epic_id: str
+    changeset_id: str
+    root_branch: str
+    workspace_branch: str
+    worktree_relpath: str | None = None
 
 
 def _list_eligible_epics(*, beads_root: Path, repo_root: Path) -> list[dict[str, object]]:
@@ -47,77 +53,223 @@ def _list_eligible_epics(*, beads_root: Path, repo_root: Path) -> list[dict[str,
         issue
         for issue in issues
         if beads.extract_workspace_root_branch(issue)
-        and lifecycle.is_eligible_epic_status(issue.get("status"), allow_hooked=True)
+        and lifecycle.canonical_lifecycle_status(issue.get("status")) != "closed"
     ]
 
 
-def _changeset_branch_matches(
+def _changeset_pr_context(issue: dict[str, object]) -> str | None:
+    description = issue.get("description")
+    metadata = changesets.parse_review_metadata(description if isinstance(description, str) else "")
+    parts: list[str] = []
+    if metadata.pr_number:
+        parts.append(f"#{metadata.pr_number}")
+    normalized_state = lifecycle.normalize_review_state(metadata.pr_state)
+    if normalized_state:
+        parts.append(normalized_state)
+    elif metadata.pr_state:
+        cleaned = metadata.pr_state.strip()
+        if cleaned:
+            parts.append(cleaned)
+    if metadata.pr_url:
+        parts.append(metadata.pr_url)
+    if not parts:
+        return None
+    return " ".join(parts)
+
+
+def _workspace_choice_label(selection: _WorkspaceSelection) -> str:
+    status = _issue_status(selection.changeset_issue)
+    title = str(selection.changeset_issue.get("title") or "").strip() or "(untitled)"
+    label = f"{selection.changeset_id} [{status}] {title} ({selection.workspace_branch})"
+    pr_context = _changeset_pr_context(selection.changeset_issue)
+    if pr_context:
+        return f"{label} - PR {pr_context}"
+    return label
+
+
+def _is_openable_changeset(issue: dict[str, object]) -> bool:
+    return _issue_status(issue) in _OPENABLE_CHANGESET_STATUSES
+
+
+def _list_openable_changesets(
     *,
-    candidates: list[str],
     project_dir: Path,
     beads_root: Path,
     repo_root: Path,
 ) -> list[_WorkspaceSelection]:
-    candidate_set = {candidate for candidate in candidates if candidate}
-    if not candidate_set:
-        return []
-
-    matches: list[_WorkspaceSelection] = []
-    for issue in _list_eligible_epics(beads_root=beads_root, repo_root=repo_root):
-        root_branch = beads.extract_workspace_root_branch(issue)
+    selections: list[_WorkspaceSelection] = []
+    for epic_issue in _list_eligible_epics(beads_root=beads_root, repo_root=repo_root):
+        root_branch = beads.extract_workspace_root_branch(epic_issue)
         if not root_branch:
             continue
-        epic_id = _issue_id(issue)
+        epic_id = _issue_id(epic_issue)
         if not epic_id:
             continue
+
         mapping = worktrees.load_mapping(worktrees.mapping_path(project_dir, epic_id))
-        if mapping is None:
-            continue
-        for changeset_id, work_branch in mapping.changesets.items():
-            if work_branch not in candidate_set:
+        work_children = beads.list_work_children(
+            epic_id,
+            beads_root=beads_root,
+            cwd=repo_root,
+            include_closed=True,
+        )
+        if work_children:
+            candidate_issues = beads.list_descendant_changesets(
+                epic_id,
+                beads_root=beads_root,
+                cwd=repo_root,
+                include_closed=True,
+            )
+        else:
+            candidate_issues = [epic_issue]
+
+        for changeset_issue in candidate_issues:
+            changeset_id = _issue_id(changeset_issue)
+            if not changeset_id or not _is_openable_changeset(changeset_issue):
                 continue
-            worktree_relpath = mapping.changeset_worktrees.get(changeset_id)
-            if not worktree_relpath:
+            workspace_branch = mapping.changesets.get(changeset_id) if mapping is not None else None
+            if not workspace_branch and changeset_id == epic_id:
+                workspace_branch = root_branch
+            if not workspace_branch:
                 continue
-            matches.append(
+
+            worktree_relpath: str | None = None
+            if mapping is not None:
+                if changeset_id == epic_id:
+                    worktree_relpath = mapping.worktree_path
+                else:
+                    worktree_relpath = mapping.changeset_worktrees.get(changeset_id)
+            if not worktree_relpath and changeset_id == epic_id:
+                worktree_relpath = beads.extract_worktree_path(epic_issue)
+            if changeset_id != epic_id and not worktree_relpath:
+                continue
+
+            selections.append(
                 _WorkspaceSelection(
-                    issue=issue,
+                    epic_issue=epic_issue,
+                    changeset_issue=changeset_issue,
+                    epic_id=epic_id,
+                    changeset_id=changeset_id,
                     root_branch=root_branch,
-                    workspace_branch=work_branch,
+                    workspace_branch=workspace_branch,
                     worktree_relpath=worktree_relpath,
                 )
             )
-    return matches
 
-
-def _candidate_values_message(
-    workspace_name: str, *, project_dir: Path, beads_root: Path, repo_root: Path
-) -> str:
-    issues = _list_eligible_epics(beads_root=beads_root, repo_root=repo_root)
-    root_values = sorted(
-        {
-            root_branch
-            for issue in issues
-            if (root_branch := beads.extract_workspace_root_branch(issue)) is not None
-        }
+    deduped: dict[tuple[str, str], _WorkspaceSelection] = {}
+    for selection in selections:
+        deduped[(selection.epic_id, selection.changeset_id)] = selection
+    return sorted(
+        deduped.values(),
+        key=lambda selection: (
+            selection.changeset_id,
+            selection.workspace_branch,
+            selection.epic_id,
+        ),
     )
-    mapped_values: set[str] = set()
-    for issue in issues:
-        epic_id = _issue_id(issue)
-        if not epic_id:
-            continue
-        mapping = worktrees.load_mapping(worktrees.mapping_path(project_dir, epic_id))
-        if mapping is None:
-            continue
-        mapped_values.update(branch for branch in mapping.changesets.values() if branch)
-    roots = ", ".join(root_values[:8]) if root_values else "(none)"
-    if mapped_values:
-        mapped = ", ".join(sorted(mapped_values)[:8])
-        return (
-            f"no epic or mapped changeset worktree found for workspace {workspace_name!r}. "
-            f"valid root workspaces: {roots}. mapped changeset branches: {mapped}"
+
+
+def _known_changeset_values(selections: list[_WorkspaceSelection]) -> tuple[str, str]:
+    known_ids = sorted({selection.changeset_id for selection in selections})
+    known_branches = sorted(
+        {selection.workspace_branch for selection in selections}
+        | {selection.root_branch for selection in selections}
+    )
+    id_text = ", ".join(known_ids[:8]) if known_ids else "(none)"
+    branch_text = ", ".join(known_branches[:8]) if known_branches else "(none)"
+    return id_text, branch_text
+
+
+def _unmapped_input_message(workspace_name: str, selections: list[_WorkspaceSelection]) -> str:
+    id_text, branch_text = _known_changeset_values(selections)
+    first = next(iter(sorted({selection.changeset_id for selection in selections})), None)
+    example = first or "<changeset-id>"
+    return (
+        f"no mapped active changeset found for input {workspace_name!r}. "
+        f"try an explicit changeset id (for example: atelier open {example}). "
+        f"known changeset ids: {id_text}. known changeset/workspace branches: {branch_text}"
+    )
+
+
+def _ambiguous_input_message(workspace_name: str, matches: list[_WorkspaceSelection]) -> str:
+    details = ", ".join(
+        f"{selection.changeset_id} ({selection.workspace_branch})"
+        for selection in sorted(
+            matches,
+            key=lambda selection: (
+                selection.changeset_id,
+                selection.workspace_branch,
+                selection.epic_id,
+            ),
+        )[:8]
+    )
+    return (
+        f"input {workspace_name!r} matches multiple changesets: {details}. "
+        "specify a changeset id explicitly (for example: atelier open <changeset-id>)"
+    )
+
+
+def _select_changeset_by_workspace(
+    *,
+    project_dir: Path,
+    workspace_name: str | None,
+    raw: bool,
+    branch_prefix: str,
+    beads_root: Path,
+    repo_root: Path,
+) -> _WorkspaceSelection:
+    selections = _list_openable_changesets(
+        project_dir=project_dir,
+        beads_root=beads_root,
+        repo_root=repo_root,
+    )
+    if not selections:
+        die("no mapped open/in_progress/blocked changesets found")
+
+    if workspace_name:
+        direct_matches = [
+            selection for selection in selections if selection.changeset_id == workspace_name
+        ]
+        if len(direct_matches) == 1:
+            return direct_matches[0]
+        if len(direct_matches) > 1:
+            die(_ambiguous_input_message(workspace_name, direct_matches))
+
+        candidates = branching.candidates_for_root_branch(workspace_name, branch_prefix, raw)
+        candidate_set = {candidate for candidate in candidates if candidate}
+        matches: dict[tuple[str, str], _WorkspaceSelection] = {}
+        for selection in selections:
+            if (
+                selection.workspace_branch in candidate_set
+                or selection.root_branch in candidate_set
+            ):
+                matches[(selection.epic_id, selection.changeset_id)] = selection
+
+        if not matches:
+            die(_unmapped_input_message(workspace_name, selections))
+
+        resolved = sorted(
+            matches.values(),
+            key=lambda selection: (
+                selection.changeset_id,
+                selection.workspace_branch,
+                selection.epic_id,
+            ),
         )
-    return f"no epic found for workspace {workspace_name!r}. valid root workspaces: {roots}"
+        if len(resolved) > 1:
+            die(_ambiguous_input_message(workspace_name, resolved))
+        return resolved[0]
+
+    choices: dict[str, _WorkspaceSelection] = {}
+    for selection in selections:
+        label = _workspace_choice_label(selection)
+        choices[label] = selection
+
+    if len(choices) == 1:
+        return next(iter(choices.values()))
+
+    selected = select("Changeset to open", list(choices.keys()))
+    return choices[selected]
 
 
 def _select_epic_by_workspace(
@@ -129,73 +281,15 @@ def _select_epic_by_workspace(
     beads_root: Path,
     repo_root: Path,
 ) -> _WorkspaceSelection:
-    if workspace_name:
-        candidates = branching.candidates_for_root_branch(workspace_name, branch_prefix, raw)
-        matches: list[_WorkspaceSelection] = []
-        for candidate in candidates:
-            for issue in beads.find_epics_by_root_branch(
-                candidate, beads_root=beads_root, cwd=repo_root
-            ):
-                root_branch = beads.extract_workspace_root_branch(issue)
-                if not root_branch:
-                    continue
-                matches.append(
-                    _WorkspaceSelection(
-                        issue=issue,
-                        root_branch=root_branch,
-                        workspace_branch=root_branch,
-                    )
-                )
-        if not matches:
-            matches = _changeset_branch_matches(
-                candidates=candidates,
-                project_dir=project_dir,
-                beads_root=beads_root,
-                repo_root=repo_root,
-            )
-        if not matches:
-            die(
-                _candidate_values_message(
-                    workspace_name,
-                    project_dir=project_dir,
-                    beads_root=beads_root,
-                    repo_root=repo_root,
-                )
-            )
-    else:
-        matches = [
-            _WorkspaceSelection(
-                issue=issue,
-                root_branch=root_branch,
-                workspace_branch=root_branch,
-            )
-            for issue in _list_eligible_epics(beads_root=beads_root, repo_root=repo_root)
-            if (root_branch := beads.extract_workspace_root_branch(issue)) is not None
-        ]
-        if not matches:
-            die("no epics with workspace branches found")
-
-    choices: dict[str, _WorkspaceSelection] = {}
-    seen: set[tuple[str, str, str | None]] = set()
-    for selection in matches:
-        issue = selection.issue
-        issue_id = _issue_id(issue)
-        dedupe_key = (issue_id, selection.workspace_branch, selection.worktree_relpath)
-        if dedupe_key in seen:
-            continue
-        seen.add(dedupe_key)
-        root_branch = selection.workspace_branch
-        label = _workspace_choice_label(issue, root_branch)
-        choices[label] = selection
-
-    if not choices:
-        die("no eligible epics found for the workspace selection")
-
-    if len(choices) == 1:
-        return next(iter(choices.values()))
-
-    selection = select("Workspace to open", list(choices.keys()))
-    return choices[selection]
+    """Backwards-compatible shim for legacy call sites and tests."""
+    return _select_changeset_by_workspace(
+        project_dir=project_dir,
+        workspace_name=workspace_name,
+        raw=raw,
+        branch_prefix=branch_prefix,
+        beads_root=beads_root,
+        repo_root=repo_root,
+    )
 
 
 def _resolve_worktree_path(
@@ -313,7 +407,7 @@ def open_worktree(args: object) -> None:
     beads_root = config.resolve_beads_root(project_data_dir, repo_root)
     beads.run_bd_command(["prime"], beads_root=beads_root, cwd=repo_root)
 
-    selection = _select_epic_by_workspace(
+    selection = _select_changeset_by_workspace(
         project_dir=project_data_dir,
         workspace_name=str(workspace_name) if workspace_name else None,
         raw=raw,
@@ -322,19 +416,21 @@ def open_worktree(args: object) -> None:
         repo_root=repo_root,
     )
     if not selection.root_branch:
-        die("selected epic is missing workspace.root_branch")
+        die("selected changeset is missing workspace.root_branch")
 
     worktree_path = _resolve_worktree_path(
         project_data_dir,
         repo_root,
-        str(selection.issue.get("id") or ""),
+        selection.epic_id,
         selection.root_branch,
-        selection.worktree_relpath or beads.extract_worktree_path(selection.issue),
+        selection.worktree_relpath,
         git_path=git_path,
     )
     project_enlistment = project_config.project.enlistment or enlistment_path
     env = workspace.workspace_environment(
-        project_enlistment, selection.workspace_branch, worktree_path
+        project_enlistment,
+        selection.workspace_branch,
+        worktree_path,
     )
     if set_title:
         title = term.workspace_title(project_enlistment, selection.workspace_branch)

--- a/tests/atelier/commands/test_open.py
+++ b/tests/atelier/commands/test_open.py
@@ -28,6 +28,32 @@ def _make_hooked_issue(root_branch: str, worktree_relpath: str) -> dict[str, obj
     return issue
 
 
+def _make_changeset_issue(
+    changeset_id: str,
+    title: str,
+    *,
+    work_branch: str,
+    status: str = "open",
+    pr_number: str | None = None,
+    pr_state: str | None = None,
+    pr_url: str | None = None,
+) -> dict[str, object]:
+    lines = [f"changeset.work_branch: {work_branch}"]
+    if pr_number is not None:
+        lines.append(f"pr_number: {pr_number}")
+    if pr_state is not None:
+        lines.append(f"pr_state: {pr_state}")
+    if pr_url is not None:
+        lines.append(f"pr_url: {pr_url}")
+    return {
+        "id": changeset_id,
+        "title": title,
+        "status": status,
+        "labels": ["at:changeset"],
+        "description": "\n".join(lines) + "\n",
+    }
+
+
 def test_open_runs_command_in_worktree() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
@@ -68,10 +94,8 @@ def test_open_runs_command_in_worktree() -> None:
                 return_value=Path("/beads"),
             ),
             patch("atelier.commands.open.beads.run_bd_command"),
-            patch(
-                "atelier.commands.open.beads.find_epics_by_root_branch",
-                return_value=[issue],
-            ),
+            patch("atelier.commands.open.beads.list_epics", return_value=[issue]),
+            patch("atelier.commands.open.beads.list_work_children", return_value=[]),
             patch("atelier.commands.open.exec.run_with_runner", fake_run),
         ):
             with pytest.raises(SystemExit) as raised:
@@ -133,7 +157,8 @@ def test_open_includes_hooked_epics_for_workspace_selection() -> None:
                 return_value=Path("/beads"),
             ),
             patch("atelier.commands.open.beads.run_bd_command"),
-            patch("atelier.commands.open.beads.run_bd_json", return_value=[issue]),
+            patch("atelier.commands.open.beads.list_epics", return_value=[issue]),
+            patch("atelier.commands.open.beads.list_work_children", return_value=[]),
             patch("atelier.commands.open.exec.run_with_runner", fake_run),
         ):
             with pytest.raises(SystemExit) as raised:
@@ -191,10 +216,8 @@ def test_open_uses_shell_override() -> None:
                 return_value=Path("/beads"),
             ),
             patch("atelier.commands.open.beads.run_bd_command"),
-            patch(
-                "atelier.commands.open.beads.find_epics_by_root_branch",
-                return_value=[issue],
-            ),
+            patch("atelier.commands.open.beads.list_epics", return_value=[issue]),
+            patch("atelier.commands.open.beads.list_work_children", return_value=[]),
             patch("atelier.commands.open.exec.run_with_runner", fake_run),
         ):
             with pytest.raises(SystemExit) as raised:
@@ -239,6 +262,11 @@ def test_open_resolves_changeset_work_branch_to_changeset_worktree() -> None:
 
         project_config = config.ProjectConfig()
         issue = _make_issue("feat/root", "worktrees/epic-1")
+        changeset_issue = _make_changeset_issue(
+            "at-1my.1",
+            "Child changeset",
+            work_branch="feat/root-at-1my.1",
+        )
         captured: dict[str, object] = {}
 
         def fake_run(request: object, *, runner: object | None = None) -> object:
@@ -264,8 +292,15 @@ def test_open_resolves_changeset_work_branch_to_changeset_worktree() -> None:
                 return_value=Path("/beads"),
             ),
             patch("atelier.commands.open.beads.run_bd_command"),
-            patch("atelier.commands.open.beads.find_epics_by_root_branch", return_value=[]),
-            patch("atelier.commands.open.beads.run_bd_json", return_value=[issue]),
+            patch("atelier.commands.open.beads.list_epics", return_value=[issue]),
+            patch(
+                "atelier.commands.open.beads.list_work_children",
+                return_value=[changeset_issue],
+            ),
+            patch(
+                "atelier.commands.open.beads.list_descendant_changesets",
+                return_value=[changeset_issue],
+            ),
             patch("atelier.commands.open.worktrees.load_mapping", return_value=mapping),
             patch(
                 "atelier.commands.open.worktrees.ensure_worktree_mapping",
@@ -292,6 +327,96 @@ def test_open_resolves_changeset_work_branch_to_changeset_worktree() -> None:
         assert env["ATELIER_WORKSPACE"] == "feat/root-at-1my.1"
 
 
+def test_open_resolves_changeset_id_to_changeset_worktree() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        project_root = root / "project"
+        repo_root = root / "repo"
+        project_root.mkdir()
+        repo_root.mkdir()
+        project_data_dir = root / "data"
+        root_worktree_path = project_data_dir / "worktrees" / "epic-1"
+        root_worktree_path.mkdir(parents=True)
+        (root_worktree_path / ".git").write_text("gitdir: /tmp\n", encoding="utf-8")
+        changeset_worktree_path = project_data_dir / "worktrees" / "at-1my.1"
+        changeset_worktree_path.mkdir(parents=True)
+        (changeset_worktree_path / ".git").write_text("gitdir: /tmp\n", encoding="utf-8")
+
+        mapping = worktrees.WorktreeMapping(
+            epic_id="epic-1",
+            worktree_path="worktrees/epic-1",
+            root_branch="feat/root",
+            changesets={"at-1my.1": "feat/root-at-1my.1"},
+            changeset_worktrees={"at-1my.1": "worktrees/at-1my.1"},
+        )
+
+        project_config = config.ProjectConfig()
+        issue = _make_issue("feat/root", "worktrees/epic-1")
+        changeset_issue = _make_changeset_issue(
+            "at-1my.1",
+            "Child changeset",
+            work_branch="feat/root-at-1my.1",
+        )
+        captured: dict[str, object] = {}
+
+        def fake_run(request: object, *, runner: object | None = None) -> object:
+            del runner
+            assert isinstance(request, open_cmd.exec.CommandRequest)
+            captured["cwd"] = request.cwd
+            captured["env"] = request.env
+            return open_cmd.exec.CommandResult(
+                argv=request.argv, returncode=0, stdout="", stderr=""
+            )
+
+        with (
+            patch(
+                "atelier.commands.open.resolve_current_project_with_repo_root",
+                return_value=(project_root, project_config, str(repo_root), repo_root),
+            ),
+            patch(
+                "atelier.commands.open.config.resolve_project_data_dir",
+                return_value=project_data_dir,
+            ),
+            patch(
+                "atelier.commands.open.config.resolve_beads_root",
+                return_value=Path("/beads"),
+            ),
+            patch("atelier.commands.open.beads.run_bd_command"),
+            patch("atelier.commands.open.beads.list_epics", return_value=[issue]),
+            patch(
+                "atelier.commands.open.beads.list_work_children",
+                return_value=[changeset_issue],
+            ),
+            patch(
+                "atelier.commands.open.beads.list_descendant_changesets",
+                return_value=[changeset_issue],
+            ),
+            patch("atelier.commands.open.worktrees.load_mapping", return_value=mapping),
+            patch(
+                "atelier.commands.open.worktrees.ensure_worktree_mapping",
+                return_value=mapping,
+            ),
+            patch("atelier.commands.open.exec.run_with_runner", fake_run),
+        ):
+            with pytest.raises(SystemExit) as raised:
+                open_cmd.open_worktree(
+                    SimpleNamespace(
+                        workspace_name="at-1my.1",
+                        raw=False,
+                        command=["pwd"],
+                        shell=None,
+                        workspace_root=False,
+                        set_title=False,
+                    )
+                )
+
+        assert raised.value.code == 0
+        assert captured["cwd"] == changeset_worktree_path
+        env = captured["env"]
+        assert env
+        assert env["ATELIER_WORKSPACE"] == "feat/root-at-1my.1"
+
+
 def test_open_prompts_for_workspace() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
@@ -300,13 +425,46 @@ def test_open_prompts_for_workspace() -> None:
         project_root.mkdir()
         repo_root.mkdir()
         project_data_dir = root / "data"
-        worktree_path = project_data_dir / "worktrees" / "epic-1"
-        worktree_path.mkdir(parents=True)
-        (worktree_path / ".git").write_text("gitdir: /tmp\n", encoding="utf-8")
+        first_worktree_path = project_data_dir / "worktrees" / "at-1my.1"
+        first_worktree_path.mkdir(parents=True)
+        (first_worktree_path / ".git").write_text("gitdir: /tmp\n", encoding="utf-8")
+        second_worktree_path = project_data_dir / "worktrees" / "at-1my.2"
+        second_worktree_path.mkdir(parents=True)
+        (second_worktree_path / ".git").write_text("gitdir: /tmp\n", encoding="utf-8")
 
         project_config = config.ProjectConfig()
         issue = _make_issue("feat/root", "worktrees/epic-1")
-        choices = ["feat/root [open] Epic (epic-1)"]
+        first_changeset = _make_changeset_issue(
+            "at-1my.1",
+            "First changeset",
+            work_branch="feat/root-at-1my.1",
+            pr_number="17",
+            pr_state="in-review",
+            pr_url="https://example.test/pr/17",
+        )
+        second_changeset = _make_changeset_issue(
+            "at-1my.2",
+            "Second changeset",
+            work_branch="feat/root-at-1my.2",
+        )
+        mapping = worktrees.WorktreeMapping(
+            epic_id="epic-1",
+            worktree_path="worktrees/epic-1",
+            root_branch="feat/root",
+            changesets={
+                "at-1my.1": "feat/root-at-1my.1",
+                "at-1my.2": "feat/root-at-1my.2",
+            },
+            changeset_worktrees={
+                "at-1my.1": "worktrees/at-1my.1",
+                "at-1my.2": "worktrees/at-1my.2",
+            },
+        )
+        captured_choices: list[str] = []
+
+        def fake_select(_prompt: str, choices: list[str]) -> str:
+            captured_choices.extend(choices)
+            return choices[0]
 
         def fake_run(request: object, *, runner: object | None = None) -> object:
             del runner
@@ -329,11 +487,21 @@ def test_open_prompts_for_workspace() -> None:
                 return_value=Path("/beads"),
             ),
             patch("atelier.commands.open.beads.run_bd_command"),
+            patch("atelier.commands.open.beads.list_epics", return_value=[issue]),
             patch(
-                "atelier.commands.open.beads.run_bd_json",
-                return_value=[issue],
+                "atelier.commands.open.beads.list_work_children",
+                return_value=[first_changeset, second_changeset],
             ),
-            patch("atelier.commands.open.select", return_value=choices[0]),
+            patch(
+                "atelier.commands.open.beads.list_descendant_changesets",
+                return_value=[first_changeset, second_changeset],
+            ),
+            patch("atelier.commands.open.worktrees.load_mapping", return_value=mapping),
+            patch(
+                "atelier.commands.open.worktrees.ensure_worktree_mapping",
+                return_value=mapping,
+            ),
+            patch("atelier.commands.open.select", side_effect=fake_select),
             patch("atelier.commands.open.exec.run_with_runner", fake_run),
         ):
             with pytest.raises(SystemExit):
@@ -347,29 +515,40 @@ def test_open_prompts_for_workspace() -> None:
                         set_title=False,
                     )
                 )
+        assert any(
+            "at-1my.1" in choice
+            and "First changeset" in choice
+            and "PR #17 in-review https://example.test/pr/17" in choice
+            for choice in captured_choices
+        )
 
 
 def test_select_epic_by_workspace_suggests_valid_values_on_lookup_failure() -> None:
-    issue = _make_issue("feat/root", "worktrees/epic-1")
-    mapping = worktrees.WorktreeMapping(
+    epic_issue = _make_issue("feat/root", "worktrees/epic-1")
+    changeset_issue = _make_changeset_issue(
+        "at-1my.1",
+        "Child changeset",
+        work_branch="feat/root-at-1my.1",
+    )
+    selection = open_cmd._WorkspaceSelection(
+        epic_issue=epic_issue,
+        changeset_issue=changeset_issue,
         epic_id="epic-1",
-        worktree_path="worktrees/epic-1",
+        changeset_id="at-1my.1",
         root_branch="feat/root",
-        changesets={"at-1my.1": "feat/root-at-1my.1"},
-        changeset_worktrees={"at-1my.1": "worktrees/at-1my.1"},
+        workspace_branch="feat/root-at-1my.1",
+        worktree_relpath="worktrees/at-1my.1",
     )
 
     def fake_die(message: str) -> None:
         raise RuntimeError(message)
 
     with (
-        patch("atelier.commands.open.beads.find_epics_by_root_branch", return_value=[]),
-        patch("atelier.commands.open.beads.run_bd_json", return_value=[issue]),
-        patch("atelier.commands.open.worktrees.load_mapping", return_value=mapping),
+        patch("atelier.commands.open._list_openable_changesets", return_value=[selection]),
         patch("atelier.commands.open.die", side_effect=fake_die),
     ):
         with pytest.raises(RuntimeError) as raised:
-            open_cmd._select_epic_by_workspace(
+            open_cmd._select_changeset_by_workspace(
                 project_dir=Path("/project-data"),
                 workspace_name="unknown",
                 raw=True,
@@ -379,8 +558,61 @@ def test_select_epic_by_workspace_suggests_valid_values_on_lookup_failure() -> N
             )
 
     message = str(raised.value)
-    assert "valid root workspaces: feat/root" in message
-    assert "mapped changeset branches: feat/root-at-1my.1" in message
+    assert "try an explicit changeset id" in message
+    assert "known changeset ids: at-1my.1" in message
+
+
+def test_select_changeset_by_workspace_fails_closed_on_ambiguous_mapping() -> None:
+    epic_issue = _make_issue("feat/root", "worktrees/epic-1")
+    first_issue = _make_changeset_issue(
+        "at-1my.1",
+        "First changeset",
+        work_branch="feat/root-at-1my.1",
+    )
+    second_issue = _make_changeset_issue(
+        "at-1my.2",
+        "Second changeset",
+        work_branch="feat/root-at-1my.2",
+    )
+    first = open_cmd._WorkspaceSelection(
+        epic_issue=epic_issue,
+        changeset_issue=first_issue,
+        epic_id="epic-1",
+        changeset_id="at-1my.1",
+        root_branch="feat/root",
+        workspace_branch="feat/root-at-1my.1",
+        worktree_relpath="worktrees/at-1my.1",
+    )
+    second = open_cmd._WorkspaceSelection(
+        epic_issue=epic_issue,
+        changeset_issue=second_issue,
+        epic_id="epic-1",
+        changeset_id="at-1my.2",
+        root_branch="feat/root",
+        workspace_branch="feat/root-at-1my.2",
+        worktree_relpath="worktrees/at-1my.2",
+    )
+
+    def fake_die(message: str) -> None:
+        raise RuntimeError(message)
+
+    with (
+        patch("atelier.commands.open._list_openable_changesets", return_value=[first, second]),
+        patch("atelier.commands.open.die", side_effect=fake_die),
+    ):
+        with pytest.raises(RuntimeError) as raised:
+            open_cmd._select_changeset_by_workspace(
+                project_dir=Path("/project-data"),
+                workspace_name="feat/root",
+                raw=True,
+                branch_prefix="",
+                beads_root=Path("/beads"),
+                repo_root=Path("/repo"),
+            )
+
+    message = str(raised.value)
+    assert "matches multiple changesets" in message
+    assert "atelier open <changeset-id>" in message
 
 
 def test_resolve_worktree_path_reconciles_stale_mapping_root() -> None:


### PR DESCRIPTION
# Summary

- Make `atelier open` changeset-centric so explicit inputs can resolve by changeset identity instead of only workspace/root-branch names.

# Changes

- Reworked open-target resolution to index mapped changesets under active epics and resolve explicit input in this order: direct changeset id first, then compatibility alias mapping.
- Updated compatibility behavior to fail closed when an alias maps to multiple changesets, with deterministic diagnostics and actionable changeset-id examples.
- Switched interactive `atelier open` choices to changeset rows and included PR context (`pr_number` / `pr_state` / `pr_url`) when present.
- Updated `open` command tests to cover direct changeset-id opens, compatibility resolution, interactive PR-context rendering, and ambiguous/unmapped fail-closed paths.
- Updated CLI argument help text to describe changeset ids as the preferred `open` input.

# Testing

- `just format`
- `just lint`
- `PYTHONPATH=worktree/src uv run --python /Users/scott/code/atelier/.venv/bin/python pytest worktree/tests/atelier/commands/test_open.py worktree/tests/atelier/commands/test_open_cli.py -q`
- `just test` *(fails in this environment during collection: `ModuleNotFoundError: No module named 'pydantic_core._pydantic_core'` from the uv tools install path)*

# Tickets

- Addresses #446

# Risks / Rollout

- Moderate: `atelier open` selection/resolution semantics changed from epic/workspace-first to changeset-first. Existing workspace/branch aliases still work when they resolve to exactly one changeset.

# Notes

- This change intentionally keeps `atelier open` read-only with respect to PR/bead state; it only hydrates existing review metadata for interactive display.
