### PR TITLE
Detect stale terminal PR lifecycle drift during worker startup

### DIFF
--- a/src/atelier/worker/stale_pr_lifecycle.py
+++ b/src/atelier/worker/stale_pr_lifecycle.py
@@ -1,0 +1,167 @@
+"""Read-only classification for stale terminal PR lifecycle drift."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .. import changeset_fields, git, lifecycle, prs
+
+Issue = dict[str, object]
+
+_NON_TERMINAL_STATUSES = frozenset({"open", "blocked", "in_progress"})
+_TERMINAL_PR_STATES = frozenset({"merged", "closed"})
+
+
+@dataclass(frozen=True)
+class StaleTerminalPrLifecycleClassification:
+    """Classification result for stale terminal PR lifecycle evidence."""
+
+    kind: str
+    reason: str
+    canonical_status: str | None
+    stored_pr_state: str | None
+    live_pr_state: str | None = None
+    stale_fields: tuple[str, ...] = ()
+    detail: str | None = None
+
+    @property
+    def is_candidate(self) -> bool:
+        """Return whether the issue is a stale terminal lifecycle candidate."""
+        return self.kind == "candidate"
+
+    @property
+    def is_anomaly(self) -> bool:
+        """Return whether the classification represents ambiguous evidence."""
+        return self.kind == "anomaly"
+
+
+def _classification(
+    *,
+    kind: str,
+    reason: str,
+    canonical_status: str | None,
+    stored_pr_state: str | None,
+    live_pr_state: str | None = None,
+    stale_fields: tuple[str, ...] = (),
+    detail: str | None = None,
+) -> StaleTerminalPrLifecycleClassification:
+    return StaleTerminalPrLifecycleClassification(
+        kind=kind,
+        reason=reason,
+        canonical_status=canonical_status,
+        stored_pr_state=stored_pr_state,
+        live_pr_state=live_pr_state,
+        stale_fields=stale_fields,
+        detail=detail,
+    )
+
+
+def classify_stale_terminal_pr_lifecycle(
+    issue: Issue,
+    *,
+    repo_slug: str | None,
+    repo_root: Path,
+    branch_pr: bool,
+    git_path: str | None,
+) -> StaleTerminalPrLifecycleClassification:
+    """Classify stale terminal PR lifecycle drift for a non-terminal changeset.
+
+    Args:
+        issue: Changeset bead payload under evaluation.
+        repo_slug: Optional GitHub ``owner/repo`` slug used for PR lookups.
+        repo_root: Repository root used for git branch checks.
+        branch_pr: Whether the project uses PR-mediated publishing.
+        git_path: Optional git executable override.
+
+    Returns:
+        Classification describing whether the issue is a stale terminal PR
+        candidate, an ambiguous anomaly, or an ordinary non-candidate path.
+    """
+    canonical_status = lifecycle.canonical_lifecycle_status(issue.get("status"))
+    stored_pr_state = changeset_fields.review_state(issue)
+    if not branch_pr:
+        return _classification(
+            kind="none",
+            reason="non_pr_project",
+            canonical_status=canonical_status,
+            stored_pr_state=stored_pr_state,
+        )
+    if canonical_status not in _NON_TERMINAL_STATUSES:
+        return _classification(
+            kind="none",
+            reason=f"status_{canonical_status or 'unknown'}",
+            canonical_status=canonical_status,
+            stored_pr_state=stored_pr_state,
+        )
+
+    work_branch = changeset_fields.work_branch(issue)
+    if not work_branch:
+        return _classification(
+            kind="anomaly",
+            reason="missing_work_branch",
+            canonical_status=canonical_status,
+            stored_pr_state=stored_pr_state,
+        )
+    if not repo_slug:
+        return _classification(
+            kind="anomaly",
+            reason="missing_repo_slug",
+            canonical_status=canonical_status,
+            stored_pr_state=stored_pr_state,
+        )
+
+    pushed = git.git_ref_exists(repo_root, f"refs/remotes/origin/{work_branch}", git_path=git_path)
+    lookup = prs.lookup_github_pr_status(repo_slug, work_branch)
+    if lookup.failed:
+        lookup = prs.lookup_github_pr_status(repo_slug, work_branch, refresh=True)
+    if lookup.failed:
+        return _classification(
+            kind="anomaly",
+            reason="pr_lifecycle_lookup_failed",
+            canonical_status=canonical_status,
+            stored_pr_state=stored_pr_state,
+            detail=lookup.error or "unknown",
+        )
+
+    payload = lookup.payload if lookup.found and isinstance(lookup.payload, dict) else None
+    review_requested = prs.has_review_requests(payload)
+    live_pr_state = prs.lifecycle_state(
+        payload,
+        pushed=pushed,
+        review_requested=review_requested,
+    )
+    if live_pr_state in lifecycle.ACTIVE_PR_LIFECYCLE_STATES:
+        return _classification(
+            kind="none",
+            reason=f"active_pr_lifecycle_{live_pr_state}",
+            canonical_status=canonical_status,
+            stored_pr_state=stored_pr_state,
+            live_pr_state=live_pr_state,
+        )
+    if live_pr_state not in _TERMINAL_PR_STATES:
+        return _classification(
+            kind="none",
+            reason="terminal_pr_state_unavailable",
+            canonical_status=canonical_status,
+            stored_pr_state=stored_pr_state,
+            live_pr_state=live_pr_state,
+        )
+
+    stale_fields = ["status"]
+    if stored_pr_state not in _TERMINAL_PR_STATES or stored_pr_state != live_pr_state:
+        stale_fields.append("pr_state")
+    return _classification(
+        kind="candidate",
+        reason=f"terminal_pr_{live_pr_state}",
+        canonical_status=canonical_status,
+        stored_pr_state=stored_pr_state,
+        live_pr_state=live_pr_state,
+        stale_fields=tuple(stale_fields),
+    )
+
+
+__all__ = [
+    "StaleTerminalPrLifecycleClassification",
+    "classify_stale_terminal_pr_lifecycle",
+]

--- a/src/atelier/worker/work_startup_runtime.py
+++ b/src/atelier/worker/work_startup_runtime.py
@@ -13,6 +13,7 @@ from ..worker import prompts as worker_prompts
 from ..worker import queueing as worker_queueing
 from ..worker import review as worker_review
 from ..worker import selection as worker_selection
+from ..worker import stale_pr_lifecycle
 from ..worker.models import StartupContractResult, StartupFinalizePreflightResult
 from ..worker.session import startup as worker_startup
 from .work_finalization_runtime import (
@@ -61,6 +62,63 @@ def startup_finalize_preflight(
     Returns:
         Startup preflight decision with deterministic reason code.
     """
+    if not branch_pr:
+        integration_proven, _integrated_sha = changeset_integration_signal(
+            issue,
+            repo_slug=repo_slug,
+            repo_root=repo_root,
+            git_path=git_path,
+            require_target_branch_proof=True,
+        )
+        if not integration_proven:
+            return StartupFinalizePreflightResult(
+                should_finalize_only=False,
+                reason="normal_path:integration_unproven",
+            )
+        return StartupFinalizePreflightResult(
+            should_finalize_only=True,
+            reason="finalize_only:non_pr_integration_proven",
+        )
+
+    stale_terminal = stale_pr_lifecycle.classify_stale_terminal_pr_lifecycle(
+        issue,
+        repo_slug=repo_slug,
+        repo_root=repo_root,
+        branch_pr=branch_pr,
+        git_path=git_path,
+    )
+    if stale_terminal.is_anomaly:
+        return StartupFinalizePreflightResult(
+            should_finalize_only=False,
+            reason=f"normal_path:stale_terminal_pr_anomaly_{stale_terminal.reason}",
+        )
+    if stale_terminal.reason.startswith("active_pr_lifecycle_"):
+        lifecycle_label = stale_terminal.live_pr_state or "none"
+        return StartupFinalizePreflightResult(
+            should_finalize_only=False,
+            reason=f"normal_path:pr_lifecycle_{lifecycle_label}",
+        )
+    if stale_terminal.is_candidate:
+        integration_proven, _integrated_sha = changeset_integration_signal(
+            issue,
+            repo_slug=repo_slug,
+            repo_root=repo_root,
+            git_path=git_path,
+            require_target_branch_proof=True,
+        )
+        if not integration_proven:
+            return StartupFinalizePreflightResult(
+                should_finalize_only=False,
+                reason=(
+                    "normal_path:stale_terminal_pr_lifecycle_"
+                    f"{stale_terminal.live_pr_state or 'none'}"
+                ),
+            )
+        return StartupFinalizePreflightResult(
+            should_finalize_only=True,
+            reason=f"finalize_only:pr_lifecycle_{stale_terminal.live_pr_state}_integration_proven",
+        )
+
     integration_proven, _integrated_sha = changeset_integration_signal(
         issue,
         repo_slug=repo_slug,
@@ -72,11 +130,6 @@ def startup_finalize_preflight(
         return StartupFinalizePreflightResult(
             should_finalize_only=False,
             reason="normal_path:integration_unproven",
-        )
-    if not branch_pr:
-        return StartupFinalizePreflightResult(
-            should_finalize_only=True,
-            reason="finalize_only:non_pr_integration_proven",
         )
 
     work_branch = changeset_fields.work_branch(issue)

--- a/tests/atelier/worker/test_runtime.py
+++ b/tests/atelier/worker/test_runtime.py
@@ -689,18 +689,33 @@ def test_next_changeset_service_passes_beads_root_to_review_waiting_gate() -> No
 
 
 def test_startup_finalize_preflight_short_circuits_terminal_pr_with_integration() -> None:
-    issue = {"description": "changeset.work_branch: feat/root-at-epic.1\n"}
+    issue = {
+        "status": "blocked",
+        "description": "changeset.work_branch: feat/root-at-epic.1\npr_state: draft-pr\n",
+    }
     with (
         patch(
             "atelier.worker.work_startup_runtime.changeset_integration_signal",
             return_value=(True, "abc1234"),
         ) as integration_signal,
         patch(
-            "atelier.worker.work_startup_runtime.lookup_pr_payload",
-            return_value={"number": 42},
-        ) as lookup_pr,
-        patch("atelier.worker.work_startup_runtime.prs.has_review_requests", return_value=False),
-        patch("atelier.worker.work_startup_runtime.prs.lifecycle_state", return_value="merged"),
+            "atelier.worker.work_startup_runtime.stale_pr_lifecycle.git.git_ref_exists",
+            return_value=True,
+        ),
+        patch(
+            "atelier.worker.work_startup_runtime.stale_pr_lifecycle.prs.lookup_github_pr_status",
+            return_value=work_startup_runtime.prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 42,
+                    "state": "CLOSED",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                    "mergedAt": "2026-03-01T00:00:00Z",
+                    "closedAt": "2026-03-01T00:00:00Z",
+                },
+            ),
+        ),
     ):
         result = work_startup_runtime.startup_finalize_preflight(
             issue=issue,
@@ -719,22 +734,34 @@ def test_startup_finalize_preflight_short_circuits_terminal_pr_with_integration(
         git_path="git",
         require_target_branch_proof=True,
     )
-    lookup_pr.assert_called_once_with("org/repo", "feat/root-at-epic.1")
 
 
 def test_startup_finalize_preflight_fails_closed_when_pr_not_terminal() -> None:
-    issue = {"description": "changeset.work_branch: feat/root-at-epic.1\n"}
+    issue = {
+        "status": "in_progress",
+        "description": "changeset.work_branch: feat/root-at-epic.1\npr_state: closed\n",
+    }
     with (
         patch(
             "atelier.worker.work_startup_runtime.changeset_integration_signal",
-            return_value=(True, "abc1234"),
+            side_effect=AssertionError("integration should not be checked for active PR states"),
+        ) as integration_signal,
+        patch(
+            "atelier.worker.work_startup_runtime.stale_pr_lifecycle.git.git_ref_exists",
+            return_value=True,
         ),
         patch(
-            "atelier.worker.work_startup_runtime.lookup_pr_payload",
-            return_value={"number": 42},
+            "atelier.worker.work_startup_runtime.stale_pr_lifecycle.prs.lookup_github_pr_status",
+            return_value=work_startup_runtime.prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 42,
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                },
+            ),
         ),
-        patch("atelier.worker.work_startup_runtime.prs.has_review_requests", return_value=False),
-        patch("atelier.worker.work_startup_runtime.prs.lifecycle_state", return_value="pr-open"),
     ):
         result = work_startup_runtime.startup_finalize_preflight(
             issue=issue,
@@ -746,6 +773,56 @@ def test_startup_finalize_preflight_fails_closed_when_pr_not_terminal() -> None:
 
     assert result.should_finalize_only is False
     assert result.reason == "normal_path:pr_lifecycle_pr-open"
+    integration_signal.assert_not_called()
+
+
+def test_startup_finalize_preflight_flags_stale_terminal_pr_without_integration() -> None:
+    issue = {
+        "status": "blocked",
+        "description": "changeset.work_branch: feat/root-at-epic.2\npr_state: draft-pr\n",
+    }
+
+    with (
+        patch(
+            "atelier.worker.work_startup_runtime.stale_pr_lifecycle.git.git_ref_exists",
+            return_value=True,
+        ),
+        patch(
+            "atelier.worker.work_startup_runtime.stale_pr_lifecycle.prs.lookup_github_pr_status",
+            return_value=work_startup_runtime.prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 43,
+                    "state": "CLOSED",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                    "mergedAt": "2026-03-02T00:00:00Z",
+                    "closedAt": "2026-03-02T00:00:00Z",
+                },
+            ),
+        ),
+        patch(
+            "atelier.worker.work_startup_runtime.changeset_integration_signal",
+            return_value=(False, None),
+        ) as integration_signal,
+    ):
+        result = work_startup_runtime.startup_finalize_preflight(
+            issue=issue,
+            repo_slug="org/repo",
+            branch_pr=True,
+            repo_root=Path("/repo"),
+            git_path="git",
+        )
+
+    assert result.should_finalize_only is False
+    assert result.reason == "normal_path:stale_terminal_pr_lifecycle_merged"
+    integration_signal.assert_called_once_with(
+        issue,
+        repo_slug="org/repo",
+        repo_root=Path("/repo"),
+        git_path="git",
+        require_target_branch_proof=True,
+    )
 
 
 def test_startup_service_reports_planner_owned_executable_violations() -> None:

--- a/tests/atelier/worker/test_stale_pr_lifecycle.py
+++ b/tests/atelier/worker/test_stale_pr_lifecycle.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from atelier import prs
+from atelier.worker import stale_pr_lifecycle
+
+
+def test_classify_stale_terminal_pr_lifecycle_marks_candidate_fields() -> None:
+    issue = {
+        "status": "blocked",
+        "description": "changeset.work_branch: feat/root-at-1.2\npr_state: in-review\n",
+    }
+
+    with (
+        patch("atelier.worker.stale_pr_lifecycle.git.git_ref_exists", return_value=True),
+        patch(
+            "atelier.worker.stale_pr_lifecycle.prs.lookup_github_pr_status",
+            return_value=prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 12,
+                    "state": "CLOSED",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                    "mergedAt": "2026-03-01T00:00:00Z",
+                    "closedAt": "2026-03-01T00:00:00Z",
+                },
+            ),
+        ),
+    ):
+        result = stale_pr_lifecycle.classify_stale_terminal_pr_lifecycle(
+            issue,
+            repo_slug="org/repo",
+            repo_root=Path("/repo"),
+            branch_pr=True,
+            git_path="git",
+        )
+
+    assert result.kind == "candidate"
+    assert result.reason == "terminal_pr_merged"
+    assert result.live_pr_state == "merged"
+    assert result.stale_fields == ("status", "pr_state")
+
+
+def test_classify_stale_terminal_pr_lifecycle_tracks_status_only_when_review_state_matches() -> (
+    None
+):
+    issue = {
+        "status": "in_progress",
+        "description": "changeset.work_branch: feat/root-at-1.3\npr_state: merged\n",
+    }
+
+    with (
+        patch("atelier.worker.stale_pr_lifecycle.git.git_ref_exists", return_value=True),
+        patch(
+            "atelier.worker.stale_pr_lifecycle.prs.lookup_github_pr_status",
+            return_value=prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 13,
+                    "state": "CLOSED",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                    "mergedAt": "2026-03-02T00:00:00Z",
+                    "closedAt": "2026-03-02T00:00:00Z",
+                },
+            ),
+        ),
+    ):
+        result = stale_pr_lifecycle.classify_stale_terminal_pr_lifecycle(
+            issue,
+            repo_slug="org/repo",
+            repo_root=Path("/repo"),
+            branch_pr=True,
+            git_path="git",
+        )
+
+    assert result.kind == "candidate"
+    assert result.stale_fields == ("status",)
+
+
+def test_classify_stale_terminal_pr_lifecycle_excludes_active_pr_states() -> None:
+    issue = {
+        "status": "blocked",
+        "description": "changeset.work_branch: feat/root-at-1.4\npr_state: closed\n",
+    }
+
+    with (
+        patch("atelier.worker.stale_pr_lifecycle.git.git_ref_exists", return_value=True),
+        patch(
+            "atelier.worker.stale_pr_lifecycle.prs.lookup_github_pr_status",
+            return_value=prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 14,
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                },
+            ),
+        ),
+    ):
+        result = stale_pr_lifecycle.classify_stale_terminal_pr_lifecycle(
+            issue,
+            repo_slug="org/repo",
+            repo_root=Path("/repo"),
+            branch_pr=True,
+            git_path="git",
+        )
+
+    assert result.kind == "none"
+    assert result.reason == "active_pr_lifecycle_pr-open"
+    assert result.live_pr_state == "pr-open"
+
+
+def test_classify_stale_terminal_pr_lifecycle_marks_lookup_failure_as_anomaly() -> None:
+    issue = {
+        "status": "blocked",
+        "description": "changeset.work_branch: feat/root-at-1.5\npr_state: draft-pr\n",
+    }
+
+    with (
+        patch("atelier.worker.stale_pr_lifecycle.git.git_ref_exists", return_value=True),
+        patch(
+            "atelier.worker.stale_pr_lifecycle.prs.lookup_github_pr_status",
+            side_effect=[
+                prs.GithubPrLookup(outcome="error", error="gh timeout"),
+                prs.GithubPrLookup(outcome="error", error="gh timeout"),
+            ],
+        ),
+    ):
+        result = stale_pr_lifecycle.classify_stale_terminal_pr_lifecycle(
+            issue,
+            repo_slug="org/repo",
+            repo_root=Path("/repo"),
+            branch_pr=True,
+            git_path="git",
+        )
+
+    assert result.kind == "anomaly"
+    assert result.reason == "pr_lifecycle_lookup_failed"
+    assert result.detail == "gh timeout"


### PR DESCRIPTION
# Summary

- Add a read-only classifier for stale terminal PR lifecycle drift during worker startup.

# Changes

- Detect when live GitHub PR state is terminal while changeset status or stored review metadata is still non-terminal.
- Surface ambiguous PR evidence as anomaly output instead of treating it like ordinary in-flight review.
- Use the classifier in startup preflight so stale terminal drift is separated from active review before finalize decisions.
- Add focused worker tests for candidate detection, active PR exclusion, anomaly classification, and startup preflight behavior.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #545

# Risks / Rollout

- This slice is read-only classification only; it does not mutate bead lifecycle state.

# Notes

- Follow-on changesets can reuse the classifier output for convergence and safe finalization.
