### PR TITLE
Converge doctor --fix prefix drift and non-actionable blockers

### DIFF
--- a/src/atelier/commands/doctor.py
+++ b/src/atelier/commands/doctor.py
@@ -74,6 +74,8 @@ class _DoctorFinding:
 
     @property
     def startup_blocker(self) -> bool:
+        if self.code == "prefix-migration-drift" and not bool(self.details.get("changed")):
+            return False
         return self.code in _STARTUP_BLOCKER_CODES
 
     def as_dict(self) -> dict[str, object]:
@@ -631,16 +633,25 @@ def _prefix_drift_remediation(
 ) -> str:
     notes: list[str] = []
     if action.changed:
+        targets: list[str] = []
+        if action.update_changeset_metadata:
+            targets.append("changeset lineage")
+        if action.update_changeset_worktree_path:
+            targets.append("changeset worktree_path")
+        if action.update_mapping:
+            targets.append("mapping branch/worktree")
+        target_summary = ", ".join(targets) if targets else "lineage metadata"
         if fix:
-            notes.append("repair applied in fix mode")
+            notes.append(f"repair applied in fix mode; updated {target_summary}")
+            notes.append("rerun `atelier doctor` to confirm zero prefix drift findings")
         else:
-            notes.append("run `atelier doctor --fix` to apply canonical repair")
+            notes.append(f"run `atelier doctor --fix` to update {target_summary}")
     else:
-        notes.append("no persistent update required")
+        notes.append("drift is non-actionable: canonical branch/worktree already aligned")
     if "work-branch-conflict" in action.drift_classes:
         notes.append("resolves startup work-branch override conflicts")
     if "worktree-path-conflict" in action.drift_classes:
-        notes.append("aligns changeset worktree path metadata/mapping")
+        notes.append("converges worktree path to canonical branch-selected location")
     return "; ".join(notes)
 
 

--- a/src/atelier/prefix_migration_drift.py
+++ b/src/atelier/prefix_migration_drift.py
@@ -212,6 +212,18 @@ def _distinct_values(*values: str | None) -> tuple[str, ...]:
     return tuple(sorted({value for value in values if value is not None}))
 
 
+def _filesystem_path_for_branch(
+    git_index: _GitWorktreeIndex,
+    branch: str | None,
+) -> str | None:
+    if branch is None:
+        return None
+    paths = git_index.branch_to_paths.get(branch)
+    if not paths:
+        return None
+    return paths[0]
+
+
 def _changesets_for_epic(
     epic_id: str,
     *,
@@ -405,16 +417,11 @@ def _resolve_repair_action(
             lookup_pr_status=lookup_pr_status,
         )
 
-    filesystem_path_for_metadata_branch = None
-    if metadata_work_branch is not None:
-        paths = git_index.branch_to_paths.get(metadata_work_branch)
-        if paths:
-            filesystem_path_for_metadata_branch = paths[0]
     filesystem_path_for_canonical_branch = None
     if changeset_id == epic_id:
-        canonical_branch_paths = git_index.branch_to_paths.get(canonical_root)
-        if canonical_branch_paths:
-            filesystem_path_for_canonical_branch = canonical_branch_paths[0]
+        filesystem_path_for_canonical_branch = _filesystem_path_for_branch(
+            git_index, canonical_root
+        )
 
     if changeset_id == epic_id:
         canonical_work_branch = canonical_root
@@ -448,25 +455,22 @@ def _resolve_repair_action(
             canonical_work_branch = derived_work_branch
             work_branch_source = "derived"
 
-        canonical_branch_paths = git_index.branch_to_paths.get(canonical_work_branch)
-        if canonical_branch_paths:
-            filesystem_path_for_canonical_branch = canonical_branch_paths[0]
+        filesystem_path_for_canonical_branch = _filesystem_path_for_branch(
+            git_index, canonical_work_branch
+        )
 
-        if mapped_branch is not None and mapped_relpath is not None:
-            canonical_worktree = mapped_relpath
-            worktree_source = "checked-out-worktree"
-        elif filesystem_path_for_canonical_branch is not None:
+        if filesystem_path_for_canonical_branch is not None:
             canonical_worktree = filesystem_path_for_canonical_branch
             worktree_source = "filesystem-canonical-branch"
-        elif filesystem_path_for_metadata_branch is not None:
-            canonical_worktree = filesystem_path_for_metadata_branch
-            worktree_source = "filesystem-metadata-branch"
-        elif mapping_worktree_path is not None:
-            canonical_worktree = mapping_worktree_path
-            worktree_source = "mapping"
-        elif metadata_worktree_path is not None:
+        elif mapped_branch == canonical_work_branch and mapped_relpath is not None:
+            canonical_worktree = mapped_relpath
+            worktree_source = "checked-out-worktree"
+        elif metadata_work_branch == canonical_work_branch and metadata_worktree_path is not None:
             canonical_worktree = metadata_worktree_path
             worktree_source = "metadata"
+        elif mapping_work_branch == canonical_work_branch and mapping_worktree_path is not None:
+            canonical_worktree = mapping_worktree_path
+            worktree_source = "mapping"
         else:
             canonical_worktree = worktrees.changeset_worktree_relpath(changeset_id)
             worktree_source = "default"
@@ -544,6 +548,8 @@ def repair_prefix_migration_drift(
     repo_slug: str | None = None,
     git_path: str | None = None,
     lookup_pr_status: PrLookupStatus = prs.lookup_github_pr_status,
+    target_epic_id: str | None = None,
+    target_changeset_ids: Collection[str] | None = None,
 ) -> list[PrefixMigrationRepairAction]:
     """Plan or apply deterministic repairs for prefix-migration drift.
 
@@ -555,6 +561,9 @@ def repair_prefix_migration_drift(
         repo_slug: Optional GitHub ``owner/name`` for PR-head evidence.
         git_path: Optional git executable override.
         lookup_pr_status: PR lookup adapter for tests and runtime injection.
+        target_epic_id: Optional epic id to scope planned/applied actions.
+        target_changeset_ids: Optional changeset ids to scope work within
+            ``target_epic_id``.
 
     Returns:
         Planned or applied actions for drifted changesets, sorted
@@ -567,6 +576,8 @@ def repair_prefix_migration_drift(
         repo_slug=repo_slug,
         git_path=git_path,
         lookup_pr_status=lookup_pr_status,
+        target_epic_id=target_epic_id,
+        target_changeset_ids=target_changeset_ids,
     )
     drift_classes = _drift_classes_by_changeset(drift_records)
     if not drift_classes:

--- a/src/atelier/worker/session/worktree.py
+++ b/src/atelier/worker/session/worktree.py
@@ -88,6 +88,20 @@ def _startup_worktree_preflight(
     if not target_changesets:
         return
 
+    planned_actions = prefix_migration_drift.repair_prefix_migration_drift(
+        project_data_dir=project_data_dir,
+        beads_root=beads_root,
+        repo_root=repo_root,
+        apply=False,
+        repo_slug=repo_slug,
+        git_path=git_path,
+        target_epic_id=selected_epic,
+        target_changeset_ids=target_changesets,
+    )
+    planned_action_by_key = {
+        (action.epic_id, action.changeset_id): action for action in planned_actions
+    }
+
     drift_records = prefix_migration_drift.scan_prefix_migration_drift(
         project_data_dir=project_data_dir,
         beads_root=beads_root,
@@ -108,7 +122,26 @@ def _startup_worktree_preflight(
         if record_changeset_id not in target_changesets:
             continue
         record_epic_id = _normalize_drift_value(record.get("epic_id")) or "<unknown>"
-        values_json = _format_drift_values(record.get("values"))
+        action = planned_action_by_key.get((record_epic_id, record_changeset_id))
+        if drift_class == "metadata-read-failure":
+            actionable = True
+        elif action is None:
+            actionable = True
+        else:
+            actionable = action.changed and drift_class in action.drift_classes
+        if not actionable:
+            continue
+
+        raw_values = record.get("values")
+        details = dict(raw_values) if isinstance(raw_values, dict) else {}
+        if action is not None:
+            details["repair.changed"] = action.changed
+            details["repair.canonical_work_branch"] = action.canonical_work_branch
+            details["repair.canonical_worktree_path"] = action.canonical_worktree_path
+            details["repair.update_mapping"] = action.update_mapping
+            details["repair.update_changeset_metadata"] = action.update_changeset_metadata
+            details["repair.update_changeset_worktree_path"] = action.update_changeset_worktree_path
+        values_json = _format_drift_values(details)
         diagnostics.append(
             "check=prefix-migration-preflight "
             f"epic={record_epic_id} "

--- a/tests/atelier/commands/test_doctor.py
+++ b/tests/atelier/commands/test_doctor.py
@@ -154,6 +154,64 @@ def test_doctor_json_fix_mode_reports_applied() -> None:
     assert "bd export" not in "\n".join(guidance.values())
 
 
+def test_doctor_json_non_actionable_prefix_drift_not_counted_as_startup_blocker() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        project_root = root / "project"
+        repo_root = root / "repo"
+        project_root.mkdir(parents=True, exist_ok=True)
+        repo_root.mkdir(parents=True, exist_ok=True)
+        project_config = config.ProjectConfig.model_validate(
+            {"project": {"enlistment": str(repo_root), "origin": "github.com/org/repo"}}
+        )
+        actions = [
+            PrefixMigrationRepairAction(
+                epic_id="epic-1",
+                changeset_id="epic-1.2",
+                drift_classes=("worktree-path-conflict",),
+                canonical_root_branch="feat/root",
+                canonical_work_branch="feat/root-epic-1.2",
+                work_branch_source="open-pr-head",
+                canonical_worktree_path="worktrees/epic-1.2",
+                worktree_path_source="filesystem-canonical-branch",
+                pr_head_ref="feat/root-epic-1.2",
+                pr_lookup_branch="at/legacy-epic-1.2",
+                update_workspace_root_branch=False,
+                update_changeset_metadata=False,
+                update_changeset_worktree_path=False,
+                update_mapping=False,
+                applied=False,
+            )
+        ]
+        with (
+            patch(
+                "atelier.commands.doctor.resolve_current_project_with_repo_root",
+                return_value=(project_root, project_config, str(repo_root), repo_root),
+            ),
+            patch("atelier.commands.doctor.beads.run_bd_command", return_value=DummyResult()),
+            patch(
+                "atelier.commands.doctor.prefix_migration_drift.repair_prefix_migration_drift",
+                return_value=actions,
+            ),
+            patch(
+                "atelier.commands.doctor._collect_doctor_context",
+                return_value=_empty_context(project_root),
+            ),
+            patch("atelier.commands.doctor._collect_agent_runtime", return_value=({}, {})),
+        ):
+            buffer = io.StringIO()
+            with patch("sys.stdout", buffer):
+                doctor_cmd.doctor(SimpleNamespace(format="json", fix=False))
+
+    payload = json.loads(buffer.getvalue())
+    prefix_findings = payload["checks"]["prefix_migration_drift"]["findings"]
+    assert len(prefix_findings) == 1
+    assert prefix_findings[0]["startup_blocker"] is False
+    assert payload["counts"]["startup_blockers"] == 0
+    assert payload["prefix_normalization"]["required"] is False
+    assert "non-actionable" in prefix_findings[0]["remediation"]
+
+
 def test_doctor_json_includes_multi_check_health_report() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)

--- a/tests/atelier/test_prefix_migration_drift.py
+++ b/tests/atelier/test_prefix_migration_drift.py
@@ -415,7 +415,7 @@ def test_repair_prefix_migration_drift_plans_updates_without_applying(tmp_path: 
     assert action.canonical_work_branch == "feat/pr-head"
     assert action.work_branch_source == "open-pr-head"
     assert action.canonical_worktree_path == "worktrees/ts-epic.1"
-    assert action.worktree_path_source == "filesystem-metadata-branch"
+    assert action.worktree_path_source == "default"
     assert action.update_changeset_metadata is True
     assert action.update_changeset_worktree_path is True
     assert action.update_mapping is True
@@ -518,6 +518,86 @@ def test_repair_prefix_migration_drift_apply_updates_mapping_and_metadata(tmp_pa
     assert updated_mapping.root_branch == "feat/new-root"
     assert updated_mapping.changesets["ts-epic.1"] == "feat/pr-head"
     assert updated_mapping.changeset_worktrees["ts-epic.1"] == "worktrees/ts-epic.1"
+
+
+def test_repair_prefix_migration_drift_converges_duplicate_branch_paths_deterministically(
+    tmp_path: Path,
+) -> None:
+    project_data_dir = tmp_path / "data"
+    repo_root = tmp_path / "repo"
+    project_data_dir.mkdir(parents=True)
+    repo_root.mkdir(parents=True)
+    mapping_path = worktrees.mapping_path(project_data_dir, "ts-epic")
+    worktrees.write_mapping(
+        mapping_path,
+        worktrees.WorktreeMapping(
+            epic_id="ts-epic",
+            worktree_path="worktrees/ts-epic",
+            root_branch="feat/new-root",
+            changesets={"ts-epic.1": "feat/pr-head"},
+            changeset_worktrees={"ts-epic.1": "worktrees/ts-epic.1"},
+        ),
+    )
+    legacy_path = project_data_dir / "worktrees" / "at-legacy-ts-epic.1"
+    legacy_path.mkdir(parents=True)
+    (legacy_path / ".git").write_text("gitdir: /tmp/gitdir", encoding="utf-8")
+    canonical_path = project_data_dir / "worktrees" / "ts-epic.1"
+    canonical_path.mkdir(parents=True)
+    (canonical_path / ".git").write_text("gitdir: /tmp/gitdir", encoding="utf-8")
+
+    epic_issue = {
+        "id": "ts-epic",
+        "labels": ["at:epic"],
+        "description": "workspace.root_branch: feat/new-root\n",
+    }
+    changeset_issue = {
+        "id": "ts-epic.1",
+        "labels": [],
+        "type": "task",
+        "description": (
+            "changeset.root_branch: feat/new-root\n"
+            "changeset.work_branch: feat/pr-head\n"
+            "worktree_path: worktrees/ts-epic.1\n"
+        ),
+    }
+    worktree_output = _git_worktree_output(legacy_path, "feat/pr-head") + _git_worktree_output(
+        canonical_path, "feat/pr-head"
+    )
+
+    with (
+        patch("atelier.prefix_migration_drift.beads.list_epics", return_value=[epic_issue]),
+        patch(
+            "atelier.prefix_migration_drift.beads.list_descendant_changesets",
+            return_value=[changeset_issue],
+        ),
+        patch("atelier.prefix_migration_drift.beads.list_work_children", return_value=[]),
+        patch(
+            "atelier.prefix_migration_drift.exec_util.try_run_command",
+            return_value=subprocess.CompletedProcess(
+                args=["git", "worktree", "list", "--porcelain"],
+                returncode=0,
+                stdout=worktree_output,
+                stderr="",
+            ),
+        ),
+        patch("atelier.prefix_migration_drift.git.git_current_branch", return_value="feat/pr-head"),
+    ):
+        actions = prefix_migration_drift.repair_prefix_migration_drift(
+            project_data_dir=project_data_dir,
+            beads_root=tmp_path / ".beads",
+            repo_root=repo_root,
+            apply=False,
+        )
+
+    assert len(actions) == 1
+    action = actions[0]
+    assert action.changed is True
+    assert action.canonical_work_branch == "feat/pr-head"
+    assert action.canonical_worktree_path == "worktrees/at-legacy-ts-epic.1"
+    assert action.worktree_path_source == "filesystem-canonical-branch"
+    assert action.update_changeset_metadata is False
+    assert action.update_changeset_worktree_path is True
+    assert action.update_mapping is True
 
 
 def test_scan_prefix_migration_drift_reports_mixed_legacy_prefix_states(tmp_path: Path) -> None:

--- a/tests/atelier/worker/test_session_worktree.py
+++ b/tests/atelier/worker/test_session_worktree.py
@@ -91,8 +91,33 @@ def test_prepare_worktrees_blocks_before_mutations_on_prefix_drift_for_selected_
             }
         ]
     )
+    plan_repairs = Mock(
+        return_value=[
+            worktree.prefix_migration_drift.PrefixMigrationRepairAction(
+                epic_id="at-epic",
+                changeset_id="at-epic.1",
+                drift_classes=("work-branch-conflict",),
+                canonical_root_branch="feat/new",
+                canonical_work_branch="feat/new-at-epic.1",
+                work_branch_source="derived",
+                canonical_worktree_path="worktrees/at-epic.1",
+                worktree_path_source="default",
+                pr_head_ref=None,
+                pr_lookup_branch=None,
+                update_workspace_root_branch=False,
+                update_changeset_metadata=True,
+                update_changeset_worktree_path=True,
+                update_mapping=True,
+                applied=False,
+            )
+        ]
+    )
 
     with (
+        patch(
+            "atelier.worker.session.worktree.prefix_migration_drift.repair_prefix_migration_drift",
+            plan_repairs,
+        ),
         patch(
             "atelier.worker.session.worktree.prefix_migration_drift.scan_prefix_migration_drift",
             scan_drift,
@@ -138,6 +163,16 @@ def test_prepare_worktrees_blocks_before_mutations_on_prefix_drift_for_selected_
         target_epic_id="at-epic",
         target_changeset_ids={"at-epic", "at-epic.1"},
     )
+    plan_repairs.assert_called_once_with(
+        project_data_dir=Path("/project"),
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+        apply=False,
+        repo_slug=None,
+        git_path="git",
+        target_epic_id="at-epic",
+        target_changeset_ids={"at-epic", "at-epic.1"},
+    )
     reconcile_mapping.assert_not_called()
     ensure_epic_worktree.assert_not_called()
     ensure_changeset_branch.assert_not_called()
@@ -164,8 +199,13 @@ def test_prepare_worktrees_blocks_before_mutations_on_targeted_metadata_read_fai
             }
         ]
     )
+    plan_repairs = Mock(return_value=[])
 
     with (
+        patch(
+            "atelier.worker.session.worktree.prefix_migration_drift.repair_prefix_migration_drift",
+            plan_repairs,
+        ),
         patch(
             "atelier.worker.session.worktree.prefix_migration_drift.scan_prefix_migration_drift",
             scan_drift,
@@ -211,10 +251,93 @@ def test_prepare_worktrees_blocks_before_mutations_on_targeted_metadata_read_fai
         target_epic_id="at-epic",
         target_changeset_ids={"at-epic", "at-epic.1"},
     )
+    plan_repairs.assert_called_once_with(
+        project_data_dir=Path("/project"),
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+        apply=False,
+        repo_slug=None,
+        git_path="git",
+        target_epic_id="at-epic",
+        target_changeset_ids={"at-epic", "at-epic.1"},
+    )
     reconcile_mapping.assert_not_called()
     ensure_epic_worktree.assert_not_called()
     ensure_changeset_branch.assert_not_called()
     assert not logs
+
+
+def test_startup_worktree_preflight_ignores_non_actionable_prefix_drift() -> None:
+    scan_drift = Mock(
+        return_value=[
+            {
+                "epic_id": "at-epic",
+                "changeset_id": "at-epic.1",
+                "drift_class": "worktree-path-conflict",
+                "values": {
+                    "metadata.worktree_path": "worktrees/ts-epic.1",
+                    "mapping.worktree_path": "worktrees/ts-epic.1",
+                    "filesystem.path_for_metadata_branch": "worktrees/at-legacy.1",
+                },
+            }
+        ]
+    )
+    plan_repairs = Mock(
+        return_value=[
+            worktree.prefix_migration_drift.PrefixMigrationRepairAction(
+                epic_id="at-epic",
+                changeset_id="at-epic.1",
+                drift_classes=("worktree-path-conflict",),
+                canonical_root_branch="feat/new",
+                canonical_work_branch="feat/new-at-epic.1",
+                work_branch_source="derived",
+                canonical_worktree_path="worktrees/ts-epic.1",
+                worktree_path_source="mapping",
+                pr_head_ref=None,
+                pr_lookup_branch=None,
+                update_workspace_root_branch=False,
+                update_changeset_metadata=False,
+                update_changeset_worktree_path=False,
+                update_mapping=False,
+                applied=False,
+            )
+        ]
+    )
+    mapping = worktrees.WorktreeMapping(
+        epic_id="at-epic",
+        worktree_path="worktrees/at-epic",
+        root_branch="feat/new",
+        changesets={"at-epic.1": "feat/new-at-epic.1"},
+        changeset_worktrees={"at-epic.1": "worktrees/ts-epic.1"},
+    )
+
+    with (
+        patch(
+            "atelier.worker.session.worktree.prefix_migration_drift.repair_prefix_migration_drift",
+            plan_repairs,
+        ),
+        patch(
+            "atelier.worker.session.worktree.prefix_migration_drift.scan_prefix_migration_drift",
+            scan_drift,
+        ),
+        patch("atelier.worker.session.worktree.git.git_origin_url", return_value=None),
+        patch("atelier.worker.session.worktree.prs.github_repo_slug", return_value=None),
+        patch("atelier.worker.session.worktree.worktrees.load_mapping", return_value=mapping),
+    ):
+        worktree._startup_worktree_preflight(
+            project_data_dir=Path("/project"),
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+            selected_epic="at-epic",
+            changeset_id="at-epic.1",
+            root_branch_value="feat/new",
+            changeset_parent_branch="feat/new",
+            allow_parent_branch_override=False,
+            git_path="git",
+        )
+
+    scan_drift.assert_called_once()
+    plan_repairs.assert_called_once()
 
 
 def test_prepare_worktrees_reconciles_ownership_before_worktree_setup(tmp_path: Path) -> None:


### PR DESCRIPTION
# Summary

- Make `atelier doctor --fix` converge prefix-migration drift when duplicate legacy worktree paths coexist, and avoid residual non-actionable startup blockers.

# Changes

- Updated prefix-drift repair path resolution to choose a deterministic worktree path from the selected canonical work branch, instead of preserving conflicting alternate mapping paths.
- Added scoped repair planning inputs (`target_epic_id`, `target_changeset_ids`) so startup preflight can evaluate only the selected changesets.
- Changed startup preflight blocker classification to fail on actionable drift (or metadata read failures) and ignore non-actionable drift records where no persistent update is required.
- Updated doctor startup-blocker semantics so `prefix-migration-drift` findings with `changed=false` are warnings, not startup blockers.
- Expanded remediation diagnostics to describe what fix mode updates and how to confirm a clean post-fix state.
- Added regression coverage for duplicate `at-*`/`ts-*` worktree coexistence and non-actionable preflight drift behavior.

# Testing

- `uv run pytest tests/atelier/test_prefix_migration_drift.py tests/atelier/worker/test_session_worktree.py tests/atelier/commands/test_doctor.py tests/atelier/test_prefix_migration_convergence.py -q`
- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #509

# Risks / Rollout

- This change can rewrite changeset worktree-path metadata/mapping when duplicate worktrees exist for the same canonical branch; behavior is deterministic and covered by regression tests.

# Notes

- No migration steps are required beyond running `atelier doctor --fix` in affected projects.
