### PR TITLE
Finalize explicit launch-context routing migration guidance

### DIFF
--- a/docs/beads-store-parity.md
+++ b/docs/beads-store-parity.md
@@ -9,12 +9,14 @@ the default planning store.
 
 ## One-shot parity check
 
-Run these commands from a project worktree to verify planner/worker parity:
+Run these commands with explicit launch context to verify planner/worker parity:
 
 ```bash
-python3 src/atelier/skills/planner-startup-check/scripts/refresh_overview.py --agent-id "$ATELIER_AGENT_ID"
+python3 src/atelier/skills/planner-startup-check/scripts/refresh_overview.py --agent-id "<planner-agent-id>" --repo-dir "<repo-root-or-./worktree>"
 atelier work --mode auto --dry-run
 ```
+
+If you run from an agent home, use `--repo-dir ./worktree`.
 
 Verify both outputs report:
 

--- a/docs/runtime-env-subprocess-inventory.md
+++ b/docs/runtime-env-subprocess-inventory.md
@@ -8,8 +8,18 @@ when launching planner/worker/editor/shell subprocesses.
 - Subprocess launch env is sanitized by
   `src/atelier/runtime_env.py::sanitize_subprocess_environment`.
 - Inherited routing keys from ambient parent env are ignored.
-- Legacy ambient fallback compatibility is scheduled for removal after
-  `2026-07-01`.
+- Internal launch flows no longer use ambient fallback routing via
+  `ATELIER_PROJECT`, `ATELIER_WORKSPACE_DIR`, or cross-session
+  `ATELIER_AGENT_ID`.
+
+## Operator migration notes
+
+- Scripts that need repository resolution must pass `--repo-dir` explicitly or
+  run from an agent home that has a local `./worktree` link.
+- Planner startup refresh commands should pass `--agent-id` explicitly instead
+  of relying on inherited shell state.
+- Runtime warnings about removed inherited keys are now immediate guidance for
+  explicit launch context, not future deprecation notices.
 
 ## Variable inventory
 
@@ -27,16 +37,14 @@ when launching planner/worker/editor/shell subprocesses.
   - Class: workspace context
 - `ATELIER_PROJECT`
   - Owner (set path): `src/atelier/workspace.py::workspace_environment`
-  - Primary consumers:
-    `src/atelier/beads_context.py::resolve_runtime_repo_dir_hint` (legacy
-    fallback), `src/atelier/auto_export.py::resolve_auto_export_context`
-    (indirect via beads context helper)
-  - Class: project routing
+  - Primary consumers: downstream shell/editor commands and user scripts that
+    run inside workspace-aware subprocesses.
+  - Class: workspace context
 - `ATELIER_WORKSPACE_DIR`
   - Owner (set path): `src/atelier/workspace.py::workspace_environment`
-  - Primary consumers:
-    `src/atelier/beads_context.py::resolve_runtime_repo_dir_hint`
-  - Class: project routing
+  - Primary consumers: downstream shell/editor commands and user scripts that
+    run inside workspace-aware subprocesses.
+  - Class: workspace context
 - `ATELIER_HOOKS_PATH`
   - Owner (set path): `src/atelier/hooks.py::ensure_hooks_path`
   - Primary consumers: hook-capable runtimes (Claude/Gemini/OpenCode/Copilot)

--- a/src/atelier/runtime_env.py
+++ b/src/atelier/runtime_env.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 from collections.abc import Iterable, Mapping
 
-LEGACY_AMBIENT_ENV_REMOVAL_DATE = "2026-07-01"
 _WARNING_SAMPLE_LIMIT = 6
 
 USER_DEFAULT_ENV_KEYS: frozenset[str] = frozenset(
@@ -58,7 +57,7 @@ def sanitize_subprocess_environment(
 
 
 def format_ambient_env_warning(removed_keys: Iterable[str]) -> str | None:
-    """Build a compatibility warning for dropped inherited runtime env keys.
+    """Build a warning for dropped inherited runtime env keys.
 
     Args:
         removed_keys: Iterable of removed ``ATELIER_*`` key names.
@@ -76,7 +75,6 @@ def format_ambient_env_warning(removed_keys: Iterable[str]) -> str | None:
     return (
         "Warning: ignored inherited runtime routing env keys "
         f"({sample}{suffix}). "
-        "Use launch-time project context instead of ambient ATELIER_* routing "
-        "state; legacy fallback compatibility is scheduled for removal after "
-        f"{LEGACY_AMBIENT_ENV_REMOVAL_DATE}."
+        "Use explicit launch context (for example --repo-dir or the local "
+        "./worktree link) instead of ambient ATELIER_* routing state."
     )

--- a/src/atelier/skills/planner-startup-check/SKILL.md
+++ b/src/atelier/skills/planner-startup-check/SKILL.md
@@ -72,7 +72,7 @@ reject unsupported invocation forms.
 ## On-demand refresh
 
 - During an active planner session, re-run the same read-only overview with:
-  `python3 skills/planner-startup-check/scripts/refresh_overview.py --agent-id "$ATELIER_AGENT_ID" --repo-dir ./worktree`
+  `python3 skills/planner-startup-check/scripts/refresh_overview.py --agent-id "<planner-agent-id>" --repo-dir ./worktree`
 - This refresh is read-only and includes:
   - unread planner inbox messages
   - queued messages with queue name and claim state

--- a/tests/atelier/test_agents.py
+++ b/tests/atelier/test_agents.py
@@ -313,7 +313,7 @@ class TestAgentSpec:
         )
         assert len(warnings) == 1
         assert "ATELIER_PROJECT" in warnings[0]
-        assert "2026-07-01" in warnings[0]
+        assert "--repo-dir" in warnings[0]
 
     def test_agent_environment_does_not_warn_for_self_scoped_agent_id(self) -> None:
         warnings: list[str] = []

--- a/tests/atelier/test_runtime_env.py
+++ b/tests/atelier/test_runtime_env.py
@@ -28,13 +28,14 @@ def test_format_ambient_env_warning_returns_none_when_no_keys() -> None:
     assert runtime_env.format_ambient_env_warning(()) is None
 
 
-def test_format_ambient_env_warning_includes_removed_keys_and_removal_date() -> None:
+def test_format_ambient_env_warning_includes_removed_keys_and_migration_guidance() -> None:
     warning = runtime_env.format_ambient_env_warning(("ATELIER_PROJECT", "ATELIER_WORKSPACE"))
 
     assert warning is not None
     assert "ATELIER_PROJECT" in warning
     assert "ATELIER_WORKSPACE" in warning
-    assert "2026-07-01" in warning
+    assert "--repo-dir" in warning
+    assert "./worktree" in warning
 
 
 def test_sanitize_subprocess_environment_empty_mapping_does_not_inherit_ambient(


### PR DESCRIPTION
# Summary

- Finalize operator-facing migration guidance and tests for Atelier's explicit runtime launch-context routing behavior.

# Changes

- Updated `runtime_env.format_ambient_env_warning` to remove the stale deprecation date and point users to explicit launch context (`--repo-dir` or local `./worktree`).
- Updated runtime environment inventory docs with operator migration notes and corrected `ATELIER_PROJECT` / `ATELIER_WORKSPACE_DIR` consumer descriptions.
- Updated planner startup/parity docs to use explicit `--agent-id` and `--repo-dir` guidance in command examples.
- Updated runtime-env and agent-environment tests to assert the new warning guidance text.

# Testing

- `just test`
- `just format`
- `just lint`

# Tickets

- Addresses #526

# Risks / Rollout

- Low risk: behavior change is limited to warning text and operator docs/tests alignment.
- Rollout impact: operators relying on ambient routing hints should use explicit `--repo-dir` (or `./worktree` from agent homes).

# Notes

- This changeset is intentionally scoped to docs/tests and warning text alignment only.
