### PR TITLE
Make planner startup triage use a canonical command plan

### DIFF
--- a/src/atelier/planner_startup_check.py
+++ b/src/atelier/planner_startup_check.py
@@ -1,0 +1,311 @@
+"""Deterministic planner-startup command planning and Beads invocation helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from . import beads, lifecycle, messages
+
+_SUPPORTED_LIST_FLAGS = frozenset({"--label", "--assignee", "--all", "--limit", "--parent"})
+_LIST_FLAGS_REQUIRING_VALUE = frozenset({"--label", "--assignee", "--limit", "--parent"})
+_FORBIDDEN_INVOCATION_PREFIXES = ("--db", "--db=", "--beads-dir", "--beads-dir=")
+
+
+@dataclass(frozen=True)
+class StartupCommandStep:
+    """Metadata for one fixed planner-startup command step.
+
+    Attributes:
+        name: Stable command identity used by the startup executor.
+        inputs: Explicit input names consumed by the command.
+        output: Explicit output field produced by the command.
+    """
+
+    name: str
+    inputs: tuple[str, ...]
+    output: str
+
+
+@dataclass(frozen=True)
+class StartupCommandResult:
+    """Structured outputs from the canonical startup command plan."""
+
+    inbox_messages: list[dict[str, object]]
+    queued_messages: list[dict[str, object]]
+    epics: list[dict[str, object]]
+    parity_report: beads.EpicDiscoveryParityReport
+
+
+_STARTUP_COMMAND_PLAN: tuple[StartupCommandStep, ...] = (
+    StartupCommandStep(
+        name="list_inbox_unread_messages",
+        inputs=("agent_id",),
+        output="inbox_messages",
+    ),
+    StartupCommandStep(
+        name="list_queue_unread_messages",
+        inputs=(),
+        output="queued_messages",
+    ),
+    StartupCommandStep(
+        name="list_indexed_epics",
+        inputs=(),
+        output="epics",
+    ),
+    StartupCommandStep(
+        name="compute_epic_discovery_parity",
+        inputs=("epics",),
+        output="parity_report",
+    ),
+)
+
+
+def startup_command_plan() -> tuple[StartupCommandStep, ...]:
+    """Return the canonical planner-startup command plan in execution order.
+
+    Returns:
+        Ordered startup command steps with explicit input and output contracts.
+    """
+
+    return _STARTUP_COMMAND_PLAN
+
+
+def validate_startup_list_invocation(args: list[str]) -> None:
+    """Validate a startup helper `bd list` invocation.
+
+    Args:
+        args: `bd` arguments without the leading binary name.
+
+    Raises:
+        ValueError: If the invocation uses unsupported syntax or forbidden flags.
+    """
+
+    if not args:
+        raise ValueError("startup helper requires a non-empty bd invocation")
+    if args[0] != "list":
+        raise ValueError("startup helper supports only `bd list` invocations")
+
+    index = 1
+    while index < len(args):
+        token = str(args[index]).strip()
+        lower = token.lower()
+        if any(
+            lower == blocked or lower.startswith(blocked)
+            for blocked in _FORBIDDEN_INVOCATION_PREFIXES
+        ):
+            raise ValueError(f"forbidden startup bd invocation flag: {token}")
+        if lower == "--json":
+            raise ValueError("startup helper manages JSON mode; do not pass --json")
+        if token.startswith("--"):
+            if token not in _SUPPORTED_LIST_FLAGS:
+                raise ValueError(f"unsupported startup bd list flag: {token}")
+            if token in _LIST_FLAGS_REQUIRING_VALUE:
+                if index + 1 >= len(args):
+                    raise ValueError(f"startup bd list flag requires a value: {token}")
+                value = str(args[index + 1]).strip()
+                if not value or value.startswith("--"):
+                    raise ValueError(f"startup bd list flag requires a value: {token}")
+                index += 2
+                continue
+        index += 1
+
+
+@dataclass(frozen=True)
+class StartupBeadsInvocationHelper:
+    """Shared Beads helper for planner-startup command execution."""
+
+    beads_root: Path
+    cwd: Path
+
+    def _run_list_query(self, args: list[str]) -> list[dict[str, object]]:
+        validate_startup_list_invocation(args)
+        return beads.run_bd_json(args, beads_root=self.beads_root, cwd=self.cwd)
+
+    def list_inbox_messages(
+        self,
+        agent_id: str,
+        *,
+        unread_only: bool = True,
+    ) -> list[dict[str, object]]:
+        """List planner inbox messages via the canonical startup helper path."""
+
+        args = [
+            "list",
+            "--label",
+            beads.issue_label("message", beads_root=self.beads_root),
+            "--assignee",
+            agent_id,
+        ]
+        if unread_only:
+            args.extend(["--label", beads.issue_label("unread", beads_root=self.beads_root)])
+        return self._run_list_query(args)
+
+    def list_queue_messages(
+        self,
+        *,
+        queue: str | None = None,
+        unclaimed_only: bool = True,
+        unread_only: bool = True,
+    ) -> list[dict[str, object]]:
+        """List queued message beads from deterministic startup queries."""
+
+        args = ["list", "--label", beads.issue_label("message", beads_root=self.beads_root)]
+        if unread_only:
+            args.extend(["--label", beads.issue_label("unread", beads_root=self.beads_root)])
+        issues = self._run_list_query(args)
+        matches: list[dict[str, object]] = []
+        for issue in issues:
+            description = issue.get("description")
+            if not isinstance(description, str):
+                continue
+            payload = messages.parse_message(description)
+            queue_name = payload.metadata.get("queue")
+            if not isinstance(queue_name, str) or not queue_name.strip():
+                continue
+            if queue is not None and queue_name != queue:
+                continue
+            claimed_by = payload.metadata.get("claimed_by")
+            assignee = issue.get("assignee")
+            assignee_claim = (
+                assignee.strip() if isinstance(assignee, str) and assignee.strip() else None
+            )
+            normalized_claim = (
+                claimed_by.strip()
+                if isinstance(claimed_by, str) and claimed_by.strip()
+                else assignee_claim
+            )
+            if unclaimed_only and normalized_claim:
+                continue
+            enriched = dict(issue)
+            enriched["queue"] = queue_name
+            enriched["claimed_by"] = normalized_claim
+            matches.append(enriched)
+        return matches
+
+    def list_epics(self, *, include_closed: bool = False) -> list[dict[str, object]]:
+        """List epic beads via fixed `<prefix>:epic` discovery."""
+
+        args = [
+            "list",
+            "--label",
+            beads.issue_label("epic", beads_root=self.beads_root),
+            "--all",
+            "--limit",
+            "0",
+        ]
+        issues = self._run_list_query(args)
+        if include_closed:
+            return issues
+        return [
+            issue
+            for issue in issues
+            if lifecycle.canonical_lifecycle_status(issue.get("status")) != "closed"
+        ]
+
+    def list_work_children(
+        self,
+        parent_id: str,
+        *,
+        include_closed: bool = False,
+    ) -> list[dict[str, object]]:
+        """List direct child work beads for a parent issue."""
+
+        args = ["list", "--parent", parent_id]
+        if include_closed:
+            args.append("--all")
+        issues = self._run_list_query(args)
+        return [
+            issue
+            for issue in issues
+            if lifecycle.is_work_issue(
+                labels=lifecycle.normalized_labels(issue.get("labels")),
+                issue_type=lifecycle.issue_payload_type(issue),
+            )
+        ]
+
+    def list_descendant_changesets(
+        self,
+        parent_id: str,
+        *,
+        include_closed: bool = False,
+    ) -> list[dict[str, object]]:
+        """List descendant changesets (leaf work beads under a parent)."""
+
+        descendants: list[dict[str, object]] = []
+        seen: set[str] = set()
+        queue = [parent_id]
+        while queue:
+            current = queue.pop(0)
+            children = self.list_work_children(current, include_closed=include_closed)
+            for issue in children:
+                issue_id = str(issue.get("id") or "").strip()
+                if not issue_id or issue_id in seen:
+                    continue
+                seen.add(issue_id)
+                grandchildren = self.list_work_children(issue_id, include_closed=include_closed)
+                if not grandchildren:
+                    descendants.append(issue)
+                queue.append(issue_id)
+        return descendants
+
+    def epic_discovery_parity_report(
+        self,
+        *,
+        indexed_epics: list[dict[str, object]],
+    ) -> beads.EpicDiscoveryParityReport:
+        """Return startup epic discovery parity diagnostics."""
+
+        return beads.epic_discovery_parity_report(
+            beads_root=self.beads_root,
+            cwd=self.cwd,
+            indexed_epics=indexed_epics,
+        )
+
+
+def execute_startup_command_plan(
+    agent_id: str,
+    *,
+    helper: StartupBeadsInvocationHelper,
+) -> StartupCommandResult:
+    """Execute the canonical startup command plan in fixed order.
+
+    Args:
+        agent_id: Planner agent id used for inbox lookup.
+        helper: Shared Beads invocation helper bound to beads root + repo cwd.
+
+    Returns:
+        Structured startup command outputs.
+
+    Raises:
+        RuntimeError: If the plan contains an unknown step.
+    """
+
+    inbox_messages: list[dict[str, object]] = []
+    queued_messages: list[dict[str, object]] = []
+    epics: list[dict[str, object]] = []
+    parity_report: beads.EpicDiscoveryParityReport | None = None
+
+    for step in startup_command_plan():
+        if step.name == "list_inbox_unread_messages":
+            inbox_messages = helper.list_inbox_messages(agent_id, unread_only=True)
+            continue
+        if step.name == "list_queue_unread_messages":
+            queued_messages = helper.list_queue_messages(unclaimed_only=False, unread_only=True)
+            continue
+        if step.name == "list_indexed_epics":
+            epics = helper.list_epics(include_closed=False)
+            continue
+        if step.name == "compute_epic_discovery_parity":
+            parity_report = helper.epic_discovery_parity_report(indexed_epics=epics)
+            continue
+        raise RuntimeError(f"unknown startup command step: {step.name}")
+
+    if parity_report is None:
+        parity_report = helper.epic_discovery_parity_report(indexed_epics=epics)
+    return StartupCommandResult(
+        inbox_messages=inbox_messages,
+        queued_messages=queued_messages,
+        epics=epics,
+        parity_report=parity_report,
+    )

--- a/src/atelier/skills/planner-startup-check/SKILL.md
+++ b/src/atelier/skills/planner-startup-check/SKILL.md
@@ -37,6 +37,26 @@ during startup triage. Do not wait for approval to capture deferred work.
      `bd update <id> --type epic --add-label at:epic`
    - `cs:*` lifecycle labels are not execution gates.
 
+## Canonical startup command plan
+
+Planner startup triage uses a fixed ordered command plan with explicit I/O:
+
+1. `list_inbox_unread_messages`
+   - inputs: `agent_id`
+   - output: `inbox_messages`
+1. `list_queue_unread_messages`
+   - inputs: none
+   - output: `queued_messages`
+1. `list_indexed_epics`
+   - inputs: none
+   - output: `epics`
+1. `compute_epic_discovery_parity`
+   - inputs: `epics`
+   - output: `parity_report`
+
+All Beads invocations in this flow run through the shared startup helper and
+reject unsupported invocation forms.
+
 ## Verification
 
 - Inbox and queue are processed before planning work starts.

--- a/src/atelier/skills/planner-startup-check/scripts/refresh_overview.py
+++ b/src/atelier/skills/planner-startup-check/scripts/refresh_overview.py
@@ -8,8 +8,13 @@ import os
 import sys
 from pathlib import Path
 
-from atelier import beads, lifecycle, planner_overview
+from atelier import lifecycle, planner_overview
 from atelier.beads_context import resolve_skill_beads_context
+from atelier.planner_startup_check import (
+    StartupBeadsInvocationHelper,
+    StartupCommandResult,
+    execute_startup_command_plan,
+)
 
 DEFAULT_DEFERRED_EPIC_SCAN_LIMIT = 25
 
@@ -30,8 +35,7 @@ def _queue_claim_state(issue: dict[str, object]) -> str:
 def _deferred_descendant_changesets(
     epics: list[dict[str, object]],
     *,
-    beads_root: Path,
-    repo_root: Path,
+    helper: StartupBeadsInvocationHelper,
 ) -> tuple[list[tuple[dict[str, object], list[dict[str, object]]]], int, int]:
     scan_limit = _deferred_epic_scan_limit()
     groups: list[tuple[dict[str, object], list[dict[str, object]]]] = []
@@ -51,10 +55,8 @@ def _deferred_descendant_changesets(
     skipped_epics = max(0, len(active_epics) - len(scanned_epics))
     for epic in scanned_epics:
         epic_id = str(epic.get("id") or "").strip()
-        descendants = beads.list_descendant_changesets(
+        descendants = helper.list_descendant_changesets(
             epic_id,
-            beads_root=beads_root,
-            cwd=repo_root,
             include_closed=False,
         )
         deferred = [
@@ -82,13 +84,11 @@ def _append_deferred_changeset_summary(
     lines: list[str],
     epics: list[dict[str, object]],
     *,
-    beads_root: Path,
-    repo_root: Path,
+    helper: StartupBeadsInvocationHelper,
 ) -> None:
     groups, skipped_epics, scan_limit = _deferred_descendant_changesets(
         epics,
-        beads_root=beads_root,
-        repo_root=repo_root,
+        helper=helper,
     )
     if not groups:
         lines.append("No deferred changesets under open/in-progress/blocked epics.")
@@ -132,12 +132,19 @@ def _resolve_context(*, beads_dir: str | None) -> tuple[Path, Path, str | None]:
     return context.beads_root, context.repo_root, context.override_warning
 
 
+def _startup_helper(*, beads_root: Path, repo_root: Path) -> StartupBeadsInvocationHelper:
+    return StartupBeadsInvocationHelper(beads_root=beads_root, cwd=repo_root)
+
+
 def _render_startup_overview(agent_id: str, *, beads_root: Path, repo_root: Path) -> str:
     lines: list[str] = ["Planner startup overview", f"- Beads root: {beads_root}"]
-
-    inbox = beads.list_inbox_messages(
-        agent_id, beads_root=beads_root, cwd=repo_root, unread_only=True
+    helper = _startup_helper(beads_root=beads_root, repo_root=repo_root)
+    command_result: StartupCommandResult = execute_startup_command_plan(
+        agent_id,
+        helper=helper,
     )
+
+    inbox = command_result.inbox_messages
     if inbox:
         lines.append("Unread messages:")
         for issue in sorted(inbox, key=_issue_sort_key):
@@ -145,12 +152,7 @@ def _render_startup_overview(agent_id: str, *, beads_root: Path, repo_root: Path
     else:
         lines.append("No unread messages.")
 
-    queued = beads.list_queue_messages(
-        beads_root=beads_root,
-        cwd=repo_root,
-        unread_only=True,
-        unclaimed_only=False,
-    )
+    queued = command_result.queued_messages
     if queued:
         lines.append("Queued messages:")
         for issue in sorted(queued, key=_issue_sort_key):
@@ -161,13 +163,9 @@ def _render_startup_overview(agent_id: str, *, beads_root: Path, repo_root: Path
     else:
         lines.append("No queued messages.")
 
-    epics = planner_overview.list_epics(beads_root=beads_root, repo_root=repo_root)
+    epics = command_result.epics
     lines.append(f"- Total epics: {len(epics)}")
-    parity = beads.epic_discovery_parity_report(
-        beads_root=beads_root,
-        cwd=repo_root,
-        indexed_epics=epics,
-    )
+    parity = command_result.parity_report
     lines.append(
         f"- Active top-level work (open/in_progress/blocked): {parity.active_top_level_work_count}"
     )
@@ -195,8 +193,7 @@ def _render_startup_overview(agent_id: str, *, beads_root: Path, repo_root: Path
     _append_deferred_changeset_summary(
         lines,
         epics,
-        beads_root=beads_root,
-        repo_root=repo_root,
+        helper=helper,
     )
     lines.extend(planner_overview.render_epics(epics, show_drafts=True).splitlines())
     return "\n".join(lines)

--- a/tests/atelier/skills/test_planner_startup_refresh_script.py
+++ b/tests/atelier/skills/test_planner_startup_refresh_script.py
@@ -27,17 +27,40 @@ def _parity_ok() -> SimpleNamespace:
     )
 
 
+def _startup_result(
+    module,
+    *,
+    inbox: list[dict[str, object]],
+    queued: list[dict[str, object]],
+    epics: list[dict[str, object]],
+    parity: object,
+):
+    return module.StartupCommandResult(
+        inbox_messages=inbox,
+        queued_messages=queued,
+        epics=epics,
+        parity_report=parity,
+    )
+
+
 def test_render_startup_overview_reports_empty_sections(monkeypatch) -> None:
     module = _load_script()
-    monkeypatch.setattr(module.beads, "list_inbox_messages", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(module.beads, "list_queue_messages", lambda **_kwargs: [])
-    monkeypatch.setattr(module.beads, "list_descendant_changesets", lambda *_args, **_kwargs: [])
     monkeypatch.setattr(
-        module.beads,
-        "epic_discovery_parity_report",
-        lambda **_kwargs: _parity_ok(),
+        module,
+        "execute_startup_command_plan",
+        lambda *_args, **_kwargs: _startup_result(
+            module,
+            inbox=[],
+            queued=[],
+            epics=[],
+            parity=_parity_ok(),
+        ),
     )
-    monkeypatch.setattr(module.planner_overview, "list_epics", lambda **_kwargs: [])
+    monkeypatch.setattr(
+        module.StartupBeadsInvocationHelper,
+        "list_descendant_changesets",
+        lambda *_args, **_kwargs: [],
+    )
     monkeypatch.setattr(
         module.planner_overview,
         "render_epics",
@@ -87,15 +110,8 @@ def test_render_startup_overview_lists_claim_state_and_sorts_messages(monkeypatc
     ]
     calls: dict[str, object] = {}
 
-    def _fake_list_inbox_messages(*_args, **_kwargs):
-        return inbox
-
-    def _fake_list_queue_messages(**kwargs):
-        calls["queue_kwargs"] = kwargs
-        return queued
-
-    def _fake_list_descendant_changesets(parent_id: str, **kwargs):
-        calls.setdefault("descendant_calls", []).append((parent_id, kwargs))
+    def _fake_list_descendant_changesets(_self, parent_id: str, *, include_closed: bool):
+        calls.setdefault("descendant_calls", []).append((parent_id, include_closed))
         if parent_id == "at-1":
             return [
                 {"id": "at-1.2", "title": "Second deferred", "status": "deferred"},
@@ -108,30 +124,31 @@ def test_render_startup_overview_lists_claim_state_and_sorts_messages(monkeypatc
             ]
         return []
 
-    monkeypatch.setattr(module.beads, "list_inbox_messages", _fake_list_inbox_messages)
-    monkeypatch.setattr(module.beads, "list_queue_messages", _fake_list_queue_messages)
     monkeypatch.setattr(
-        module.beads, "list_descendant_changesets", _fake_list_descendant_changesets
+        module.StartupBeadsInvocationHelper,
+        "list_descendant_changesets",
+        _fake_list_descendant_changesets,
     )
     monkeypatch.setattr(
-        module.beads,
-        "epic_discovery_parity_report",
-        lambda **_kwargs: SimpleNamespace(
-            active_top_level_work_count=2,
-            indexed_active_epic_count=2,
-            missing_executable_identity=(),
-            missing_from_index=(),
-            in_parity=True,
+        module,
+        "execute_startup_command_plan",
+        lambda *_args, **_kwargs: _startup_result(
+            module,
+            inbox=inbox,
+            queued=queued,
+            epics=[
+                {"id": "at-1", "title": "Epic one", "status": "open"},
+                {"id": "at-2", "title": "Epic blocked", "status": "blocked"},
+                {"id": "at-3", "title": "Epic closed", "status": "closed"},
+            ],
+            parity=SimpleNamespace(
+                active_top_level_work_count=2,
+                indexed_active_epic_count=2,
+                missing_executable_identity=(),
+                missing_from_index=(),
+                in_parity=True,
+            ),
         ),
-    )
-    monkeypatch.setattr(
-        module.planner_overview,
-        "list_epics",
-        lambda **_kwargs: [
-            {"id": "at-1", "title": "Epic one", "status": "open"},
-            {"id": "at-2", "title": "Epic blocked", "status": "blocked"},
-            {"id": "at-3", "title": "Epic closed", "status": "closed"},
-        ],
     )
     monkeypatch.setattr(
         module.planner_overview,
@@ -168,66 +185,45 @@ def test_render_startup_overview_lists_claim_state_and_sorts_messages(monkeypatc
         "Open epics:",
         "- at-1 [open] Example",
     ]
-    assert calls["queue_kwargs"] == {
-        "beads_root": Path("/beads"),
-        "cwd": Path("/repo"),
-        "unread_only": True,
-        "unclaimed_only": False,
-    }
     assert calls["descendant_calls"] == [
-        (
-            "at-1",
-            {
-                "beads_root": Path("/beads"),
-                "cwd": Path("/repo"),
-                "include_closed": False,
-            },
-        ),
-        (
-            "at-2",
-            {
-                "beads_root": Path("/beads"),
-                "cwd": Path("/repo"),
-                "include_closed": False,
-            },
-        ),
+        ("at-1", False),
+        ("at-2", False),
     ]
 
 
 def test_render_startup_overview_caps_deferred_epic_scan(monkeypatch) -> None:
     module = _load_script()
     monkeypatch.setenv("ATELIER_STARTUP_DEFERRED_EPIC_SCAN_LIMIT", "1")
-    monkeypatch.setattr(module.beads, "list_inbox_messages", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(module.beads, "list_queue_messages", lambda **_kwargs: [])
     monkeypatch.setattr(
-        module.beads,
-        "epic_discovery_parity_report",
-        lambda **_kwargs: SimpleNamespace(
-            active_top_level_work_count=3,
-            indexed_active_epic_count=3,
-            missing_executable_identity=(),
-            missing_from_index=(),
-            in_parity=True,
+        module,
+        "execute_startup_command_plan",
+        lambda *_args, **_kwargs: _startup_result(
+            module,
+            inbox=[],
+            queued=[],
+            epics=[
+                {"id": "at-1", "title": "Epic one", "status": "open"},
+                {"id": "at-2", "title": "Epic two", "status": "in_progress"},
+                {"id": "at-3", "title": "Epic three", "status": "blocked"},
+            ],
+            parity=SimpleNamespace(
+                active_top_level_work_count=3,
+                indexed_active_epic_count=3,
+                missing_executable_identity=(),
+                missing_from_index=(),
+                in_parity=True,
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        module.StartupBeadsInvocationHelper,
+        "list_descendant_changesets",
+        lambda _self, parent_id, *, include_closed: (
+            scanned_epics.append(parent_id)
+            or [{"id": f"{parent_id}.1", "title": "Deferred child", "status": "deferred"}]
         ),
     )
     scanned_epics: list[str] = []
-
-    def _fake_list_descendant_changesets(parent_id: str, **_kwargs):
-        scanned_epics.append(parent_id)
-        return [{"id": f"{parent_id}.1", "title": "Deferred child", "status": "deferred"}]
-
-    monkeypatch.setattr(
-        module.beads, "list_descendant_changesets", _fake_list_descendant_changesets
-    )
-    monkeypatch.setattr(
-        module.planner_overview,
-        "list_epics",
-        lambda **_kwargs: [
-            {"id": "at-1", "title": "Epic one", "status": "open"},
-            {"id": "at-2", "title": "Epic two", "status": "in_progress"},
-            {"id": "at-3", "title": "Epic three", "status": "blocked"},
-        ],
-    )
     monkeypatch.setattr(
         module.planner_overview,
         "render_epics",
@@ -288,28 +284,35 @@ def test_main_emits_override_warning(monkeypatch, capsys, tmp_path: Path) -> Non
 
 def test_render_startup_overview_reports_identity_guardrail_remediation(monkeypatch) -> None:
     module = _load_script()
-    monkeypatch.setattr(module.beads, "list_inbox_messages", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(module.beads, "list_queue_messages", lambda **_kwargs: [])
-    monkeypatch.setattr(module.beads, "list_descendant_changesets", lambda *_args, **_kwargs: [])
-    monkeypatch.setattr(module.planner_overview, "list_epics", lambda **_kwargs: [])
     monkeypatch.setattr(
-        module.beads,
-        "epic_discovery_parity_report",
-        lambda **_kwargs: SimpleNamespace(
-            active_top_level_work_count=1,
-            indexed_active_epic_count=0,
-            missing_executable_identity=(
-                SimpleNamespace(
-                    issue_id="at-missing",
-                    status="open",
-                    issue_type="epic",
-                    labels=(),
-                    remediation_command="bd update at-missing --type epic --add-label at:epic",
+        module,
+        "execute_startup_command_plan",
+        lambda *_args, **_kwargs: _startup_result(
+            module,
+            inbox=[],
+            queued=[],
+            epics=[],
+            parity=SimpleNamespace(
+                active_top_level_work_count=1,
+                indexed_active_epic_count=0,
+                missing_executable_identity=(
+                    SimpleNamespace(
+                        issue_id="at-missing",
+                        status="open",
+                        issue_type="epic",
+                        labels=(),
+                        remediation_command="bd update at-missing --type epic --add-label at:epic",
+                    ),
                 ),
+                missing_from_index=(),
+                in_parity=False,
             ),
-            missing_from_index=(),
-            in_parity=False,
         ),
+    )
+    monkeypatch.setattr(
+        module.StartupBeadsInvocationHelper,
+        "list_descendant_changesets",
+        lambda *_args, **_kwargs: [],
     )
     monkeypatch.setattr(
         module.planner_overview,
@@ -325,3 +328,38 @@ def test_render_startup_overview_reports_identity_guardrail_remediation(monkeypa
 
     assert "Identity guardrail violations (deterministic remediation):" in rendered
     assert "remediation: bd update at-missing --type epic --add-label at:epic" in rendered
+
+
+def test_render_startup_overview_passes_agent_id_to_command_plan(monkeypatch) -> None:
+    module = _load_script()
+    captured_agent_ids: list[str] = []
+
+    def _fake_execute(agent_id: str, **_kwargs):
+        captured_agent_ids.append(agent_id)
+        return _startup_result(
+            module,
+            inbox=[],
+            queued=[],
+            epics=[],
+            parity=_parity_ok(),
+        )
+
+    monkeypatch.setattr(module, "execute_startup_command_plan", _fake_execute)
+    monkeypatch.setattr(
+        module.StartupBeadsInvocationHelper,
+        "list_descendant_changesets",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        module.planner_overview,
+        "render_epics",
+        lambda issues, *, show_drafts: "Epics by state:\n- (none)",
+    )
+
+    module._render_startup_overview(
+        "atelier/planner/example",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    assert captured_agent_ids == ["atelier/planner/example"]

--- a/tests/atelier/test_planner_startup_check.py
+++ b/tests/atelier/test_planner_startup_check.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from atelier import planner_startup_check
+
+
+def _parity() -> SimpleNamespace:
+    return SimpleNamespace(
+        active_top_level_work_count=1,
+        indexed_active_epic_count=1,
+        missing_executable_identity=(),
+        missing_from_index=(),
+        in_parity=True,
+    )
+
+
+def test_startup_command_plan_order_is_fixed() -> None:
+    plan = planner_startup_check.startup_command_plan()
+
+    assert [(step.name, step.inputs, step.output) for step in plan] == [
+        ("list_inbox_unread_messages", ("agent_id",), "inbox_messages"),
+        ("list_queue_unread_messages", (), "queued_messages"),
+        ("list_indexed_epics", (), "epics"),
+        ("compute_epic_discovery_parity", ("epics",), "parity_report"),
+    ]
+
+
+def test_validate_startup_list_invocation_rejects_forbidden_flag() -> None:
+    with pytest.raises(ValueError, match="forbidden startup bd invocation flag"):
+        planner_startup_check.validate_startup_list_invocation(
+            ["list", "--db", "/tmp/beads.db", "--label", "at:message"]
+        )
+
+
+def test_validate_startup_list_invocation_rejects_unsupported_flag() -> None:
+    with pytest.raises(ValueError, match="unsupported startup bd list flag"):
+        planner_startup_check.validate_startup_list_invocation(
+            ["list", "--label", "at:message", "--status", "open"]
+        )
+
+
+def test_execute_startup_command_plan_runs_steps_in_order() -> None:
+    calls: list[str] = []
+
+    class _FakeHelper:
+        def list_inbox_messages(self, *_args, **_kwargs):
+            calls.append("inbox")
+            return [{"id": "at-msg-1", "title": "Message"}]
+
+        def list_queue_messages(self, *_args, **_kwargs):
+            calls.append("queue")
+            return [{"id": "at-q-1", "title": "Queued", "queue": "planner", "claimed_by": ""}]
+
+        def list_epics(self, *_args, **_kwargs):
+            calls.append("epics")
+            return [{"id": "at-1", "title": "Epic", "status": "open"}]
+
+        def epic_discovery_parity_report(self, *_args, **_kwargs):
+            calls.append("parity")
+            return _parity()
+
+    helper = _FakeHelper()
+
+    result = planner_startup_check.execute_startup_command_plan(
+        "atelier/planner/example",
+        helper=helper,  # type: ignore[arg-type]
+    )
+
+    assert calls == ["inbox", "queue", "epics", "parity"]
+    assert [issue["id"] for issue in result.inbox_messages] == ["at-msg-1"]
+    assert [issue["id"] for issue in result.epics] == ["at-1"]


### PR DESCRIPTION
# Summary

Implement deterministic planner startup command orchestration by introducing a
canonical command plan and a shared Beads invocation helper for startup triage
queries.

# Changes

- Added `planner_startup_check` module with:
  - a fixed startup command plan with explicit input/output contracts
  - `execute_startup_command_plan` to run the plan in deterministic order
  - `StartupBeadsInvocationHelper` for startup Beads access
  - `validate_startup_list_invocation` guardrails that reject forbidden or
    unsupported `bd` invocation forms
- Updated `planner-startup-check` refresh script to execute startup data loading
  through the canonical plan/helper path instead of ad-hoc direct calls.
- Documented the canonical startup command plan in the
  `planner-startup-check` skill instructions.
- Added regression tests for:
  - startup command plan order
  - forbidden startup invocation rejection
  - refresh script behavior under the new command-plan executor

# Testing

- `uv run pytest tests/atelier/test_planner_startup_check.py tests/atelier/skills/test_planner_startup_refresh_script.py -q`
- `just format`
- `just lint`
- `just test`

## Tickets
- Addresses #475

# Risks / Rollout

- Queue/inbox filtering in startup helper now uses deterministic read-only list
  queries and metadata parsing; behavior is covered by updated refresh-script
  tests.

# Notes

- Startup changeset scope is limited to command planning/invocation plumbing;
  no output-format redesign was introduced.
