### PR TITLE
Remove ambient ATELIER_PROJECT/ATELIER_WORKSPACE_DIR repo-hint fallbacks

### DIFF
--- a/src/atelier/auto_export.py
+++ b/src/atelier/auto_export.py
@@ -72,8 +72,7 @@ def resolve_auto_export_context(*, repo_hint: Path | None = None) -> AutoExportC
     Args:
         repo_hint: Optional filesystem path used to locate the Git enlistment.
             When omitted, the resolver uses runtime repo hint resolution
-            (`./worktree`, `ATELIER_WORKSPACE_DIR`, legacy
-            `ATELIER_PROJECT`), then the current working directory.
+            (`./worktree`), then the current working directory.
 
     Returns:
         A resolved context containing project config, project data dir,

--- a/src/atelier/beads_context.py
+++ b/src/atelier/beads_context.py
@@ -2,16 +2,12 @@
 
 from __future__ import annotations
 
-import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 
 from . import config, git
 from .commands.resolve import resolve_current_project_with_repo_root, resolve_project_for_enlistment
-
-LEGACY_ATELIER_PROJECT_FALLBACK_REMOVAL_DATE = "2026-07-01"
-LEGACY_ATELIER_WORKSPACE_DIR_FALLBACK_REMOVAL_DATE = "2026-07-01"
 
 
 @dataclass(frozen=True)
@@ -46,16 +42,17 @@ def resolve_runtime_repo_dir_hint(
     cwd: Path | None = None,
     env: Mapping[str, str] | None = None,
 ) -> tuple[str | None, str | None]:
-    """Resolve runtime repo-dir hint without depending on ambient ATELIER_PROJECT.
+    """Resolve runtime repo-dir hints from explicit input or local worktree link.
 
     Args:
         repo_dir: Optional explicit repo dir argument.
         cwd: Optional working directory override for deterministic testing.
         env: Optional environment override for deterministic testing.
+            Retained for API compatibility.
 
     Returns:
-        Tuple of ``(repo_dir_hint, warning)`` where warning is emitted when the
-        legacy ``ATELIER_PROJECT`` fallback was needed.
+        Tuple of ``(repo_dir_hint, warning)``. ``warning`` is reserved for
+        compatibility and currently always ``None``.
     """
     explicit = str(repo_dir or "").strip()
     if explicit:
@@ -66,26 +63,7 @@ def resolve_runtime_repo_dir_hint(
     if worktree_link.exists():
         return str(worktree_link.resolve()), None
 
-    runtime_env = env if env is not None else os.environ
-    workspace_dir = str(runtime_env.get("ATELIER_WORKSPACE_DIR", "")).strip()
-    if workspace_dir:
-        return (
-            workspace_dir,
-            "warning: deprecated runtime fallback via ATELIER_WORKSPACE_DIR; "
-            "pass --repo-dir or run from an agent home with ./worktree. Legacy "
-            "fallback compatibility is scheduled for removal after "
-            f"{LEGACY_ATELIER_WORKSPACE_DIR_FALLBACK_REMOVAL_DATE}.",
-        )
-
-    project_dir = str(runtime_env.get("ATELIER_PROJECT", "")).strip()
-    if project_dir:
-        return (
-            project_dir,
-            "warning: deprecated runtime fallback via ATELIER_PROJECT; pass "
-            "--repo-dir or run from an agent home with ./worktree. Legacy "
-            "fallback compatibility is scheduled for removal after "
-            f"{LEGACY_ATELIER_PROJECT_FALLBACK_REMOVAL_DATE}.",
-        )
+    _ = env
     return None, None
 
 

--- a/tests/atelier/test_beads_context.py
+++ b/tests/atelier/test_beads_context.py
@@ -232,27 +232,15 @@ def test_resolve_runtime_repo_dir_hint_returns_explicit_worktree_repo_dir_withou
     assert warning is None
 
 
-def test_resolve_runtime_repo_dir_hint_warns_on_legacy_atelier_project_fallback() -> None:
+def test_resolve_runtime_repo_dir_hint_does_not_use_ambient_env_fallbacks() -> None:
     hint, warning = beads_context.resolve_runtime_repo_dir_hint(
         repo_dir=None,
         cwd=Path("/tmp"),
-        env={"ATELIER_PROJECT": "/repo/from-env"},
+        env={
+            "ATELIER_PROJECT": "/repo/from-env",
+            "ATELIER_WORKSPACE_DIR": "/repo/from-workspace-dir",
+        },
     )
 
-    assert hint == "/repo/from-env"
-    assert warning is not None
-    assert "ATELIER_PROJECT" in warning
-    assert "2026-07-01" in warning
-
-
-def test_resolve_runtime_repo_dir_hint_warns_on_legacy_workspace_dir_fallback() -> None:
-    hint, warning = beads_context.resolve_runtime_repo_dir_hint(
-        repo_dir=None,
-        cwd=Path("/tmp"),
-        env={"ATELIER_WORKSPACE_DIR": "/repo/from-workspace-dir"},
-    )
-
-    assert hint == "/repo/from-workspace-dir"
-    assert warning is not None
-    assert "ATELIER_WORKSPACE_DIR" in warning
-    assert "2026-07-01" in warning
+    assert hint is None
+    assert warning is None


### PR DESCRIPTION
# Summary

- Remove ambient `ATELIER_PROJECT` and `ATELIER_WORKSPACE_DIR` repo-hint fallbacks from runtime context resolution.

# Changes

- Update `resolve_runtime_repo_dir_hint` to resolve hints from explicit `--repo-dir` input or local `./worktree` only.
- Remove legacy env-fallback warning branches and related constants from `beads_context`.
- Update `beads_context` tests to assert ambient env vars are ignored for repo hint resolution.
- Align `auto_export.resolve_auto_export_context` docs with the new repo-hint contract.

# Testing

- `just test`
- `just format`
- `just lint`

## Tickets
- Addresses #524

# Risks / Rollout

- Runtime entrypoints launched without `--repo-dir` and without a local `./worktree` symlink now rely on normal project resolution from cwd rather than ambient env vars.

# Notes

- None.
