### PR TITLE
Bound structured worker stream capture memory usage

### DIFF
--- a/src/atelier/worker/session/agent.py
+++ b/src/atelier/worker/session/agent.py
@@ -33,6 +33,7 @@ _STRUCTURED_LIVE_PREVIEW_CHARS = 140
 _STRUCTURED_REASONING_EMIT_LIMIT = 4
 _STREAM_CAPTURE_TAIL_MAX_LINES = 256
 _STREAM_CAPTURE_TAIL_MAX_CHARS = 64 * 1024
+_STREAM_CAPTURE_PENDING_MAX_CHARS = 64 * 1024
 
 
 @dataclass(frozen=True)
@@ -220,6 +221,8 @@ def _consume_stream_chunk(
         target.append(line)
         if line_handler is not None:
             line_handler(line)
+    if len(buffer) > _STREAM_CAPTURE_PENDING_MAX_CHARS:
+        buffer = buffer[-_STREAM_CAPTURE_PENDING_MAX_CHARS:]
     return buffer
 
 

--- a/tests/atelier/worker/test_session_agent.py
+++ b/tests/atelier/worker/test_session_agent.py
@@ -620,6 +620,36 @@ def test_consume_stream_chunk_flushes_split_lines_deterministically() -> None:
     ]
 
 
+def test_consume_stream_chunk_caps_pending_without_newlines() -> None:
+    captured: list[str] = []
+    handled: list[str] = []
+    max_pending = session_agent._STREAM_CAPTURE_PENDING_MAX_CHARS
+    source = "".join(str(i % 10) for i in range(max_pending + 128))
+
+    pending = session_agent._consume_stream_chunk(
+        chunk=source.encode(),
+        pending="",
+        target=captured,
+        line_handler=handled.append,
+    )
+
+    assert captured == []
+    assert handled == []
+    assert len(pending) == max_pending
+    assert pending == source[-max_pending:]
+
+    pending = session_agent._consume_stream_chunk(
+        chunk=b"\n",
+        pending=pending,
+        target=captured,
+        line_handler=handled.append,
+    )
+
+    assert pending == ""
+    assert captured == [source[-max_pending:]]
+    assert handled == [source[-max_pending:]]
+
+
 class _RealCommandOps:
     """Command ops using actual worker helpers (for integration-style tests)."""
 


### PR DESCRIPTION
# Summary

- Eliminate unbounded in-memory buffering of structured worker stdout/stderr capture during Codex/Claude non-trace sessions.

# Changes

- Added a bounded tail capture buffer in `worker/session/agent.py` and wired `_run_streaming_capture_command` to keep only a capped tail for `stdout`/`stderr` return fields.
- Preserved incremental stream parsing behavior for complete lines and trailing partial-line flush handling.
- Added regression tests for long-stream bounded capture and partial-line flushing in `tests/atelier/worker/test_session_agent.py`.

# Testing

- `just format`
- `just lint`
- `PYTHONPATH=src just test`

## Tickets

- None

# Risks / Rollout

- Low risk: change is scoped to structured stream capture internals and session-agent tests.

# Notes

- Trace mode behavior is unchanged; this only affects non-trace structured capture buffering.
