### PR TITLE
Fail closed startup preflight for legacy prefix drift

### DIFF
--- a/src/atelier/prefix_migration_drift.py
+++ b/src/atelier/prefix_migration_drift.py
@@ -274,6 +274,34 @@ def _record(
     }
 
 
+def _system_exit_code(exc: SystemExit) -> int:
+    code = exc.code
+    if isinstance(code, int):
+        return code
+    return 1
+
+
+def _metadata_read_failure_record(
+    *,
+    epic_id: str,
+    changeset_id: str,
+    target_kind: str,
+    target_id: str,
+    exit_code: int,
+) -> dict[str, object]:
+    return _record(
+        epic_id=epic_id,
+        changeset_id=changeset_id,
+        drift_class="metadata-read-failure",
+        values={
+            "bd.command": f"show {target_id}",
+            "bd.exit_code": str(exit_code),
+            "lookup.target_kind": target_kind,
+            "lookup.target_id": target_id,
+        },
+    )
+
+
 def _canonical_root_branch(*values: str | None) -> str | None:
     for value in values:
         if value is not None:
@@ -702,8 +730,16 @@ def scan_prefix_migration_drift(
                 beads_root=beads_root,
                 cwd=repo_root,
             )
-        except SystemExit:
-            scoped_epics = []
+        except SystemExit as exc:
+            return [
+                _metadata_read_failure_record(
+                    epic_id=scoped_epic_id,
+                    changeset_id=scoped_epic_id,
+                    target_kind="epic",
+                    target_id=scoped_epic_id,
+                    exit_code=_system_exit_code(exc),
+                )
+            ]
         epics = [
             issue for issue in scoped_epics if _normalize_text(issue.get("id")) == scoped_epic_id
         ]
@@ -726,7 +762,16 @@ def scan_prefix_migration_drift(
                         beads_root=beads_root,
                         cwd=repo_root,
                     )
-                except SystemExit:
+                except SystemExit as exc:
+                    records.append(
+                        _metadata_read_failure_record(
+                            epic_id=epic_id,
+                            changeset_id=changeset_id,
+                            target_kind="changeset",
+                            target_id=changeset_id,
+                            exit_code=_system_exit_code(exc),
+                        )
+                    )
                     continue
                 for issue in scoped_changesets:
                     issue_id = _normalize_text(issue.get("id"))

--- a/src/atelier/worker/session/worktree.py
+++ b/src/atelier/worker/session/worktree.py
@@ -42,6 +42,7 @@ class WorktreePreparationControl(Protocol):
 
 _BLOCKING_PREFIX_DRIFT_CLASSES = frozenset(
     {
+        "metadata-read-failure",
         "root-branch-conflict",
         "work-branch-conflict",
         "worktree-path-conflict",

--- a/tests/atelier/test_prefix_migration_drift.py
+++ b/tests/atelier/test_prefix_migration_drift.py
@@ -260,6 +260,76 @@ def test_scan_prefix_migration_drift_scopes_to_selected_epic_and_changesets(
     list_work_children.assert_not_called()
 
 
+def test_scan_prefix_migration_drift_records_targeted_changeset_read_failure(
+    tmp_path: Path,
+) -> None:
+    project_data_dir = tmp_path / "data"
+    repo_root = tmp_path / "repo"
+    project_data_dir.mkdir(parents=True)
+    repo_root.mkdir(parents=True)
+
+    epic_issue = {
+        "id": "ts-epic",
+        "labels": ["at:epic"],
+        "description": "workspace.root_branch: feat/new-root\n",
+    }
+
+    def fake_show(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> list[dict[str, object]]:
+        del beads_root, cwd
+        if args == ["show", "ts-epic"]:
+            return [epic_issue]
+        if args == ["show", "ts-epic.1"]:
+            raise SystemExit(7)
+        raise AssertionError(f"unexpected bd command: {args!r}")
+
+    with (
+        patch("atelier.prefix_migration_drift.beads.run_bd_json", side_effect=fake_show),
+        patch("atelier.prefix_migration_drift.beads.list_epics") as list_epics,
+        patch(
+            "atelier.prefix_migration_drift.beads.list_descendant_changesets"
+        ) as list_descendants,
+        patch("atelier.prefix_migration_drift.beads.list_work_children") as list_work_children,
+        patch(
+            "atelier.prefix_migration_drift.exec_util.try_run_command",
+            return_value=subprocess.CompletedProcess(
+                args=["git", "worktree", "list", "--porcelain"],
+                returncode=0,
+                stdout="",
+                stderr="",
+            ),
+        ),
+    ):
+        records = prefix_migration_drift.scan_prefix_migration_drift(
+            project_data_dir=project_data_dir,
+            beads_root=tmp_path / ".beads",
+            repo_root=repo_root,
+            target_epic_id="ts-epic",
+            target_changeset_ids={"ts-epic.1"},
+        )
+
+    assert records == [
+        {
+            "epic_id": "ts-epic",
+            "changeset_id": "ts-epic.1",
+            "drift_class": "metadata-read-failure",
+            "values": {
+                "bd.command": "show ts-epic.1",
+                "bd.exit_code": "7",
+                "lookup.target_id": "ts-epic.1",
+                "lookup.target_kind": "changeset",
+            },
+        }
+    ]
+    list_epics.assert_not_called()
+    list_descendants.assert_not_called()
+    list_work_children.assert_not_called()
+
+
 def test_repair_prefix_migration_drift_plans_updates_without_applying(tmp_path: Path) -> None:
     project_data_dir = tmp_path / "data"
     repo_root = tmp_path / "repo"

--- a/tests/atelier/worker/test_session_worktree.py
+++ b/tests/atelier/worker/test_session_worktree.py
@@ -144,6 +144,79 @@ def test_prepare_worktrees_blocks_before_mutations_on_prefix_drift_for_selected_
     assert not logs
 
 
+def test_prepare_worktrees_blocks_before_mutations_on_targeted_metadata_read_failure() -> None:
+    logs: list[str] = []
+    reconcile_mapping = Mock()
+    ensure_epic_worktree = Mock()
+    ensure_changeset_branch = Mock()
+    scan_drift = Mock(
+        return_value=[
+            {
+                "epic_id": "at-epic",
+                "changeset_id": "at-epic.1",
+                "drift_class": "metadata-read-failure",
+                "values": {
+                    "bd.command": "show at-epic.1",
+                    "bd.exit_code": "7",
+                    "lookup.target_kind": "changeset",
+                    "lookup.target_id": "at-epic.1",
+                },
+            }
+        ]
+    )
+
+    with (
+        patch(
+            "atelier.worker.session.worktree.prefix_migration_drift.scan_prefix_migration_drift",
+            scan_drift,
+        ),
+        patch("atelier.worker.session.worktree.git.git_origin_url", return_value=None),
+        patch("atelier.worker.session.worktree.prs.github_repo_slug", return_value=None),
+        patch(
+            "atelier.worker.session.worktree.worktrees.reconcile_mapping_ownership",
+            reconcile_mapping,
+        ),
+        patch(
+            "atelier.worker.session.worktree.worktrees.ensure_git_worktree",
+            ensure_epic_worktree,
+        ),
+        patch(
+            "atelier.worker.session.worktree.worktrees.ensure_changeset_branch",
+            ensure_changeset_branch,
+        ),
+    ):
+        with pytest.raises(RuntimeError, match="drift_class=metadata-read-failure"):
+            worktree.prepare_worktrees(
+                context=worktree.WorktreePreparationContext(
+                    dry_run=False,
+                    project_data_dir=Path("/project"),
+                    repo_root=Path("/repo"),
+                    beads_root=Path("/beads"),
+                    selected_epic="at-epic",
+                    changeset_id="at-epic.1",
+                    root_branch_value="feat/new",
+                    changeset_parent_branch="feat/new",
+                    allow_parent_branch_override=False,
+                    git_path="git",
+                ),
+                control=_TestControl(logs),
+            )
+
+    scan_drift.assert_called_once_with(
+        project_data_dir=Path("/project"),
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+        repo_slug=None,
+        git_path="git",
+        target_epic_id="at-epic",
+        target_changeset_ids={"at-epic", "at-epic.1"},
+    )
+    reconcile_mapping.assert_not_called()
+    ensure_epic_worktree.assert_not_called()
+    ensure_changeset_branch.assert_not_called()
+    assert not logs
+
+
 def test_prepare_worktrees_reconciles_ownership_before_worktree_setup(tmp_path: Path) -> None:
     logs: list[str] = []
     repo_root = tmp_path / "repo"


### PR DESCRIPTION
# Summary

- Add a fail-closed startup preflight that detects legacy prefix-migration drift before worker startup mutates worktree metadata.

# Changes

- Added a read-only startup preflight in worker worktree preparation that:
  - scans prefix migration drift for the selected epic/changeset,
  - detects high-risk lineage override mismatches for epic-as-changeset startup,
  - blocks startup with deterministic diagnostics and explicit remediation guidance.
- Wired preflight execution to run before any mapping ownership reconciliation, branch metadata updates, or worktree checkout mutations.
- Updated worker session worktree tests to assert fail-closed behavior for migration drift scenarios.
- Added regression coverage that confirms startup blocks before any mutation when selected changeset drift is detected.

# Testing

- `just format`
- `just lint`
- `just test`

# Tickets

- Fixes #480

# Risks / Rollout

- Startup now blocks earlier when migration drift exists; operators must run remediation (`atelier doctor --fix`) before retrying.

# Notes

- This change is read-only detection + fail-closed startup behavior only; it does not auto-normalize drifted state.
