### PR TITLE
Add adversarial tests for structured worker stream edge cases

### DIFF
--- a/tests/atelier/worker/test_output.py
+++ b/tests/atelier/worker/test_output.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import pytest
-
 from atelier.worker.session import output_claude, output_codex
 from atelier.worker.session.output import (
     AgentOutputCapture,
@@ -254,7 +252,7 @@ def test_agent_output_capture_feed_stdout_text() -> None:
 
 
 def test_agent_output_capture_assistant_preview_text_truncates() -> None:
-    """assistant_preview_text returns clipped text when max_chars is provided."""
+    """assistant_preview_text clips preview text when max_chars is set."""
     capture = AgentOutputCapture(agent_name="codex")
     capture.feed_stdout_line(
         '{"type":"item.completed","item":{"type":"agent_message","text":"'
@@ -444,6 +442,34 @@ def test_agent_output_capture_codex_json_counts_events() -> None:
     summary = capture.render_summary_lines(failed=False)
     assert "Agent output (codex):" in summary[0]
     assert "events=2" in summary[0]
+    assert any("Assistant preview: Done" in line for line in summary)
+
+
+def test_agent_output_capture_codex_mixed_json_text_interleaving_is_deterministic() -> None:
+    """Mixed plain-text and JSON lines stay deterministic."""
+    capture = AgentOutputCapture(agent_name="codex")
+    capture.feed_stdout_line("status: bootstrapping workspace")
+    capture.feed_stdout_line('{"type":"thread.started","thread_id":"thread_1"}')
+    capture.feed_stdout_line('{"type":"schema.evolved","meta":{"version":2}}')
+    capture.feed_stdout_line(
+        '{"type":"item.completed","item":{"type":"command_execution","command":"bash -lc ls"}}'
+    )
+    capture.feed_stdout_line("assistant: hidden protocol noise")
+    capture.feed_stdout_line(
+        '{"type":"item.completed","item":{"type":"agent_message","text":"Done"}}'
+    )
+
+    assert capture.raw_line_count == 6
+    assert capture.structured_event_count == 4
+    assert capture.tool_event_count == 1
+    assert capture.suppressed_line_count == 1
+
+    summary = capture.render_summary_lines(failed=False)
+    assert "Agent output (codex): completed" in summary[0]
+    assert "events=4" in summary[0]
+    assert "tools=1" in summary[0]
+    assert "suppressed=1" in summary[0]
+    assert "meaningful=" not in summary[0]
     assert any("Assistant preview: Done" in line for line in summary)
 
 

--- a/tests/atelier/worker/test_session_agent.py
+++ b/tests/atelier/worker/test_session_agent.py
@@ -519,6 +519,48 @@ def test_start_agent_session_codex_emits_live_progress_updates(monkeypatch) -> N
     assert any("Agent output (codex): completed" in m for m in control.say_messages)
 
 
+def test_consume_stream_chunk_flushes_split_lines_deterministically() -> None:
+    captured: list[str] = []
+    handled: list[str] = []
+
+    pending = session_agent._consume_stream_chunk(
+        chunk=b'{"type":"turn.started"}\npartial',
+        pending="",
+        target=captured,
+        line_handler=handled.append,
+    )
+    assert pending == "partial"
+    assert captured == ['{"type":"turn.started"}']
+    assert handled == ['{"type":"turn.started"}']
+
+    pending = session_agent._consume_stream_chunk(
+        chunk=b' line\n{"type":"turn.completed","usage":{"output_tokens":1}}',
+        pending=pending,
+        target=captured,
+        line_handler=handled.append,
+    )
+    assert pending == '{"type":"turn.completed","usage":{"output_tokens":1}}'
+    assert captured == ['{"type":"turn.started"}', "partial line"]
+    assert handled == ['{"type":"turn.started"}', "partial line"]
+
+    session_agent._flush_stream_tail(
+        pending=pending,
+        target=captured,
+        line_handler=handled.append,
+    )
+
+    assert captured == [
+        '{"type":"turn.started"}',
+        "partial line",
+        '{"type":"turn.completed","usage":{"output_tokens":1}}',
+    ]
+    assert handled == [
+        '{"type":"turn.started"}',
+        "partial line",
+        '{"type":"turn.completed","usage":{"output_tokens":1}}',
+    ]
+
+
 class _RealCommandOps:
     """Command ops using actual worker helpers (for integration-style tests)."""
 
@@ -638,11 +680,67 @@ def test_start_agent_session_codex_trace_streams_raw_output(monkeypatch) -> None
     assert not any("Agent output (codex):" in line for line in control.say_messages)
 
 
+def test_start_agent_session_codex_failure_with_truncated_tail_uses_tail_diagnostic(
+    monkeypatch,
+) -> None:
+    def _run_streaming_capture_command(
+        *,
+        cmd: list[str],
+        cwd: Path | None,
+        env: dict[str, str],
+        stdout_line_handler=None,
+        stderr_line_handler=None,
+    ) -> session_agent._StreamedCommandResult | None:
+        del cmd, cwd, env, stderr_line_handler
+        if stdout_line_handler is not None:
+            stdout_line_handler(
+                '{"type":"item.completed","item":{"type":"agent_message","text":"Working"}}'
+            )
+            stdout_line_handler(
+                '{"type":"item.completed","item":{"type":"agent_message","text":"incomplete"'
+            )
+        return session_agent._StreamedCommandResult(returncode=1, stdout="", stderr="")
+
+    monkeypatch.setattr(
+        session_agent,
+        "_run_streaming_capture_command",
+        _run_streaming_capture_command,
+    )
+    agent = agent_home.AgentHome(
+        name="codex",
+        agent_id="atelier/worker/codex/p100",
+        role="worker",
+        path=Path("/tmp/agent-home"),
+    )
+    control = _TestControl()
+
+    result = session_agent.start_agent_session(
+        dry_run=False,
+        agent=agent,
+        agent_spec=_FakeAgentSpec(name="codex"),
+        agent_options=[],
+        opening_prompt="hello",
+        env={},
+        command_ops=_TestCommandOps(),
+        session_control=control,
+        blocked_handler=_TestBlockedHandler(),
+    )
+
+    assert result is None
+    assert any("Agent output (codex): failed" in line for line in control.say_messages)
+    assert any(
+        'Diagnostic: {"type":"item.completed","item":{"type":"agent_message","text":"incomplete"'
+        in line
+        for line in control.say_messages
+    )
+    assert any("ATELIER_WORK_AGENT_TRACE=1" in line for line in control.say_messages)
+
+
 def test_start_agent_session_claude_stream_json_renders_summary(
     monkeypatch,
     claude_session_fixture_content: str,
 ) -> None:
-    """Claude session uses fixture stdout; summary includes events and preview."""
+    """Claude fixture stdout renders a summary with events and preview text."""
     seen_cmds: list[list[str]] = []
 
     def _run_streaming_capture_command(


### PR DESCRIPTION
# Summary

Add adversarial coverage for structured worker stream handling so mixed content,
partial boundaries, and interrupted runs produce deterministic capture results.

# Changes

- added a codex capture test that interleaves plain text, structured JSON events,
  and an unknown schema-evolution event type, and asserts stable counters + summary
  rendering
- added chunk-assembly tests for `_consume_stream_chunk` and `_flush_stream_tail`
  to verify split-line reassembly and final pending-line flush behavior
- added a codex failure-path test for truncated tail content to verify deterministic
  fallback diagnostics in failed structured summaries
- removed an unused import and tightened touched docstrings to satisfy style checks

# Testing

- `uv run pytest tests/atelier/worker/test_output.py tests/atelier/worker/test_session_agent.py -q`
- `uv run ruff check tests/atelier/worker/test_output.py tests/atelier/worker/test_session_agent.py`

## Tickets

- None

# Risks / Rollout

- low risk; test-only changes

# Notes

- existing concise-output and trace-mode passthrough assertions remain covered in
  the same test modules and pass in this run
