### PR TITLE
Fix GC stale-agent cleanup pagination

### DIFF
--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -206,6 +206,8 @@ Atelier planning state. They are treated as external ticket sources.
 - `atelier gc`
 
   - Cleans up stale hooks, claims, orphaned worktrees, and stale queue claims.
+  - Scans the full `at:agent` bead set (`bd list --all --limit 0`) so a single
+    pass can release all stale session agents.
   - Closes channel messages when explicit retention metadata is present.
   - Channel retention metadata can be set via `retention_days` or `expires_at`
     in message frontmatter.

--- a/src/atelier/gc/agents.py
+++ b/src/atelier/gc/agents.py
@@ -18,7 +18,14 @@ def collect_agent_homes(
 ) -> list[GcAction]:
     actions: list[GcAction] = []
     agent_issues = beads.run_bd_json(
-        ["list", "--label", beads.issue_label("agent", beads_root=beads_root)],
+        [
+            "list",
+            "--label",
+            beads.issue_label("agent", beads_root=beads_root),
+            "--all",
+            "--limit",
+            "0",
+        ],
         beads_root=beads_root,
         cwd=repo_root,
     )

--- a/src/atelier/gc/hooks.py
+++ b/src/atelier/gc/hooks.py
@@ -38,7 +38,14 @@ def collect_hooks(
     actions: list[GcAction] = []
 
     agent_issues = beads.run_bd_json(
-        ["list", "--label", beads.issue_label("agent", beads_root=beads_root)],
+        [
+            "list",
+            "--label",
+            beads.issue_label("agent", beads_root=beads_root),
+            "--all",
+            "--limit",
+            "0",
+        ],
         beads_root=beads_root,
         cwd=repo_root,
     )

--- a/tests/atelier/gc/test_agents.py
+++ b/tests/atelier/gc/test_agents.py
@@ -119,3 +119,47 @@ def test_collect_agent_homes_prunes_stale_session_agent_beads_deterministically(
         ("close", "agent-stale-nohook"),
         ("cleanup", stale_no_hook_agent),
     ]
+
+
+def test_collect_agent_homes_scans_all_agent_pages_for_stale_sessions() -> None:
+    project_dir = Path("/project")
+    beads_root = Path("/beads")
+    repo_root = Path("/repo")
+
+    expected_args = ["list", "--label", "at:agent", "--all", "--limit", "0"]
+    total_agents = 75
+    stale_agents = [f"atelier/worker/codex/p{index:04d}-t1" for index in range(total_agents)]
+    agent_issues = [
+        {
+            "id": f"agent-{index}",
+            "title": agent_id,
+            "labels": ["at:agent"],
+            "description": f"agent_id: {agent_id}\nrole_type: worker\n",
+        }
+        for index, agent_id in enumerate(stale_agents)
+    ]
+
+    def fake_run_bd_json(
+        args: list[str], *, beads_root: Path, cwd: Path
+    ) -> list[dict[str, object]]:
+        if args == expected_args:
+            return agent_issues
+        return []
+
+    with (
+        patch("atelier.beads.run_bd_json", side_effect=fake_run_bd_json) as run_bd_json,
+        patch("atelier.beads.list_epics", return_value=[]),
+        patch("atelier.beads.get_agent_hook", return_value=None),
+        patch("atelier.agent_home.session_pid_from_agent_id", return_value=1234),
+        patch("atelier.agent_home.is_session_agent_active", return_value=False),
+    ):
+        actions = gc_agents.collect_agent_homes(
+            project_dir=project_dir,
+            beads_root=beads_root,
+            repo_root=repo_root,
+        )
+
+    assert len(actions) == total_agents
+    assert actions[0].description == f"Prune stale session agent bead for {stale_agents[0]}"
+    assert actions[-1].description == f"Prune stale session agent bead for {stale_agents[-1]}"
+    run_bd_json.assert_called_once_with(expected_args, beads_root=beads_root, cwd=repo_root)

--- a/tests/atelier/gc/test_hooks.py
+++ b/tests/atelier/gc/test_hooks.py
@@ -85,3 +85,53 @@ def test_release_epic_clears_assignee_and_hooked_label() -> None:
         expected_assignee="agent-1",
         expected_hooked=True,
     )
+
+
+def test_collect_hooks_scans_all_agent_pages_before_releasing_stale_hooks() -> None:
+    beads_root = Path("/beads")
+    repo_root = Path("/repo")
+    expected_args = ["list", "--label", "at:agent", "--all", "--limit", "0"]
+    total_agents = 75
+
+    agent_issues = [
+        {
+            "id": f"agent-{index}",
+            "title": f"atelier/worker/codex/p{index:04d}-t1",
+            "labels": ["at:agent"],
+            "description": f"agent_id: agent-{index}\nhook_bead: epic-{index}\n",
+        }
+        for index in range(total_agents)
+    ]
+
+    def fake_run_bd_json(
+        args: list[str], *, beads_root: Path, cwd: Path
+    ) -> list[dict[str, object]]:
+        if args == expected_args:
+            return agent_issues
+        return []
+
+    with (
+        patch("atelier.beads.run_bd_json", side_effect=fake_run_bd_json) as run_bd_json,
+        patch("atelier.beads.list_epics", return_value=[]),
+        patch(
+            "atelier.beads.get_agent_hook",
+            side_effect=lambda issue_id, *, beads_root, cwd: str(issue_id).replace("agent", "epic"),
+        ),
+        patch(
+            "atelier.gc.hooks.try_show_issue",
+            side_effect=lambda issue_id, **_kwargs: {"id": issue_id},
+        ),
+    ):
+        actions = gc_hooks.collect_hooks(
+            beads_root=beads_root,
+            repo_root=repo_root,
+            stale_hours=24.0,
+            include_missing_heartbeat=True,
+        )
+
+    assert len(actions) == total_agents
+    assert actions[0].description == "Release stale hook for agent-0 (epic epic-0)"
+    assert actions[-1].description == (
+        f"Release stale hook for agent-{total_agents - 1} (epic epic-{total_agents - 1})"
+    )
+    run_bd_json.assert_called_once_with(expected_args, beads_root=beads_root, cwd=repo_root)


### PR DESCRIPTION
# Summary

- Fix `atelier gc` stale-agent cleanup to scan the full `at:agent` bead set instead of one default page.
- Ensure one GC pass can process large projects with many stale session agents.

# Changes

- Updated GC agent listing in `gc/agents.py` and `gc/hooks.py` to use `bd list --all --limit 0` for `at:agent` queries.
- Added regression tests that simulate 75 agent beads for:
  - stale session agent-home pruning
  - stale hook release cleanup
- Documented full-scan `at:agent` behavior in `docs/behavior.md`.

# Testing

- `just format`
- `just lint`
- `UV_PYTHON=3.11 just test`

# Tickets

- Addresses #505

# Risks / Rollout

- Low risk: behavior is limited to GC list pagination for agent beads.
- Regression tests cover multi-page agent datasets to prevent relapses.

# Notes

- `just test` requires `UV_PYTHON=3.11` in this environment to avoid Python 3.14 `pydantic_core` import failures.
