### PR TITLE
Harden atelier open coverage for active changeset IDs

### DIFF
--- a/tests/atelier/commands/test_open.py
+++ b/tests/atelier/commands/test_open.py
@@ -417,6 +417,98 @@ def test_open_resolves_changeset_id_to_changeset_worktree() -> None:
         assert env["ATELIER_WORKSPACE"] == "feat/root-at-1my.1"
 
 
+@pytest.mark.parametrize("status", ["in_progress", "blocked"])
+def test_open_resolves_active_non_open_changeset_statuses_by_id(status: str) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        project_root = root / "project"
+        repo_root = root / "repo"
+        project_root.mkdir()
+        repo_root.mkdir()
+        project_data_dir = root / "data"
+        root_worktree_path = project_data_dir / "worktrees" / "epic-1"
+        root_worktree_path.mkdir(parents=True)
+        (root_worktree_path / ".git").write_text("gitdir: /tmp\n", encoding="utf-8")
+        changeset_worktree_path = project_data_dir / "worktrees" / "at-1my.1"
+        changeset_worktree_path.mkdir(parents=True)
+        (changeset_worktree_path / ".git").write_text("gitdir: /tmp\n", encoding="utf-8")
+
+        mapping = worktrees.WorktreeMapping(
+            epic_id="epic-1",
+            worktree_path="worktrees/epic-1",
+            root_branch="feat/root",
+            changesets={"at-1my.1": "feat/root-at-1my.1"},
+            changeset_worktrees={"at-1my.1": "worktrees/at-1my.1"},
+        )
+
+        project_config = config.ProjectConfig()
+        issue = _make_issue("feat/root", "worktrees/epic-1")
+        changeset_issue = _make_changeset_issue(
+            "at-1my.1",
+            "Child changeset",
+            work_branch="feat/root-at-1my.1",
+            status=status,
+        )
+        captured: dict[str, object] = {}
+
+        def fake_run(request: object, *, runner: object | None = None) -> object:
+            del runner
+            assert isinstance(request, open_cmd.exec.CommandRequest)
+            captured["cwd"] = request.cwd
+            captured["env"] = request.env
+            return open_cmd.exec.CommandResult(
+                argv=request.argv, returncode=0, stdout="", stderr=""
+            )
+
+        with (
+            patch(
+                "atelier.commands.open.resolve_current_project_with_repo_root",
+                return_value=(project_root, project_config, str(repo_root), repo_root),
+            ),
+            patch(
+                "atelier.commands.open.config.resolve_project_data_dir",
+                return_value=project_data_dir,
+            ),
+            patch(
+                "atelier.commands.open.config.resolve_beads_root",
+                return_value=Path("/beads"),
+            ),
+            patch("atelier.commands.open.beads.run_bd_command"),
+            patch("atelier.commands.open.beads.list_epics", return_value=[issue]),
+            patch(
+                "atelier.commands.open.beads.list_work_children",
+                return_value=[changeset_issue],
+            ),
+            patch(
+                "atelier.commands.open.beads.list_descendant_changesets",
+                return_value=[changeset_issue],
+            ),
+            patch("atelier.commands.open.worktrees.load_mapping", return_value=mapping),
+            patch(
+                "atelier.commands.open.worktrees.ensure_worktree_mapping",
+                return_value=mapping,
+            ),
+            patch("atelier.commands.open.exec.run_with_runner", fake_run),
+        ):
+            with pytest.raises(SystemExit) as raised:
+                open_cmd.open_worktree(
+                    SimpleNamespace(
+                        workspace_name="at-1my.1",
+                        raw=False,
+                        command=["pwd"],
+                        shell=None,
+                        workspace_root=False,
+                        set_title=False,
+                    )
+                )
+
+        assert raised.value.code == 0
+        assert captured["cwd"] == changeset_worktree_path
+        env = captured["env"]
+        assert env
+        assert env["ATELIER_WORKSPACE"] == "feat/root-at-1my.1"
+
+
 def test_open_prompts_for_workspace() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)


### PR DESCRIPTION
# Summary

This update strengthens `atelier open` changeset-centric behavior by locking in active lifecycle coverage.

## What changed

- Added regression coverage that verifies `atelier open <changeset-id>` resolves correctly when the changeset status is `in_progress`.
- Added regression coverage that verifies `atelier open <changeset-id>` resolves correctly when the changeset status is `blocked`.
- Asserted both status paths still open the mapped changeset worktree and expose the expected workspace environment.

## Why

`atelier open` is expected to treat active changesets (`open`, `in_progress`, `blocked`) as first-class open targets. This adds explicit tests so that contract cannot regress.

## Testing

- `just format`
- `just lint`
- `PYTHONPATH=src uv run --python 3.11 pytest tests/atelier/commands/test_open.py tests/atelier/commands/test_open_cli.py -q`
- `just test` *(fails in this branch on unrelated test: `tests/atelier/worker/test_session_agent.py::test_start_agent_session_codex_emits_live_progress_updates`)*

## Ticket

- Addresses #446
