### PR TITLE
Fix init prompt to keep existing Beads prefix default

### DIFF
--- a/src/atelier/config.py
+++ b/src/atelier/config.py
@@ -1074,12 +1074,17 @@ def build_project_config(
 
     suggested_seed = derive_beads_prefix_seed(enlistment_path, origin)
     suggested_prefix = suggest_available_beads_prefix(suggested_seed, taken_beads_prefixes)
+    beads_prompt_default = suggested_prefix if prompt_missing_only else existing_beads_prefix
 
     beads_prefix_arg = read_arg(args, "beads_prefix")
     if beads_prefix_arg is not None:
         beads_prefix = validate_unique_beads_prefix(beads_prefix_arg, source="--beads-prefix")
     elif should_prompt("beads", "prefix"):
-        beads_prefix_input = prompt("Beads issue prefix", suggested_prefix, required=True)
+        beads_prefix_input = prompt(
+            "Beads issue prefix",
+            beads_prompt_default,
+            required=True,
+        )
         beads_prefix = validate_unique_beads_prefix(beads_prefix_input, source="beads.prefix")
     else:
         beads_prefix = validate_unique_beads_prefix(suggested_prefix, source="beads.prefix")

--- a/tests/atelier/test_config.py
+++ b/tests/atelier/test_config.py
@@ -353,6 +353,44 @@ def test_build_project_config_non_interactive_uses_available_suggested_beads_pre
     assert payload.beads.prefix == "ts"
 
 
+def test_build_project_config_prompt_defaults_to_existing_beads_prefix() -> None:
+    args = SimpleNamespace(
+        branch_prefix="",
+        beads_prefix=None,
+        branch_pr_mode="draft",
+        branch_history="merge",
+        branch_pr_strategy="sequential",
+        agent="codex",
+        editor_edit="cat",
+        editor_work="cat",
+    )
+    existing = ProjectConfig.model_validate(
+        {
+            "project": {"origin": "github.com/org/repo"},
+            "beads": {"prefix": "gs"},
+        }
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        data_dir = Path(tmp) / "data"
+        with (
+            patch("atelier.paths.atelier_data_dir", return_value=data_dir),
+            patch("atelier.agents.available_agent_names", return_value=("codex",)),
+            patch("atelier.config.discover_local_project_prefixes", return_value={"at"}),
+            patch("atelier.config.prompt", return_value="gs") as prompt_mock,
+        ):
+            payload = config.build_project_config(
+                existing,
+                "/tmp/gumshoe",
+                "github.com/org/repo",
+                "https://github.com/org/repo",
+                args,
+                allow_editor_empty=True,
+            )
+
+    prompt_mock.assert_called_once_with("Beads issue prefix", "gs", required=True)
+    assert payload.beads.prefix == "gs"
+
+
 def test_build_project_config_preserves_agent_launch_options() -> None:
     args = SimpleNamespace(
         branch_prefix="",


### PR DESCRIPTION
# Summary

- Default the interactive `Beads issue prefix` prompt to the project's existing configured prefix when re-running init/config on an existing project.

# Changes

- In `build_project_config`, use the existing resolved prefix as the prompt default when not in first-time `prompt_missing_only` mode.
- Keep first-time prompt-missing flows using the deterministic suggested prefix.
- Add a regression test that verifies an existing project configured with `gs` is prompted with `gs` as the default.

# Testing

- `uv run pytest tests/atelier/test_config.py`
- `just format`
- `just lint`
- `UV_PYTHON=3.11 PYTHONPATH= just test`

# Tickets

- None

# Risks / Rollout

- Low risk: change is limited to Beads prefix prompt default selection and covered by targeted regression tests.

# Notes

- Reproduction context: a project already configured with prefix `gs` previously re-suggested a seed-derived prefix (for example `gu`) when prompts were rerun.
