### PR TITLE
Prevent stale closed PR lifecycle escalations during finalize

### DIFF
--- a/src/atelier/worker/finalize_pipeline.py
+++ b/src/atelier/worker/finalize_pipeline.py
@@ -291,14 +291,15 @@ def _refresh_closed_active_pr_lifecycle(
         if terminal_result is not None:
             return False, _with_stale_signal_recovery_reason(terminal_result)
         return False, None
-    if refreshed_lifecycle in {"pushed", "draft-pr", "pr-open", "in-review", "approved"}:
+    active_lifecycles = {"pushed", "draft-pr", "pr-open", "in-review", "approved"}
+    if refreshed_lifecycle in active_lifecycles:
         return True, None
-    atelier_log.info(
+    atelier_log.warning(
         "changeset="
-        f"{changeset_id} finalize recovered stale active lifecycle via refresh "
-        f"(state={refreshed_lifecycle or 'none'})"
+        f"{changeset_id} finalize PR lifecycle refresh was indeterminate "
+        f"(state={refreshed_lifecycle or 'none'}); preserving active lifecycle guard"
     )
-    return False, None
+    return True, None
 
 
 @dataclass(frozen=True)

--- a/tests/atelier/worker/test_finalize_pipeline.py
+++ b/tests/atelier/worker/test_finalize_pipeline.py
@@ -840,6 +840,51 @@ def test_run_finalize_pipeline_escalates_closed_active_lifecycle_only_after_refr
     assert notifications == ["NEEDS-DECISION: Closed changeset has active PR lifecycle (at-epic.1)"]
 
 
+def test_run_finalize_pipeline_escalates_closed_active_lifecycle_when_refresh_indeterminate(
+    monkeypatch,
+) -> None:
+    issue = {
+        "id": "at-epic.1",
+        "status": "closed",
+        "labels": [],
+        "description": "changeset.work_branch: feat/root-at-epic.1\n",
+    }
+    monkeypatch.setattr(
+        finalize_pipeline.beads,
+        "run_bd_json",
+        lambda *_args, **_kwargs: [issue],
+    )
+    monkeypatch.setattr(
+        finalize_pipeline.git,
+        "git_ref_exists",
+        lambda *_args, **_kwargs: False,
+    )
+
+    service = _FinalizeServiceStub()
+    service.changeset_waiting_on_review_or_signals_fn = lambda _issue, *, context: True
+    service.lookup_pr_payload_fn = lambda _repo_slug, _branch: {
+        "state": "OPEN",
+        "isDraft": False,
+    }
+    service.lookup_pr_payload_diagnostic_fn = lambda _repo_slug, _branch: (None, None)
+    reopened: list[str] = []
+    notifications: list[str] = []
+    service.mark_changeset_in_progress_fn = lambda changeset_id: reopened.append(changeset_id)
+    service.send_planner_notification_fn = lambda **kwargs: notifications.append(
+        str(kwargs.get("subject"))
+    )
+
+    result = finalize_pipeline.run_finalize_pipeline(
+        context=_pipeline_context(repo_slug="org/repo"),
+        service=service,
+    )
+
+    assert result.reason == "changeset_closed_pr_lifecycle_active"
+    assert result.continue_running is False
+    assert reopened == ["at-epic.1"]
+    assert notifications == ["NEEDS-DECISION: Closed changeset has active PR lifecycle (at-epic.1)"]
+
+
 def test_run_finalize_pipeline_blocks_closed_changeset_when_pr_lookup_is_ambiguous(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
# Summary

- Prevent stale closed+active PR lifecycle signals from escalating to planner before finalize performs a deterministic refresh.
- Reconcile refreshed terminal PR lifecycle (`merged`/`closed`) directly in finalize so merged work closes without spurious intervention.

# Changes

- Add a closed-state lifecycle refresh step in `run_finalize_pipeline` before `Closed changeset has active PR lifecycle` escalation.
- Introduce explicit finalize reason codes that distinguish stale-signal recovery from refresh/query failures.
- Keep unresolved active lifecycle escalation behavior, but only after refreshed lifecycle still resolves as non-terminal.
- Add regression coverage for merged-then-message incident windows tied to PRs #494 and #496, plus refresh-failure and post-refresh active escalation cases.

# Testing

- `uv run pytest tests/atelier/worker/test_finalize_pipeline.py -q`
- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #499

# Risks / Rollout

- Low risk: change is scoped to finalize closed-state PR lifecycle handling and backed by targeted + full-suite tests.

# Notes

- Existing planner escalation subject lines are preserved for unresolved lifecycle mismatches.
