### PR TITLE
Fix worker startup collisions between review feedback and dependency gates

### DIFF
--- a/src/atelier/worker/session/runner.py
+++ b/src/atelier/worker/session/runner.py
@@ -34,6 +34,10 @@ _TRANSIENT_PREPARE_WORKTREES_MARKERS = (
     "timed out",
 )
 _FOLLOWUP_STARTUP_REASONS = frozenset({"review_feedback", "merge_conflict"})
+_FOLLOWUP_DEPENDENCY_GATE_SOFT_FAILURE_MARKERS = (
+    "no issue found matching",
+    "no issues found matching the provided ids",
+)
 
 
 def _list_local_branches(*, repo_root: Path, git_path: str | None) -> tuple[str, ...]:
@@ -338,6 +342,13 @@ def _is_transient_prepare_worktrees_error(error: BaseException) -> bool:
     return any(marker in detail for marker in _TRANSIENT_PREPARE_WORKTREES_MARKERS)
 
 
+def _is_followup_dependency_gate_soft_failure(error: BaseException) -> bool:
+    if not isinstance(error, SystemExit):
+        return False
+    detail = _format_preparation_error_detail(error).lower()
+    return any(marker in detail for marker in _FOLLOWUP_DEPENDENCY_GATE_SOFT_FAILURE_MARKERS)
+
+
 def _dependency_has_work_children(
     *,
     beads: BeadsService,
@@ -437,7 +448,9 @@ def _startup_transition_decision(
             beads_root=beads_root,
             repo_root=repo_root,
         )
-    except SystemExit:
+    except SystemExit as exc:
+        if not _is_followup_dependency_gate_soft_failure(exc):
+            raise
         return _StartupTransitionDecision(
             False,
             "follow-up dependency gate unavailable (skipping status transition)",
@@ -1195,15 +1208,34 @@ def run_worker_once(
         finishstep = control.step("Mark changeset in progress", timings=timings, trace=trace)
         mark_step_extra = "skipped"
         if changeset_id:
-            transition = _startup_transition_decision(
-                issue=changeset,
-                dependency_ids=changeset_boundary.dependency_ids,
-                startup_reason=startup_result.reason,
-                branch_pr_strategy=project_config.branch.pr_strategy,
-                beads=infra.beads,
-                beads_root=beads_root,
-                repo_root=repo_root,
-            )
+            try:
+                transition = _startup_transition_decision(
+                    issue=changeset,
+                    dependency_ids=changeset_boundary.dependency_ids,
+                    startup_reason=startup_result.reason,
+                    branch_pr_strategy=project_config.branch.pr_strategy,
+                    beads=infra.beads,
+                    beads_root=beads_root,
+                    repo_root=repo_root,
+                )
+            except SystemExit as exc:
+                finishstep(extra=f"bd read failed (exit={exc.code})")
+                return finish(
+                    _abort_startup_read_failure(
+                        beads=infra.beads,
+                        lifecycle=lifecycle,
+                        control=control,
+                        selected_epic=selected_epic,
+                        agent_id=agent.agent_id,
+                        agent_bead_id=agent_bead_id_required,
+                        beads_root=beads_root,
+                        repo_root=repo_root,
+                        dry_run=dry_run,
+                        stage="evaluate startup dependency gate",
+                        verification_issue_id=str(changeset_id),
+                        reason="changeset_dependency_gate_read_failed",
+                    )
+                )
             if not transition.should_transition:
                 if dry_run:
                     control.dry_run_log(

--- a/tests/atelier/worker/test_session_runner_flow.py
+++ b/tests/atelier/worker/test_session_runner_flow.py
@@ -1188,13 +1188,105 @@ def test_run_worker_once_skips_redundant_mark_in_progress_for_in_progress_change
     deps.infra.worker_session_agent.start_agent_session.assert_called_once()
 
 
-def test_run_worker_once_review_feedback_dependency_gate_skip_is_non_blocking() -> None:
+def test_run_worker_once_followup_dependency_gate_skip_is_non_blocking() -> None:
+    for startup_reason in ("review_feedback", "merge_conflict"):
+        agent = AgentHome(
+            name="worker",
+            agent_id=f"atelier/worker/codex/p9b-{startup_reason}",
+            role="worker",
+            path=Path("/tmp/worker"),
+            session_key=f"p9b-{startup_reason}",
+        )
+        deps = _build_runner_deps(
+            startup_result=StartupContractResult(
+                epic_id="at-epic",
+                changeset_id="at-epic.2",
+                should_exit=False,
+                reason=startup_reason,
+            ),
+            preview_agent=agent,
+        )
+        selected_changeset = {
+            "id": "at-epic.2",
+            "title": "Follow-up",
+            "status": "open",
+            "labels": [],
+            "description": "",
+            "dependencies": ["at-epic.1"],
+        }
+        dependency_issue = {
+            "id": "at-epic.1",
+            "title": "Blocking dependency",
+            "status": "in_progress",
+            "labels": [],
+            "description": "",
+        }
+
+        def run_bd_json(args: list[str], *, beads_root: Path, cwd: Path) -> list[dict[str, object]]:  # noqa: ARG001
+            if args[:2] == ["show", "at-epic.2"]:
+                return [selected_changeset]
+            if args[:2] == ["show", "at-epic.1"]:
+                return [dependency_issue]
+            if args[:4] == ["list", "--parent", "at-epic.1", "--all"]:
+                return []
+            return []
+
+        deps.infra.beads.run_bd_json = Mock(side_effect=run_bd_json)
+        deps.lifecycle.resolve_epic_id_for_changeset = lambda _issue, **_kwargs: "at-epic"
+        deps.lifecycle.mark_changeset_in_progress = Mock()
+        deps.lifecycle.capture_review_feedback_snapshot = Mock(return_value=SimpleNamespace())
+        deps.infra.worker_session_worktree.prepare_worktrees = Mock(
+            return_value=SimpleNamespace(
+                epic_worktree_path=Path("/tmp/epic"),
+                changeset_worktree_path=Path("/tmp/changeset"),
+                branch="feat/root-at-epic.2",
+            )
+        )
+        deps.infra.worker_session_agent.prepare_agent_session = Mock(
+            return_value=SimpleNamespace(
+                agent_spec=SimpleNamespace(name="demo", display_name="Demo"),
+                agent_options=[],
+                project_enlistment=Path("/repo"),
+                workspace_branch="feat/root",
+                env={},
+            )
+        )
+        deps.infra.worker_session_agent.start_agent_session = Mock(
+            return_value=SimpleNamespace(
+                started_at=dt.datetime.now(dt.timezone.utc),
+                returncode=0,
+            )
+        )
+        deps.lifecycle.finalize_changeset = lambda **_kwargs: FinalizeResult(
+            continue_running=False,
+            reason="done",
+        )
+
+        summary = runner.run_worker_once(
+            SimpleNamespace(epic_id=None, queue=False, yes=False, reconcile=False),
+            run_context=WorkerRunContext(
+                mode="auto", dry_run=False, session_key=f"p9b-{startup_reason}"
+            ),
+            deps=deps,
+        )
+
+        assert summary.started is False
+        assert summary.reason == "done"
+        deps.lifecycle.mark_changeset_in_progress.assert_not_called()
+        deps.infra.worker_session_agent.start_agent_session.assert_called_once()
+        assert any(
+            "follow-up dependency gate still active" in str(call.args[0])
+            for call in deps.control._say.call_args_list
+        )
+
+
+def test_run_worker_once_releases_epic_when_dependency_gate_read_fails() -> None:
     agent = AgentHome(
         name="worker",
-        agent_id="atelier/worker/codex/p9b",
+        agent_id="atelier/worker/codex/p9c",
         role="worker",
         path=Path("/tmp/worker"),
-        session_key="p9b",
+        session_key="p9c",
     )
     deps = _build_runner_deps(
         startup_result=StartupContractResult(
@@ -1207,33 +1299,26 @@ def test_run_worker_once_review_feedback_dependency_gate_skip_is_non_blocking() 
     )
     selected_changeset = {
         "id": "at-epic.2",
-        "title": "Review follow-up",
+        "title": "Follow-up",
         "status": "open",
         "labels": [],
         "description": "",
         "dependencies": ["at-epic.1"],
-    }
-    dependency_issue = {
-        "id": "at-epic.1",
-        "title": "Blocking dependency",
-        "status": "in_progress",
-        "labels": [],
-        "description": "",
     }
 
     def run_bd_json(args: list[str], *, beads_root: Path, cwd: Path) -> list[dict[str, object]]:  # noqa: ARG001
         if args[:2] == ["show", "at-epic.2"]:
             return [selected_changeset]
         if args[:2] == ["show", "at-epic.1"]:
-            return [dependency_issue]
-        if args[:4] == ["list", "--parent", "at-epic.1", "--all"]:
-            return []
+            raise SystemExit(1)
         return []
 
     deps.infra.beads.run_bd_json = Mock(side_effect=run_bd_json)
     deps.lifecycle.resolve_epic_id_for_changeset = lambda _issue, **_kwargs: "at-epic"
     deps.lifecycle.mark_changeset_in_progress = Mock()
     deps.lifecycle.capture_review_feedback_snapshot = Mock(return_value=SimpleNamespace())
+    deps.lifecycle.release_epic_assignment = Mock()
+    deps.lifecycle.send_planner_notification = Mock()
     deps.infra.worker_session_worktree.prepare_worktrees = Mock(
         return_value=SimpleNamespace(
             epic_worktree_path=Path("/tmp/epic"),
@@ -1241,37 +1326,27 @@ def test_run_worker_once_review_feedback_dependency_gate_skip_is_non_blocking() 
             branch="feat/root-at-epic.2",
         )
     )
-    deps.infra.worker_session_agent.prepare_agent_session = Mock(
-        return_value=SimpleNamespace(
-            agent_spec=SimpleNamespace(name="demo", display_name="Demo"),
-            agent_options=[],
-            project_enlistment=Path("/repo"),
-            workspace_branch="feat/root",
-            env={},
-        )
-    )
-    deps.infra.worker_session_agent.start_agent_session = Mock(
-        return_value=SimpleNamespace(
-            started_at=dt.datetime.now(dt.timezone.utc),
-            returncode=0,
-        )
-    )
-    deps.lifecycle.finalize_changeset = lambda **_kwargs: FinalizeResult(
-        continue_running=False,
-        reason="done",
-    )
 
     summary = runner.run_worker_once(
         SimpleNamespace(epic_id=None, queue=False, yes=False, reconcile=False),
-        run_context=WorkerRunContext(mode="auto", dry_run=False, session_key="p9b"),
+        run_context=WorkerRunContext(mode="auto", dry_run=False, session_key="p9c"),
         deps=deps,
     )
 
     assert summary.started is False
-    assert summary.reason == "done"
-    deps.lifecycle.mark_changeset_in_progress.assert_not_called()
-    deps.infra.worker_session_agent.start_agent_session.assert_called_once()
-    assert any(
-        "follow-up dependency gate still active" in str(call.args[0])
-        for call in deps.control._say.call_args_list
+    assert summary.reason == "changeset_dependency_gate_read_failed"
+    assert summary.epic_id == "at-epic"
+    deps.lifecycle.send_planner_notification.assert_called_once()
+    deps.lifecycle.release_epic_assignment.assert_called_once_with(
+        "at-epic",
+        beads_root=Path("/project/.atelier/.beads"),
+        repo_root=Path("/repo"),
     )
+    deps.infra.beads.clear_agent_hook.assert_called_once_with(
+        "at-agent",
+        beads_root=Path("/project/.atelier/.beads"),
+        cwd=Path("/repo"),
+        expected_hook="at-epic",
+    )
+    deps.lifecycle.mark_changeset_in_progress.assert_not_called()
+    deps.infra.worker_session_agent.start_agent_session.assert_not_called()


### PR DESCRIPTION
# Summary

This change fixes worker startup collisions where a review-feedback follow-up could select a changeset and then fail before agent launch when dependency gates blocked a forced `in_progress` transition.

# Changes

- Added startup transition decision logic in the worker session runner to avoid forced status transitions in follow-up flows when they are not safe.
- Added dependency-gate checks for follow-up transitions so dependency-blocked changesets are handled without fail-closed startup aborts.
- Skipped redundant `status=in_progress` updates when the selected changeset is already `in_progress`.
- Added regression tests for:
  - redundant in-progress transition suppression
  - review-feedback startup selection with an active dependency gate

# Testing

- `PYTHONPATH=src just format`
- `PYTHONPATH=src just lint`
- `PYTHONPATH=src just test`

# Tickets

- Fixes #455

# Risks / Rollout

- Low risk: behavior is constrained to worker startup transition handling and covered by new tests.

# Notes

- Startup now keeps deterministic follow-up behavior for review-feedback and merge-conflict flows when transition gates are not satisfied.
