### PR TITLE
Render planner startup triage from a deterministic structured model

### DIFF
--- a/src/atelier/planner_startup_check.py
+++ b/src/atelier/planner_startup_check.py
@@ -37,6 +37,306 @@ class StartupCommandResult:
     parity_report: beads.EpicDiscoveryParityReport
 
 
+@dataclass(frozen=True)
+class StartupMessageSummary:
+    """Structured inbox message summary for startup triage rendering."""
+
+    issue_id: str
+    title: str
+
+
+@dataclass(frozen=True)
+class StartupQueuedMessageSummary:
+    """Structured queued-message summary for startup triage rendering."""
+
+    issue_id: str
+    queue: str
+    title: str
+    claimed_by: str | None
+
+
+@dataclass(frozen=True)
+class StartupIdentityViolationSummary:
+    """Structured identity guardrail violation metadata."""
+
+    issue_id: str
+    status: str
+    issue_type: str
+    labels: tuple[str, ...]
+    remediation_command: str
+
+
+@dataclass(frozen=True)
+class StartupIssueSummary:
+    """Structured issue summary used in deferred and parity sections."""
+
+    issue_id: str
+    status: str
+    title: str
+
+
+@dataclass(frozen=True)
+class StartupDeferredChangesetGroup:
+    """Deferred changesets grouped under one active epic."""
+
+    epic: StartupIssueSummary
+    changesets: tuple[StartupIssueSummary, ...]
+
+
+@dataclass(frozen=True)
+class StartupTriageDiagnostics:
+    """Structured startup diagnostics for deterministic rendering."""
+
+    beads_root: str
+    total_epics: int
+    active_top_level_work_count: int
+    indexed_active_epic_count: int
+    in_parity: bool
+    identity_violations: tuple[StartupIdentityViolationSummary, ...]
+    missing_from_index: tuple[str, ...]
+    deferred_scan_limit: int
+    deferred_scan_skipped_epics: int
+
+
+@dataclass(frozen=True)
+class StartupTriageModel:
+    """Typed startup triage model consumed by the markdown renderer."""
+
+    inbox_messages: tuple[StartupMessageSummary, ...]
+    queued_messages: tuple[StartupQueuedMessageSummary, ...]
+    deferred_changesets: tuple[StartupDeferredChangesetGroup, ...]
+    diagnostics: StartupTriageDiagnostics
+    epic_list_markdown: str
+
+
+def _issue_sort_key(issue: dict[str, object]) -> tuple[str, str]:
+    issue_id = str(issue.get("id") or "").strip()
+    title = str(issue.get("title") or "").strip()
+    return (issue_id, title)
+
+
+def _issue_status(issue: dict[str, object]) -> str:
+    canonical_status = lifecycle.canonical_lifecycle_status(issue.get("status"))
+    if canonical_status:
+        return canonical_status
+    raw_status = str(issue.get("status") or "").strip()
+    return raw_status or "unknown"
+
+
+def _issue_title(issue: dict[str, object]) -> str:
+    title = str(issue.get("title") or "").strip()
+    return title or "(untitled)"
+
+
+def _issue_id(issue: dict[str, object]) -> str:
+    issue_id = str(issue.get("id") or "").strip()
+    return issue_id or "(unknown)"
+
+
+def build_startup_triage_model(
+    *,
+    beads_root: Path,
+    command_result: StartupCommandResult,
+    deferred_groups: list[tuple[dict[str, object], list[dict[str, object]]]],
+    deferred_scan_limit: int,
+    deferred_scan_skipped_epics: int,
+    epic_list_markdown: str,
+) -> StartupTriageModel:
+    """Build a typed startup triage model from collected command outputs.
+
+    Args:
+        beads_root: Beads root path used by startup triage.
+        command_result: Canonical startup command outputs.
+        deferred_groups: Deferred changesets grouped by active epic.
+        deferred_scan_limit: Active epic scan limit used for deferred discovery.
+        deferred_scan_skipped_epics: Number of active epics skipped due to the
+            configured deferred scan limit.
+        epic_list_markdown: Stable `epic-list` section text.
+
+    Returns:
+        Structured startup triage model consumed by deterministic rendering.
+    """
+
+    inbox_messages = tuple(
+        StartupMessageSummary(
+            issue_id=_issue_id(issue),
+            title=_issue_title(issue),
+        )
+        for issue in sorted(command_result.inbox_messages, key=_issue_sort_key)
+    )
+    queued_messages = tuple(
+        StartupQueuedMessageSummary(
+            issue_id=_issue_id(issue),
+            queue=str(issue.get("queue") or "").strip() or "queue",
+            title=_issue_title(issue),
+            claimed_by=(
+                claimed_by.strip()
+                if isinstance(claimed_by := issue.get("claimed_by"), str) and claimed_by.strip()
+                else None
+            ),
+        )
+        for issue in sorted(command_result.queued_messages, key=_issue_sort_key)
+    )
+
+    normalized_groups: list[StartupDeferredChangesetGroup] = []
+    for epic, changesets in sorted(deferred_groups, key=lambda group: _issue_sort_key(group[0])):
+        normalized_groups.append(
+            StartupDeferredChangesetGroup(
+                epic=StartupIssueSummary(
+                    issue_id=_issue_id(epic),
+                    status=_issue_status(epic),
+                    title=_issue_title(epic),
+                ),
+                changesets=tuple(
+                    StartupIssueSummary(
+                        issue_id=_issue_id(issue),
+                        status=_issue_status(issue),
+                        title=_issue_title(issue),
+                    )
+                    for issue in sorted(changesets, key=_issue_sort_key)
+                ),
+            )
+        )
+    deferred_changesets = tuple(normalized_groups)
+
+    parity = command_result.parity_report
+    sorted_identity_violations = sorted(
+        tuple(getattr(parity, "missing_executable_identity", ())),
+        key=lambda item: str(getattr(item, "issue_id", "") or "").strip(),
+    )
+    identity_violations = tuple(
+        StartupIdentityViolationSummary(
+            issue_id=str(getattr(item, "issue_id", "") or "").strip() or "(unknown)",
+            status=str(getattr(item, "status", "") or "").strip() or "missing",
+            issue_type=str(getattr(item, "issue_type", "") or "").strip() or "missing",
+            labels=tuple(
+                sorted(
+                    str(label).strip()
+                    for label in tuple(getattr(item, "labels", ()))
+                    if str(label).strip()
+                )
+            ),
+            remediation_command=(
+                str(getattr(item, "remediation_command", "") or "").strip()
+                or "(missing remediation command)"
+            ),
+        )
+        for item in sorted_identity_violations
+    )
+
+    missing_from_index = tuple(
+        sorted(
+            str(issue_id).strip()
+            for issue_id in tuple(getattr(parity, "missing_from_index", ()))
+            if str(issue_id).strip()
+        )
+    )
+    diagnostics = StartupTriageDiagnostics(
+        beads_root=str(beads_root),
+        total_epics=len(command_result.epics),
+        active_top_level_work_count=int(getattr(parity, "active_top_level_work_count", 0)),
+        indexed_active_epic_count=int(getattr(parity, "indexed_active_epic_count", 0)),
+        in_parity=bool(getattr(parity, "in_parity", False)),
+        identity_violations=identity_violations,
+        missing_from_index=missing_from_index,
+        deferred_scan_limit=max(0, int(deferred_scan_limit)),
+        deferred_scan_skipped_epics=max(0, int(deferred_scan_skipped_epics)),
+    )
+    return StartupTriageModel(
+        inbox_messages=inbox_messages,
+        queued_messages=queued_messages,
+        deferred_changesets=deferred_changesets,
+        diagnostics=diagnostics,
+        epic_list_markdown=epic_list_markdown,
+    )
+
+
+def render_startup_triage_markdown(model: StartupTriageModel) -> str:
+    """Render deterministic startup markdown from a typed triage model.
+
+    Args:
+        model: Startup triage model.
+
+    Returns:
+        Stable markdown output for planner startup triage.
+    """
+
+    lines: list[str] = [
+        "Planner startup overview",
+        f"- Beads root: {model.diagnostics.beads_root}",
+    ]
+
+    if model.inbox_messages:
+        lines.append("Unread messages:")
+        for message in model.inbox_messages:
+            lines.append(f"- {message.issue_id} {message.title}")
+    else:
+        lines.append("No unread messages.")
+
+    if model.queued_messages:
+        lines.append("Queued messages:")
+        for queued_message in model.queued_messages:
+            claim_state = (
+                f"claimed by {queued_message.claimed_by}"
+                if queued_message.claimed_by
+                else "unclaimed"
+            )
+            lines.append(
+                f"- {queued_message.issue_id} [{queued_message.queue}] {queued_message.title} "
+                f"| claim: {claim_state}"
+            )
+    else:
+        lines.append("No queued messages.")
+
+    diagnostics = model.diagnostics
+    lines.append(f"- Total epics: {diagnostics.total_epics}")
+    lines.append(
+        "- Active top-level work (open/in_progress/blocked): "
+        f"{diagnostics.active_top_level_work_count}"
+    )
+    lines.append(
+        f"- Indexed active epics (at:epic discovery): {diagnostics.indexed_active_epic_count}"
+    )
+    if diagnostics.in_parity:
+        lines.append("Epic discovery parity: ok")
+    if diagnostics.identity_violations:
+        lines.append("Identity guardrail violations (deterministic remediation):")
+        for violation in diagnostics.identity_violations:
+            labels = ", ".join(violation.labels) if violation.labels else "(none)"
+            lines.append(
+                f"- {violation.issue_id} [status={violation.status} "
+                f"type={violation.issue_type}] labels={labels}"
+            )
+            lines.append(f"  remediation: {violation.remediation_command}")
+    if diagnostics.missing_from_index:
+        lines.append("Discovery index mismatch for executable top-level work:")
+        for issue_id in diagnostics.missing_from_index:
+            lines.append(f"- {issue_id}")
+        lines.append(
+            "  remediation: run `bd prime`; if mismatch persists, run "
+            "`bd doctor --fix --yes` and rerun startup."
+        )
+
+    if model.deferred_changesets:
+        lines.append("Deferred changesets under open/in-progress/blocked epics:")
+        for group in model.deferred_changesets:
+            lines.append(f"- {group.epic.issue_id} [{group.epic.status}] {group.epic.title}")
+            for issue in group.changesets:
+                lines.append(f"  - {issue.issue_id} [{issue.status}] {issue.title}")
+    else:
+        lines.append("No deferred changesets under open/in-progress/blocked epics.")
+
+    if diagnostics.deferred_scan_skipped_epics:
+        lines.append(
+            "Deferred changeset scan limited to first "
+            f"{diagnostics.deferred_scan_limit} active epics; skipped "
+            f"{diagnostics.deferred_scan_skipped_epics}."
+        )
+
+    lines.extend(model.epic_list_markdown.splitlines())
+    return "\n".join(lines)
+
+
 _STARTUP_COMMAND_PLAN: tuple[StartupCommandStep, ...] = (
     StartupCommandStep(
         name="list_inbox_unread_messages",

--- a/src/atelier/skills/planner-startup-check/scripts/refresh_overview.py
+++ b/src/atelier/skills/planner-startup-check/scripts/refresh_overview.py
@@ -13,7 +13,9 @@ from atelier.beads_context import resolve_skill_beads_context
 from atelier.planner_startup_check import (
     StartupBeadsInvocationHelper,
     StartupCommandResult,
+    build_startup_triage_model,
     execute_startup_command_plan,
+    render_startup_triage_markdown,
 )
 
 DEFAULT_DEFERRED_EPIC_SCAN_LIMIT = 25
@@ -23,13 +25,6 @@ def _issue_sort_key(issue: dict[str, object]) -> tuple[str, str]:
     issue_id = str(issue.get("id") or "").strip()
     title = str(issue.get("title") or "").strip()
     return (issue_id, title)
-
-
-def _queue_claim_state(issue: dict[str, object]) -> str:
-    claimed_by = issue.get("claimed_by")
-    if isinstance(claimed_by, str) and claimed_by.strip():
-        return f"claimed by {claimed_by.strip()}"
-    return "unclaimed"
 
 
 def _deferred_descendant_changesets(
@@ -80,40 +75,6 @@ def _deferred_epic_scan_limit() -> int:
     return max(0, parsed_limit)
 
 
-def _append_deferred_changeset_summary(
-    lines: list[str],
-    epics: list[dict[str, object]],
-    *,
-    helper: StartupBeadsInvocationHelper,
-) -> None:
-    groups, skipped_epics, scan_limit = _deferred_descendant_changesets(
-        epics,
-        helper=helper,
-    )
-    if not groups:
-        lines.append("No deferred changesets under open/in-progress/blocked epics.")
-    else:
-        lines.append("Deferred changesets under open/in-progress/blocked epics:")
-        for epic, deferred in groups:
-            epic_id = str(epic.get("id") or "").strip() or "(unknown)"
-            epic_status = lifecycle.canonical_lifecycle_status(epic.get("status")) or "unknown"
-            epic_title = str(epic.get("title") or "").strip() or "(untitled)"
-            lines.append(f"- {epic_id} [{epic_status}] {epic_title}")
-            for issue in deferred:
-                issue_id = str(issue.get("id") or "").strip() or "(unknown)"
-                issue_status = (
-                    lifecycle.canonical_lifecycle_status(issue.get("status")) or "unknown"
-                )
-                issue_title = str(issue.get("title") or "").strip() or "(untitled)"
-                lines.append(f"  - {issue_id} [{issue_status}] {issue_title}")
-
-    if skipped_epics:
-        lines.append(
-            "Deferred changeset scan limited to first "
-            f"{scan_limit} active epics; skipped {skipped_epics}."
-        )
-
-
 def _resolve_agent_id(requested_agent_id: str | None) -> str:
     candidate = str(requested_agent_id or "").strip()
     if candidate:
@@ -137,66 +98,24 @@ def _startup_helper(*, beads_root: Path, repo_root: Path) -> StartupBeadsInvocat
 
 
 def _render_startup_overview(agent_id: str, *, beads_root: Path, repo_root: Path) -> str:
-    lines: list[str] = ["Planner startup overview", f"- Beads root: {beads_root}"]
     helper = _startup_helper(beads_root=beads_root, repo_root=repo_root)
     command_result: StartupCommandResult = execute_startup_command_plan(
         agent_id,
         helper=helper,
     )
-
-    inbox = command_result.inbox_messages
-    if inbox:
-        lines.append("Unread messages:")
-        for issue in sorted(inbox, key=_issue_sort_key):
-            lines.append(f"- {issue.get('id') or ''} {issue.get('title') or ''}")
-    else:
-        lines.append("No unread messages.")
-
-    queued = command_result.queued_messages
-    if queued:
-        lines.append("Queued messages:")
-        for issue in sorted(queued, key=_issue_sort_key):
-            lines.append(
-                f"- {issue.get('id') or ''} [{issue.get('queue') or 'queue'}] "
-                f"{issue.get('title') or ''} | claim: {_queue_claim_state(issue)}"
-            )
-    else:
-        lines.append("No queued messages.")
-
-    epics = command_result.epics
-    lines.append(f"- Total epics: {len(epics)}")
-    parity = command_result.parity_report
-    lines.append(
-        f"- Active top-level work (open/in_progress/blocked): {parity.active_top_level_work_count}"
-    )
-    lines.append(f"- Indexed active epics (at:epic discovery): {parity.indexed_active_epic_count}")
-    if parity.in_parity:
-        lines.append("Epic discovery parity: ok")
-    if parity.missing_executable_identity:
-        lines.append("Identity guardrail violations (deterministic remediation):")
-        for violation in parity.missing_executable_identity:
-            labels = ", ".join(violation.labels) if violation.labels else "(none)"
-            lines.append(
-                f"- {violation.issue_id} [status={violation.status or 'missing'} "
-                f"type={violation.issue_type or 'missing'}] labels={labels}"
-            )
-            lines.append(f"  remediation: {violation.remediation_command}")
-    if parity.missing_from_index:
-        lines.append("Discovery index mismatch for executable top-level work:")
-        for issue_id in parity.missing_from_index:
-            lines.append(f"- {issue_id}")
-        lines.append(
-            "  remediation: run `bd prime`; if mismatch persists, run "
-            "`bd doctor --fix --yes` and rerun startup."
-        )
-
-    _append_deferred_changeset_summary(
-        lines,
-        epics,
+    deferred_groups, skipped_epics, scan_limit = _deferred_descendant_changesets(
+        command_result.epics,
         helper=helper,
     )
-    lines.extend(planner_overview.render_epics(epics, show_drafts=True).splitlines())
-    return "\n".join(lines)
+    triage_model = build_startup_triage_model(
+        beads_root=beads_root,
+        command_result=command_result,
+        deferred_groups=deferred_groups,
+        deferred_scan_limit=scan_limit,
+        deferred_scan_skipped_epics=skipped_epics,
+        epic_list_markdown=planner_overview.render_epics(command_result.epics, show_drafts=True),
+    )
+    return render_startup_triage_markdown(triage_model)
 
 
 def main() -> None:

--- a/tests/atelier/fixtures/planner_startup_check/startup_triage_empty.txt
+++ b/tests/atelier/fixtures/planner_startup_check/startup_triage_empty.txt
@@ -1,0 +1,11 @@
+Planner startup overview
+- Beads root: /beads
+No unread messages.
+No queued messages.
+- Total epics: 0
+- Active top-level work (open/in_progress/blocked): 0
+- Indexed active epics (at:epic discovery): 0
+Epic discovery parity: ok
+No deferred changesets under open/in-progress/blocked epics.
+Epics by state:
+- (none)

--- a/tests/atelier/fixtures/planner_startup_check/startup_triage_full.txt
+++ b/tests/atelier/fixtures/planner_startup_check/startup_triage_full.txt
@@ -1,0 +1,32 @@
+Planner startup overview
+- Beads root: /beads
+Unread messages:
+- at-msg-1 First
+- at-msg-2 Second
+Queued messages:
+- at-q-1 [planner] Queued first | claim: unclaimed
+- at-q-2 [planner] Queued second | claim: claimed by worker
+- Total epics: 3
+- Active top-level work (open/in_progress/blocked): 3
+- Indexed active epics (at:epic discovery): 2
+Identity guardrail violations (deterministic remediation):
+- at-missing-1 [status=missing type=missing] labels=(none)
+  remediation: (missing remediation command)
+- at-missing-2 [status=open type=epic] labels=alpha, zeta
+  remediation: bd update at-missing-2 --type epic --add-label at:epic
+Discovery index mismatch for executable top-level work:
+- at-a
+- at-z
+  remediation: run `bd prime`; if mismatch persists, run `bd doctor --fix --yes` and rerun startup.
+Deferred changesets under open/in-progress/blocked epics:
+- at-1 [open] Open epic
+  - at-1.1 [deferred] Alpha deferred
+- at-2 [blocked] Blocked epic
+  - at-2.1 [deferred] Deferred first
+  - at-2.2 [deferred] Deferred second
+Deferred changeset scan limited to first 1 active epics; skipped 2.
+Epics by state:
+Open epics:
+- at-1 [open] Open epic
+Blocked epics:
+- at-2 [blocked] Blocked epic

--- a/tests/atelier/test_planner_startup_check.py
+++ b/tests/atelier/test_planner_startup_check.py
@@ -1,19 +1,29 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from atelier import planner_startup_check
 
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures" / "planner_startup_check"
 
-def _parity() -> SimpleNamespace:
+
+def _parity(
+    *,
+    active_top_level_work_count: int = 1,
+    indexed_active_epic_count: int = 1,
+    missing_executable_identity: tuple[object, ...] = (),
+    missing_from_index: tuple[str, ...] = (),
+    in_parity: bool = True,
+) -> SimpleNamespace:
     return SimpleNamespace(
-        active_top_level_work_count=1,
-        indexed_active_epic_count=1,
-        missing_executable_identity=(),
-        missing_from_index=(),
-        in_parity=True,
+        active_top_level_work_count=active_top_level_work_count,
+        indexed_active_epic_count=indexed_active_epic_count,
+        missing_executable_identity=missing_executable_identity,
+        missing_from_index=missing_from_index,
+        in_parity=in_parity,
     )
 
 
@@ -72,3 +82,148 @@ def test_execute_startup_command_plan_runs_steps_in_order() -> None:
     assert calls == ["inbox", "queue", "epics", "parity"]
     assert [issue["id"] for issue in result.inbox_messages] == ["at-msg-1"]
     assert [issue["id"] for issue in result.epics] == ["at-1"]
+
+
+def test_build_startup_triage_model_normalizes_and_sorts_sections() -> None:
+    command_result = planner_startup_check.StartupCommandResult(
+        inbox_messages=[
+            {"id": "at-msg-2", "title": "Beta"},
+            {"id": "at-msg-1", "title": "Alpha"},
+        ],
+        queued_messages=[
+            {"id": "at-q-2", "title": "Second", "queue": "planner", "claimed_by": "worker-1"},
+            {"id": "at-q-1", "title": "First", "queue": "planner", "claimed_by": ""},
+        ],
+        epics=[
+            {"id": "at-2", "title": "Beta epic", "status": "blocked"},
+            {"id": "at-1", "title": "Alpha epic", "status": "open"},
+        ],
+        parity_report=_parity(active_top_level_work_count=2, indexed_active_epic_count=2),
+    )
+
+    model = planner_startup_check.build_startup_triage_model(
+        beads_root=Path("/beads"),
+        command_result=command_result,
+        deferred_groups=[
+            (
+                {"id": "at-2", "title": "Beta epic", "status": "blocked"},
+                [
+                    {"id": "at-2.2", "title": "Second deferred", "status": "deferred"},
+                    {"id": "at-2.1", "title": "First deferred", "status": "deferred"},
+                ],
+            ),
+            (
+                {"id": "at-1", "title": "Alpha epic", "status": "open"},
+                [{"id": "at-1.1", "title": "Alpha deferred", "status": "deferred"}],
+            ),
+        ],
+        deferred_scan_limit=25,
+        deferred_scan_skipped_epics=0,
+        epic_list_markdown="Epics by state:\n- (none)",
+    )
+
+    assert [message.issue_id for message in model.inbox_messages] == ["at-msg-1", "at-msg-2"]
+    assert [message.issue_id for message in model.queued_messages] == ["at-q-1", "at-q-2"]
+    assert [group.epic.issue_id for group in model.deferred_changesets] == ["at-1", "at-2"]
+    assert [issue.issue_id for issue in model.deferred_changesets[1].changesets] == [
+        "at-2.1",
+        "at-2.2",
+    ]
+
+
+def test_render_startup_triage_markdown_snapshot_empty() -> None:
+    command_result = planner_startup_check.StartupCommandResult(
+        inbox_messages=[],
+        queued_messages=[],
+        epics=[],
+        parity_report=_parity(
+            active_top_level_work_count=0,
+            indexed_active_epic_count=0,
+            in_parity=True,
+        ),
+    )
+
+    model = planner_startup_check.build_startup_triage_model(
+        beads_root=Path("/beads"),
+        command_result=command_result,
+        deferred_groups=[],
+        deferred_scan_limit=25,
+        deferred_scan_skipped_epics=0,
+        epic_list_markdown="Epics by state:\n- (none)",
+    )
+
+    rendered = planner_startup_check.render_startup_triage_markdown(model)
+    expected = (FIXTURES_DIR / "startup_triage_empty.txt").read_text(encoding="utf-8").rstrip("\n")
+    assert rendered == expected
+
+
+def test_render_startup_triage_markdown_snapshot_full_state() -> None:
+    parity = _parity(
+        active_top_level_work_count=3,
+        indexed_active_epic_count=2,
+        in_parity=False,
+        missing_executable_identity=(
+            SimpleNamespace(
+                issue_id="at-missing-2",
+                status="open",
+                issue_type="epic",
+                labels=("zeta", "alpha"),
+                remediation_command="bd update at-missing-2 --type epic --add-label at:epic",
+            ),
+            SimpleNamespace(
+                issue_id="at-missing-1",
+                status="",
+                issue_type="",
+                labels=(),
+                remediation_command="",
+            ),
+        ),
+        missing_from_index=("at-z", "at-a"),
+    )
+    command_result = planner_startup_check.StartupCommandResult(
+        inbox_messages=[
+            {"id": "at-msg-2", "title": "Second"},
+            {"id": "at-msg-1", "title": "First"},
+        ],
+        queued_messages=[
+            {"id": "at-q-2", "title": "Queued second", "queue": "planner", "claimed_by": "worker"},
+            {"id": "at-q-1", "title": "Queued first", "queue": "planner", "claimed_by": ""},
+        ],
+        epics=[
+            {"id": "at-2", "title": "Blocked epic", "status": "blocked"},
+            {"id": "at-1", "title": "Open epic", "status": "open"},
+            {"id": "at-3", "title": "Another epic", "status": "in_progress"},
+        ],
+        parity_report=parity,
+    )
+
+    model = planner_startup_check.build_startup_triage_model(
+        beads_root=Path("/beads"),
+        command_result=command_result,
+        deferred_groups=[
+            (
+                {"id": "at-2", "title": "Blocked epic", "status": "blocked"},
+                [
+                    {"id": "at-2.2", "title": "Deferred second", "status": "deferred"},
+                    {"id": "at-2.1", "title": "Deferred first", "status": "deferred"},
+                ],
+            ),
+            (
+                {"id": "at-1", "title": "Open epic", "status": "open"},
+                [{"id": "at-1.1", "title": "Alpha deferred", "status": "deferred"}],
+            ),
+        ],
+        deferred_scan_limit=1,
+        deferred_scan_skipped_epics=2,
+        epic_list_markdown=(
+            "Epics by state:\n"
+            "Open epics:\n"
+            "- at-1 [open] Open epic\n"
+            "Blocked epics:\n"
+            "- at-2 [blocked] Blocked epic"
+        ),
+    )
+
+    rendered = planner_startup_check.render_startup_triage_markdown(model)
+    expected = (FIXTURES_DIR / "startup_triage_full.txt").read_text(encoding="utf-8").rstrip("\n")
+    assert rendered == expected


### PR DESCRIPTION
# Summary

- Render planner startup triage from a typed, deterministic model instead of
  assembling markdown directly from ad-hoc shell output fields.

# Changes

- Added a structured startup triage data model in
  `planner_startup_check.py` that captures inbox, queue, deferred changesets,
  parity diagnostics, and epic-list markdown.
- Added a deterministic markdown renderer for that model so equivalent inputs
  always produce byte-stable startup overview output.
- Updated `refresh_overview.py` to collect command results, build the typed
  model, and render exclusively through the deterministic renderer.
- Added snapshot fixtures and tests for empty/full representative startup
  states, plus coverage for normalization/sorting behavior in the model builder.

# Testing

- `just format`
- `just lint`
- `/Users/scott/code/atelier/.venv/bin/python -m pytest tests/atelier/test_planner_startup_check.py tests/atelier/skills/test_planner_startup_refresh_script.py -q`
- `just test` (fails during collection in this environment with
  `ModuleNotFoundError: pydantic_core._pydantic_core` imported from
  `/Users/scott/.local/share/uv/tools/atelier/lib/python3.11/site-packages`)

# Tickets

- Fixes #476

# Risks / Rollout

- Low risk: this is a refactor of startup overview assembly with deterministic
  sorting and snapshot coverage; output sections are preserved.

# Notes

- Snapshot fixtures use `.txt` to avoid markdown auto-formatting mutating the
  expected byte-for-byte output.
