### PR TITLE
Fix finalize PR-base mismatch handling for deterministic closure

### DIFF
--- a/src/atelier/worker/finalize_pipeline.py
+++ b/src/atelier/worker/finalize_pipeline.py
@@ -100,6 +100,67 @@ def _block_missing_merged_integration(
     )
 
 
+def _finalize_from_pr_lifecycle(
+    *,
+    lifecycle_state: str | None,
+    issue: Issue,
+    changeset_id: str,
+    work_branch: str,
+    repo_slug: str | None,
+    git_path: str | None,
+    pr_payload: Issue | None,
+    pushed: bool,
+    context: "FinalizePipelineContext",
+    agent_id: str,
+    service: "FinalizePipelineService",
+) -> FinalizeResult | None:
+    """Finalize immediately for terminal PR lifecycle states when available."""
+    if lifecycle_state == "merged":
+        atelier_log.debug(f"changeset={changeset_id} finalize lifecycle=merged")
+        service.update_changeset_review_from_pr(
+            changeset_id,
+            pr_payload=pr_payload,
+            pushed=pushed,
+        )
+        integration_ok, integrated_sha = service.changeset_integration_signal(
+            issue,
+            repo_slug=repo_slug,
+            git_path=git_path,
+            require_target_branch_proof=True,
+        )
+        if not integration_ok:
+            return _block_missing_merged_integration(
+                changeset_id=changeset_id,
+                work_branch=work_branch,
+                agent_id=agent_id,
+                service=service,
+            )
+        return service.finalize_terminal_changeset(
+            context=context,
+            terminal_state="merged",
+            integrated_sha=integrated_sha,
+        )
+    if lifecycle_state == "closed":
+        atelier_log.debug(f"changeset={changeset_id} finalize lifecycle=closed")
+        service.update_changeset_review_from_pr(
+            changeset_id,
+            pr_payload=pr_payload,
+            pushed=pushed,
+        )
+        integration_ok, integrated_sha = service.changeset_integration_signal(
+            issue,
+            repo_slug=repo_slug,
+            git_path=git_path,
+            require_target_branch_proof=True,
+        )
+        return service.finalize_terminal_changeset(
+            context=context,
+            terminal_state="merged" if integration_ok else "abandoned",
+            integrated_sha=integrated_sha if integration_ok else None,
+        )
+    return None
+
+
 @dataclass(frozen=True)
 class FinalizePipelineContext:
     changeset_id: str
@@ -498,49 +559,21 @@ def run_finalize_pipeline(
         lifecycle_state = prs.lifecycle_state(
             pr_payload, pushed=pushed, review_requested=review_requested
         )
-    if lifecycle_state == "merged":
-        atelier_log.debug(f"changeset={changeset_id} finalize lifecycle=merged")
-        service.update_changeset_review_from_pr(
-            changeset_id,
-            pr_payload=pr_payload,
-            pushed=pushed,
-        )
-        integration_ok, integrated_sha = service.changeset_integration_signal(
-            issue,
-            repo_slug=repo_slug,
-            git_path=git_path,
-            require_target_branch_proof=True,
-        )
-        if not integration_ok:
-            return _block_missing_merged_integration(
-                changeset_id=changeset_id,
-                work_branch=work_branch,
-                agent_id=agent_id,
-                service=service,
-            )
-        return service.finalize_terminal_changeset(
-            context=context,
-            terminal_state="merged",
-            integrated_sha=integrated_sha,
-        )
-    if lifecycle_state == "closed":
-        atelier_log.debug(f"changeset={changeset_id} finalize lifecycle=closed")
-        service.update_changeset_review_from_pr(
-            changeset_id,
-            pr_payload=pr_payload,
-            pushed=pushed,
-        )
-        integration_ok, integrated_sha = service.changeset_integration_signal(
-            issue,
-            repo_slug=repo_slug,
-            git_path=git_path,
-            require_target_branch_proof=True,
-        )
-        return service.finalize_terminal_changeset(
-            context=context,
-            terminal_state="merged" if integration_ok else "abandoned",
-            integrated_sha=integrated_sha if integration_ok else None,
-        )
+    terminal_result = _finalize_from_pr_lifecycle(
+        lifecycle_state=lifecycle_state,
+        issue=issue,
+        changeset_id=changeset_id,
+        work_branch=work_branch,
+        repo_slug=repo_slug,
+        git_path=git_path,
+        pr_payload=pr_payload,
+        pushed=pushed,
+        context=context,
+        agent_id=agent_id,
+        service=service,
+    )
+    if terminal_result is not None:
+        return terminal_result
     if branch_pr and pushed and not pr_payload:
         integration_ok, integrated_sha = service.changeset_integration_signal(
             issue,
@@ -662,6 +695,36 @@ def run_finalize_pipeline(
             context=context,
         )
         if not aligned:
+            refreshed_payload, _refreshed_lookup_error = service.lookup_pr_payload_diagnostic(
+                repo_slug, work_branch
+            )
+            refreshed_lifecycle: str | None = None
+            if refreshed_payload is not None:
+                refreshed_lifecycle = prs.lifecycle_state(
+                    refreshed_payload,
+                    pushed=pushed,
+                    review_requested=prs.has_review_requests(refreshed_payload),
+                )
+            refreshed_terminal_result = _finalize_from_pr_lifecycle(
+                lifecycle_state=refreshed_lifecycle,
+                issue=issue,
+                changeset_id=changeset_id,
+                work_branch=work_branch,
+                repo_slug=repo_slug,
+                git_path=git_path,
+                pr_payload=refreshed_payload,
+                pushed=pushed,
+                context=context,
+                agent_id=agent_id,
+                service=service,
+            )
+            if refreshed_terminal_result is not None:
+                atelier_log.info(
+                    "changeset="
+                    f"{changeset_id} finalize bypassed PR base mismatch resolution after "
+                    f"terminal refresh ({refreshed_lifecycle})"
+                )
+                return refreshed_terminal_result
             service.mark_changeset_in_progress(changeset_id)
             body = (
                 "Detected a PR base mismatch but automatic base correction "

--- a/src/atelier/worker/work_finalization_state.py
+++ b/src/atelier/worker/work_finalization_state.py
@@ -336,6 +336,50 @@ def _normalize_branch(value: object) -> str:
     return normalized
 
 
+def _worktree_path_for_checked_out_branch(
+    repo_root: Path,
+    branch: str,
+    *,
+    git_path: str | None,
+) -> Path | None:
+    """Return the worktree path where the local branch is currently checked out.
+
+    Args:
+        repo_root: Repository root used to query worktrees.
+        branch: Local branch name.
+        git_path: Optional git binary path override.
+
+    Returns:
+        Worktree path for ``branch`` when discoverable, else ``None``.
+    """
+    result = exec.try_run_command(
+        git.git_command(
+            ["-C", str(repo_root), "worktree", "list", "--porcelain"],
+            git_path=git_path,
+        )
+    )
+    if result is None or result.returncode != 0:
+        return None
+    active_worktree: str | None = None
+    active_branch: str | None = None
+    for raw_line in (result.stdout or "").splitlines():
+        line = raw_line.strip()
+        if not line:
+            if active_worktree and active_branch == f"refs/heads/{branch}":
+                return Path(active_worktree)
+            active_worktree = None
+            active_branch = None
+            continue
+        if line.startswith("worktree "):
+            active_worktree = line.removeprefix("worktree ").strip()
+            continue
+        if line.startswith("branch "):
+            active_branch = line.removeprefix("branch ").strip()
+    if active_worktree and active_branch == f"refs/heads/{branch}":
+        return Path(active_worktree)
+    return None
+
+
 def _resolve_parent_lineage(
     issue: dict[str, object],
     *,
@@ -731,9 +775,9 @@ def align_existing_pr_base(
         notes when present.
     """
 
-    def run_git(args: list[str]) -> tuple[bool, str]:
+    def run_git(args: list[str], *, run_root: Path = repo_root) -> tuple[bool, str]:
         result = exec.try_run_command(
-            git.git_command(["-C", str(repo_root), *args], git_path=git_path)
+            git.git_command(["-C", str(run_root), *args], git_path=git_path)
         )
         if result is None:
             return False, "missing required command: git"
@@ -795,21 +839,38 @@ def align_existing_pr_base(
 
     rebased = False
     rebase_source_ref = branch_ref_for_lookup(repo_root, actual_branch, git_path=git_path)
-    current_branch = git.git_current_branch(repo_root, git_path=git_path)
+    rebase_repo_root = repo_root
+    branch_worktree = _worktree_path_for_checked_out_branch(
+        repo_root,
+        work_branch,
+        git_path=git_path,
+    )
+    if branch_worktree is not None:
+        rebase_repo_root = branch_worktree
+    original_rebase_branch = git.git_current_branch(rebase_repo_root, git_path=git_path)
+    switched_branch = False
     if rebase_source_ref:
-        ok, detail = run_git(["checkout", work_branch])
+        if original_rebase_branch != work_branch:
+            ok, detail = run_git(["checkout", work_branch], run_root=rebase_repo_root)
+            if not ok:
+                return False, detail
+            switched_branch = True
+        ok, detail = run_git(
+            ["rebase", "--onto", expected_branch, rebase_source_ref],
+            run_root=rebase_repo_root,
+        )
         if not ok:
-            return False, detail
-        ok, detail = run_git(["rebase", "--onto", expected_branch, rebase_source_ref, work_branch])
-        if not ok:
-            run_git(["rebase", "--abort"])
-            if current_branch and current_branch != work_branch:
-                run_git(["checkout", current_branch])
+            run_git(["rebase", "--abort"], run_root=rebase_repo_root)
+            if switched_branch and original_rebase_branch and original_rebase_branch != work_branch:
+                run_git(["checkout", original_rebase_branch], run_root=rebase_repo_root)
             return False, f"failed to restack {work_branch} onto {expected_branch}: {detail}"
         rebased = True
-        if current_branch and current_branch != work_branch:
-            run_git(["checkout", current_branch])
-        ok, detail = run_git(["push", "--force-with-lease", "origin", work_branch])
+        if switched_branch and original_rebase_branch and original_rebase_branch != work_branch:
+            run_git(["checkout", original_rebase_branch], run_root=rebase_repo_root)
+        ok, detail = run_git(
+            ["push", "--force-with-lease", "origin", work_branch],
+            run_root=rebase_repo_root,
+        )
         if not ok:
             return False, f"failed to force-push restacked branch {work_branch}: {detail}"
 

--- a/tests/atelier/worker/test_finalize_pipeline.py
+++ b/tests/atelier/worker/test_finalize_pipeline.py
@@ -932,6 +932,75 @@ def test_run_finalize_pipeline_blocks_when_pr_base_alignment_fails(monkeypatch) 
     assert notifications == ["NEEDS-DECISION: PR base mismatch (at-epic.1)"]
 
 
+def test_run_finalize_pipeline_skips_mismatch_notification_when_refresh_is_terminal(
+    monkeypatch,
+) -> None:
+    issue = {
+        "id": "at-epic.1",
+        "labels": [],
+        "description": "changeset.work_branch: feat/root-at-epic.1\n",
+    }
+    monkeypatch.setattr(
+        finalize_pipeline.beads,
+        "run_bd_json",
+        lambda *_args, **_kwargs: [issue],
+    )
+    monkeypatch.setattr(
+        finalize_pipeline.git,
+        "git_ref_exists",
+        lambda *_args, **_kwargs: True,
+    )
+
+    service = _FinalizeServiceStub()
+    service.lookup_pr_payload_fn = lambda _repo_slug, _branch: {
+        "number": 101,
+        "baseRefName": "feat",
+        "state": "OPEN",
+        "isDraft": False,
+    }
+    service.align_existing_pr_base_fn = lambda *, issue, pr_payload, context: (
+        False,
+        "expected=main actual=feat; failed to restack work branch",
+    )
+    service.lookup_pr_payload_diagnostic_fn = lambda _repo_slug, _branch: (
+        {
+            "number": 101,
+            "baseRefName": "feat",
+            "state": "MERGED",
+            "mergedAt": "2026-03-03T12:00:00Z",
+            "isDraft": False,
+        },
+        None,
+    )
+    service.changeset_integration_signal_fn = lambda _issue, *, repo_slug, git_path: (
+        True,
+        "abc1234",
+    )
+
+    marked: list[str] = []
+    notifications: list[str] = []
+    finalized: list[tuple[str, str | None]] = []
+    service.mark_changeset_in_progress_fn = lambda _changeset_id: marked.append("in_progress")
+    service.send_planner_notification_fn = lambda **kwargs: notifications.append(
+        str(kwargs.get("subject"))
+    )
+    service.finalize_terminal_changeset_fn = lambda *, context, terminal_state, integrated_sha: (
+        finalized.append((terminal_state, integrated_sha))
+        or FinalizeResult(continue_running=True, reason="changeset_complete")
+    )
+
+    result = finalize_pipeline.run_finalize_pipeline(
+        context=_pipeline_context(repo_slug="org/repo"),
+        service=service,
+    )
+
+    assert result.reason == "changeset_complete"
+    assert result.continue_running is True
+    assert finalized == [("merged", "abc1234")]
+    assert marked == []
+    assert notifications == []
+
+
 def test_run_finalize_pipeline_aligns_pr_base_before_pending(monkeypatch) -> None:
     issue = {
         "id": "at-epic.1",

--- a/tests/atelier/worker/test_work_finalization_state.py
+++ b/tests/atelier/worker/test_work_finalization_state.py
@@ -845,10 +845,7 @@ def test_align_existing_pr_base_rebases_and_retargets(monkeypatch) -> None:
     assert ok is True
     assert detail is not None
     assert "expected=main" in detail
-    assert any(
-        command[-5:] == ["rebase", "--onto", "main", "feat/parent", "feat/work"]
-        for command in commands
-    )
+    assert any(command[-4:] == ["rebase", "--onto", "main", "feat/parent"] for command in commands)
     assert any(
         command[-4:] == ["push", "--force-with-lease", "origin", "feat/work"]
         for command in commands
@@ -856,6 +853,99 @@ def test_align_existing_pr_base_rebases_and_retargets(monkeypatch) -> None:
     assert any(
         command[:7] == ["gh", "pr", "edit", "12", "--repo", "org/repo", "--base"]
         and command[-1] == "main"
+        for command in commands
+    )
+
+
+def test_align_existing_pr_base_rebases_from_checked_out_worktree(monkeypatch) -> None:
+    issue = {
+        "description": (
+            "changeset.root_branch: feat/root\n"
+            "changeset.parent_branch: feat/parent\n"
+            "changeset.work_branch: feat/work\n"
+            "workspace.parent_branch: main\n"
+        )
+    }
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(
+        work_finalization_state,
+        "changeset_base_branch",
+        lambda *_args, **_kwargs: "main",
+    )
+    monkeypatch.setattr(work_finalization_state.git, "git_is_clean", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        work_finalization_state.git,
+        "git_ref_exists",
+        lambda *_args, **_kwargs: True,
+    )
+    monkeypatch.setattr(
+        work_finalization_state,
+        "branch_ref_for_lookup",
+        lambda _repo_root, branch, **_kwargs: branch,
+    )
+    monkeypatch.setattr(
+        work_finalization_state.git,
+        "git_current_branch",
+        lambda repo_path, **_kwargs: (
+            "feat/work" if str(repo_path) == "/worktrees/at-epic.2" else "main"
+        ),
+    )
+    monkeypatch.setattr(
+        work_finalization_state.git,
+        "git_rev_parse",
+        lambda *_args, **_kwargs: "abc1234",
+    )
+    monkeypatch.setattr(
+        work_finalization_state.beads,
+        "update_changeset_branch_metadata",
+        lambda *_args, **_kwargs: {},
+    )
+    monkeypatch.setattr(
+        work_finalization_state.beads,
+        "run_bd_command",
+        lambda *_args, **_kwargs: None,
+    )
+
+    def _record_command(cmd: list[str]):
+        commands.append(list(cmd))
+        if cmd[:4] == ["git", "-C", "/repo", "worktree"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "worktree /repo\n"
+                    "HEAD abc1234\n"
+                    "branch refs/heads/main\n\n"
+                    "worktree /worktrees/at-epic.2\n"
+                    "HEAD def5678\n"
+                    "branch refs/heads/feat/work\n"
+                ),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(work_finalization_state.exec, "try_run_command", _record_command)
+
+    ok, detail = work_finalization_state.align_existing_pr_base(
+        issue=issue,
+        changeset_id="at-epic.2",
+        pr_payload={"number": 12, "baseRefName": "feat/parent"},
+        repo_slug="org/repo",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+        git_path="git",
+    )
+
+    assert ok is True
+    assert detail is not None
+    assert "expected=main" in detail
+    assert any(
+        command[:3] == ["git", "-C", "/worktrees/at-epic.2"]
+        and command[3:] == ["rebase", "--onto", "main", "feat/parent"]
+        for command in commands
+    )
+    assert not any(
+        command[:3] == ["git", "-C", "/repo"] and command[3:5] == ["checkout", "feat/work"]
         for command in commands
     )
 


### PR DESCRIPTION
# Summary

This change makes worker finalize deterministic when it detects a PR-base mismatch.
It now recovers automatically when reconciliation is possible and avoids sending planner escalation messages for recoverable cases.

# Changes

- Added worktree-aware PR base alignment in `work_finalization_state.align_existing_pr_base` so restacking works when the work branch is already checked out in a dedicated worktree.
- Refactored terminal PR lifecycle handling in `finalize_pipeline` into a shared helper and reused it in both the normal lifecycle path and mismatch-recovery path.
- Added a lifecycle refresh after alignment failures; if the refreshed PR is terminal (`merged` or `closed`), finalize now prioritizes terminal reconciliation instead of emitting a PR-base mismatch NEEDS-DECISION.
- Added regression tests for terminal-priority mismatch handling and worktree-aware alignment behavior.

# Testing

- `just lint`
- `just test`
- `pytest -q tests/atelier/worker/test_finalize_pipeline.py`
- `pytest -q tests/atelier/worker/test_work_finalization_state.py`

## Tickets
- Fixes #491

# Risks / Rollout

- Touches finalize-state transitions and PR-alignment logic; regressions are mitigated with focused unit tests and full repo lint/test gates.

# Notes

- PR body intentionally avoids internal planning identifiers and reflects only user-facing bug scope.
