### PR TITLE
Harden planner Beads fallback command syntax

### DIFF
--- a/docs/beads-store-parity.md
+++ b/docs/beads-store-parity.md
@@ -32,6 +32,18 @@ emit a warning with both paths:
 - `project_beads_root=<project path>`
 - `override_beads_root=<override path>`
 
+## Safe raw `bd` invocation forms
+
+When running direct diagnostics against a specific Beads store, use one of:
+
+```bash
+BEADS_DIR="<beads-root>" bd show <issue-id> --json
+bd --db "<beads-root>/beads.db" show <issue-id> --json
+```
+
+Do not pass the long `--beads-dir` flag to `bd`; that flag is for Atelier helper
+scripts, not the `bd` CLI.
+
 ## Migration and recovery playbook
 
 1. Confirm the project-scoped store path:

--- a/src/atelier/bd_invocation.py
+++ b/src/atelier/bd_invocation.py
@@ -94,6 +94,12 @@ def with_bd_mode(
     """Return a ``bd`` command with deterministic database selection."""
 
     del env
+    for argument in args:
+        if argument == "--beads-dir" or argument.startswith("--beads-dir="):
+            raise ValueError(
+                "unsupported bd flag in command arguments: --beads-dir. "
+                "Use BEADS_DIR=<path> bd ... or bd --db <path/to/beads.db> ..."
+            )
     command = ["bd"]
     has_db_flag = any(argument == "--db" or argument.startswith("--db=") for argument in args)
     if beads_dir and not has_db_flag:

--- a/src/atelier/skills/planner-startup-check/SKILL.md
+++ b/src/atelier/skills/planner-startup-check/SKILL.md
@@ -81,3 +81,5 @@ reject unsupported invocation forms.
 
 - Use the one-shot parity check and recovery playbook in
   `docs/beads-store-parity.md`.
+- For direct Beads diagnostics, use only supported raw forms:
+  `BEADS_DIR="<beads-root>" bd ...` or `bd --db "<beads-root>/beads.db" ...`.

--- a/tests/atelier/skills/test_planner_startup_refresh_script.py
+++ b/tests/atelier/skills/test_planner_startup_refresh_script.py
@@ -328,6 +328,7 @@ def test_render_startup_overview_reports_identity_guardrail_remediation(monkeypa
 
     assert "Identity guardrail violations (deterministic remediation):" in rendered
     assert "remediation: bd update at-missing --type epic --add-label at:epic" in rendered
+    assert "bd --beads-dir" not in rendered
 
 
 def test_render_startup_overview_passes_agent_id_to_command_plan(monkeypatch) -> None:

--- a/tests/atelier/test_bd_invocation.py
+++ b/tests/atelier/test_bd_invocation.py
@@ -40,6 +40,22 @@ def test_with_bd_mode_does_not_override_explicit_db_flag() -> None:
     assert command == ["bd", "--db", "/custom/beads.db", "show", "at-1", "--json"]
 
 
+def test_with_bd_mode_rejects_unsupported_beads_dir_flag() -> None:
+    with pytest.raises(ValueError, match="unsupported bd flag"):
+        with_bd_mode("show", "at-1", "--beads-dir", "/tmp/other", beads_dir="/tmp/beads", env={})
+
+
+def test_with_bd_mode_rejects_unsupported_beads_dir_equals_flag() -> None:
+    with pytest.raises(ValueError, match="unsupported bd flag"):
+        with_bd_mode(
+            "show",
+            "at-1",
+            "--beads-dir=/tmp/other",
+            beads_dir="/tmp/beads",
+            env={},
+        )
+
+
 def test_ensure_supported_bd_version_accepts_minimum(monkeypatch: pytest.MonkeyPatch) -> None:
     bd_invocation._read_bd_version_for_executable.cache_clear()
     monkeypatch.setattr(

--- a/tests/atelier/test_bd_invocation_guardrails.py
+++ b/tests/atelier/test_bd_invocation_guardrails.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from atelier import beads
+
+_FORBIDDEN_BD_FLAG = re.compile(r"\bbd\s+--beads-dir(?:\b|=)")
+
+
+def test_identity_remediation_command_uses_supported_bd_invocation() -> None:
+    command = beads._identity_remediation_command(  # pyright: ignore[reportPrivateUsage]
+        "at-123",
+        beads_root=Path("/tmp/project/.beads"),
+    )
+
+    assert "--beads-dir" not in command
+
+
+def test_runtime_and_skill_docs_do_not_embed_forbidden_bd_beads_dir_form() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    candidates = [
+        *repo_root.glob("src/atelier/**/*.py"),
+        *repo_root.glob("src/atelier/skills/**/*.md"),
+        repo_root / "docs" / "beads-store-parity.md",
+    ]
+    violations: list[str] = []
+    for path in sorted(set(candidates)):
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            if _FORBIDDEN_BD_FLAG.search(line):
+                violations.append(f"{path.relative_to(repo_root)}:{line_number}: {line.strip()}")
+
+    assert violations == []


### PR DESCRIPTION
# Summary

- Harden Beads command fallback handling so planner/skill workflows cannot emit unsupported raw `bd` invocation syntax.

# Changes

- Updated shared `with_bd_mode(...)` command construction to reject unsupported `--beads-dir` arguments and fail with explicit guidance to supported forms.
- Added regression coverage for helper behavior, planner startup remediation rendering, and a repository guardrail scan that fails if forbidden `bd` invocation syntax is introduced.
- Documented operator-safe cross-project diagnostics for direct `bd` use (`BEADS_DIR=... bd ...` and `bd --db ...`) in parity/runbook guidance.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets
- Addresses #473

# Risks / Rollout

- Low risk: behavior change is narrowly scoped to command assembly guardrails and documentation/tests.

# Notes

- No runtime behavior changes beyond rejecting unsupported `bd` argument forms before execution.
