### PR TITLE
Converge stale terminal metadata before reconcile finalization

### DIFF
--- a/src/atelier/worker/reconcile.py
+++ b/src/atelier/worker/reconcile.py
@@ -206,6 +206,14 @@ def _converge_stale_terminal_metadata(
     return tuple(updates)
 
 
+def _converged_integrated_sha(updates: tuple[str, ...]) -> str | None:
+    prefix = "changeset.integrated_sha="
+    for update in updates:
+        if update.startswith(prefix):
+            return update.removeprefix(prefix)
+    return None
+
+
 def _agent_issue_identity(issue: dict[str, object]) -> str | None:
     fields = _description_fields(issue)
     description_identity = _normalized_text(fields.get("agent_id"))
@@ -1029,9 +1037,11 @@ def reconcile_blocked_merged_changesets(
                         f"(finalize reason={finalize_result.reason})"
                     )
                 continue
-            if candidate.require_terminal_status:
+            refreshed_issue: dict[str, object] | None = None
+            if candidate.require_terminal_status or candidate.integrated_sha:
                 issue_cache.pop(changeset_id, None)
                 refreshed_issue = load_issue(changeset_id)
+            if candidate.require_terminal_status:
                 refreshed_status = (
                     _canonical_changeset_status(refreshed_issue) if refreshed_issue else None
                 )
@@ -1056,7 +1066,11 @@ def reconcile_blocked_merged_changesets(
                             )
                         )
                     continue
-            if candidate.integrated_sha:
+            if (
+                candidate.integrated_sha
+                and _converged_integrated_sha(converged_updates) is None
+                and _recorded_integrated_sha(refreshed_issue or {}) is None
+            ):
                 beads.update_changeset_integrated_sha(
                     changeset_id,
                     candidate.integrated_sha,

--- a/tests/atelier/worker/test_reconcile.py
+++ b/tests/atelier/worker/test_reconcile.py
@@ -505,7 +505,94 @@ def test_reconcile_blocked_merged_changesets_converges_stale_terminal_metadata_b
     assert result.actionable == 1
     assert result.reconciled == 1
     assert result.failed == 0
-    assert operations == [("review", "merged"), ("sha", "abc1234"), ("sha", "abc1234")]
+    assert operations == [("review", "merged"), ("sha", "abc1234")]
+
+
+def test_reconcile_blocked_merged_changesets_keeps_finalize_integrated_sha_authoritative() -> None:
+    project = config.ProjectConfig(
+        project=config.ProjectSection(origin="https://github.com/org/repo"),
+        branch=config.BranchConfig(pr=True),
+    )
+    issue = {
+        "id": "at-1.2",
+        "status": "blocked",
+        "labels": [],
+        "description": (
+            "changeset.work_branch: feat/at-1.2\n"
+            "pr_state: pushed\n"
+            "changeset.integrated_sha: abc1234\n"
+        ),
+    }
+    operations: list[tuple[str, str]] = []
+
+    def run_bd_json(args: list[str], **_kwargs: object) -> list[dict[str, object]]:
+        if args[:2] == ["show", "at-1.2"]:
+            return [issue]
+        return []
+
+    def finalize_changeset(**_kwargs: object) -> FinalizeResult:
+        issue["status"] = "closed"
+        issue["description"] = (
+            "changeset.work_branch: feat/at-1.2\n"
+            "pr_state: merged\n"
+            "changeset.integrated_sha: finalize5678\n"
+        )
+        return FinalizeResult(continue_running=True, reason="changeset_complete")
+
+    with (
+        patch("atelier.worker.reconcile.beads.list_all_changesets", return_value=[issue]),
+        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
+        patch("atelier.worker.reconcile.git.git_ref_exists", return_value=True),
+        patch(
+            "atelier.worker.reconcile.prs.lookup_github_pr_status",
+            return_value=prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 12,
+                    "state": "CLOSED",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                    "mergedAt": "2026-03-01T00:00:00Z",
+                    "closedAt": "2026-03-01T00:00:00Z",
+                },
+            ),
+        ),
+        patch(
+            "atelier.worker.reconcile.beads.update_changeset_review",
+            side_effect=lambda _changeset_id, metadata, **_kwargs: operations.append(
+                ("review", str(metadata.pr_state))
+            ),
+        ),
+        patch(
+            "atelier.worker.reconcile.beads.update_changeset_integrated_sha",
+            side_effect=lambda _changeset_id, integrated_sha, **_kwargs: operations.append(
+                ("sha", integrated_sha)
+            ),
+        ),
+    ):
+        result = reconcile.reconcile_blocked_merged_changesets(
+            agent_id="worker/1",
+            agent_bead_id="at-agent",
+            project_config=project,
+            project_data_dir=Path("/project"),
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+            dry_run=False,
+            resolve_epic_id_for_changeset=lambda *_args, **_kwargs: "at-1",
+            changeset_integration_signal=lambda *_args, **_kwargs: (True, "abc1234"),
+            issue_dependency_ids=lambda _issue: tuple(),
+            issue_labels=lambda issue: {str(label) for label in issue.get("labels", [])},
+            finalize_changeset=finalize_changeset,
+            finalize_epic_if_complete=lambda **_kwargs: FinalizeResult(
+                continue_running=True, reason="changeset_complete"
+            ),
+        )
+
+    assert result.scanned == 1
+    assert result.actionable == 1
+    assert result.reconciled == 1
+    assert result.failed == 0
+    assert operations == [("review", "merged")]
 
 
 def test_reconcile_blocked_merged_changesets_fails_closed_when_stale_terminal_finalize_stays_open() -> (


### PR DESCRIPTION
# Summary

- Converge stale terminal PR metadata before reconcile-driven finalization so workers only count the changeset as recovered after it actually closes.

# Changes

- Classify `open`, `blocked`, and orphaned `in_progress` changesets against live terminal PR state before reconcile finalization.
- Persist terminal `pr_state` and `changeset.integrated_sha` when the evidence is deterministic.
- Fail closed with explicit anomalies when PR evidence is ambiguous or finalize leaves the changeset non-terminal.
- Add reconcile coverage for metadata convergence ordering, non-terminal finalize outcomes, and PR lookup failures.

# Testing

- `just format`
- `just lint`
- `env -u VIRTUAL_ENV just test`

## Tickets
- Addresses #546

# Risks / Rollout

- This only changes reconcile-driven stale-terminal recovery paths; normal publish and review handoff flows are unchanged.

# Notes

- The branch was restacked onto `main` after the parent PR merged so this PR contains only the convergence/finalization handoff.
