### PR TITLE
Add stale-state reconciliation regression coverage and triage diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,66 +2,125 @@
 
 ## [0.8.3](https://github.com/shaug/atelier/compare/v0.8.2...v0.8.3) (2026-03-06)
 
-
 ### Bug Fixes
 
-* **config:** enforce sequential strategy for PR mode ([d3c8acd](https://github.com/shaug/atelier/commit/d3c8acdbf8175675e5da5dec8bfb8036c9bfa727))
-* **config:** remove residual pr_strategy argument handling ([06fad3a](https://github.com/shaug/atelier/commit/06fad3aa36cf3393fec71caa5f19853acd006666))
-* **config:** stop tracking branch pr strategy ([53e254a](https://github.com/shaug/atelier/commit/53e254ab02b77a3e949203150066c58b88d2bddd))
-* **doctor:** classify authoritative and stale duplicate paths ([3adfd81](https://github.com/shaug/atelier/commit/3adfd81c5e5675c0fa75658c11a931006e1f3834))
-* **prefix-migration:** auto-heal split worktree path drift ([eda298c](https://github.com/shaug/atelier/commit/eda298cf2c5d145d5a304489121c9235143b5a05)), closes [#540](https://github.com/shaug/atelier/issues/540)
-* **worker:** block no-parent PR creation when sibling PR is active ([1493fee](https://github.com/shaug/atelier/commit/1493fee20f0692754788300688f5701e7d04fc53))
-* **worker:** gate PR creation across full epic subtree ([f938782](https://github.com/shaug/atelier/commit/f9387826ca511b43c1f5a3f7981a433ca7464546))
-* **worker:** remove legacy PR strategy runtime branches ([9b38b1d](https://github.com/shaug/atelier/commit/9b38b1d1c15ddf320f8b87766481fe94d8551c3d))
+- **config:** enforce sequential strategy for PR mode
+  ([d3c8acd](https://github.com/shaug/atelier/commit/d3c8acdbf8175675e5da5dec8bfb8036c9bfa727))
+- **config:** remove residual pr_strategy argument handling
+  ([06fad3a](https://github.com/shaug/atelier/commit/06fad3aa36cf3393fec71caa5f19853acd006666))
+- **config:** stop tracking branch pr strategy
+  ([53e254a](https://github.com/shaug/atelier/commit/53e254ab02b77a3e949203150066c58b88d2bddd))
+- **doctor:** classify authoritative and stale duplicate paths
+  ([3adfd81](https://github.com/shaug/atelier/commit/3adfd81c5e5675c0fa75658c11a931006e1f3834))
+- **prefix-migration:** auto-heal split worktree path drift
+  ([eda298c](https://github.com/shaug/atelier/commit/eda298cf2c5d145d5a304489121c9235143b5a05)),
+  closes [#540](https://github.com/shaug/atelier/issues/540)
+- **worker:** block no-parent PR creation when sibling PR is active
+  ([1493fee](https://github.com/shaug/atelier/commit/1493fee20f0692754788300688f5701e7d04fc53))
+- **worker:** gate PR creation across full epic subtree
+  ([f938782](https://github.com/shaug/atelier/commit/f9387826ca511b43c1f5a3f7981a433ca7464546))
+- **worker:** remove legacy PR strategy runtime branches
+  ([9b38b1d](https://github.com/shaug/atelier/commit/9b38b1d1c15ddf320f8b87766481fe94d8551c3d))
 
 ## [0.8.2](https://github.com/shaug/atelier/compare/v0.8.1...v0.8.2) (2026-03-05)
 
-
 ### Bug Fixes
 
-* **agent-home:** drop ambient ATELIER_AGENT_ID overrides ([3d18a7d](https://github.com/shaug/atelier/commit/3d18a7d6516efe6934c1737412d63a1ce00862c6))
-* **beads-context:** remove ambient repo-hint env fallbacks ([ca53088](https://github.com/shaug/atelier/commit/ca53088892659916bd560a9f824a3f11d634924d)), closes [#524](https://github.com/shaug/atelier/issues/524)
-* **config:** default beads prefix prompt to existing value ([1ca42f8](https://github.com/shaug/atelier/commit/1ca42f841e0867126bf1553351e6f4655fe51b05))
-* **planner-startup:** use planner worktree env for repo hints ([63c8474](https://github.com/shaug/atelier/commit/63c84749812fec10d42618a3802d6db985f2354c))
-* **runtime-env:** align ambient warning text with explicit routing ([7cc6538](https://github.com/shaug/atelier/commit/7cc6538ff8cf38c95088940f83bfd9fda7f0f121)), closes [#526](https://github.com/shaug/atelier/issues/526)
-* **runtime:** suppress self-scoped agent env warnings ([68afa88](https://github.com/shaug/atelier/commit/68afa884a73cd2ea2652ad6c0d4613d409926ab7)), closes [#523](https://github.com/shaug/atelier/issues/523)
-* **worker:** allow startup worktree-path metadata override ([284c657](https://github.com/shaug/atelier/commit/284c657cbd920da221a97a4d44469720c4e8889f)), closes [#534](https://github.com/shaug/atelier/issues/534)
-* **worker:** guard epic release with explicit runtime identity ([3c4aac5](https://github.com/shaug/atelier/commit/3c4aac5533dc5c8903321b8d7f2853ff3be28fea))
-* **worker:** handle finalize dependency-gate soft failures ([c4bf366](https://github.com/shaug/atelier/commit/c4bf3668dabd6a30422a59519c0e8a203bebab92)), closes [#528](https://github.com/shaug/atelier/issues/528)
+- **agent-home:** drop ambient ATELIER_AGENT_ID overrides
+  ([3d18a7d](https://github.com/shaug/atelier/commit/3d18a7d6516efe6934c1737412d63a1ce00862c6))
+- **beads-context:** remove ambient repo-hint env fallbacks
+  ([ca53088](https://github.com/shaug/atelier/commit/ca53088892659916bd560a9f824a3f11d634924d)),
+  closes [#524](https://github.com/shaug/atelier/issues/524)
+- **config:** default beads prefix prompt to existing value
+  ([1ca42f8](https://github.com/shaug/atelier/commit/1ca42f841e0867126bf1553351e6f4655fe51b05))
+- **planner-startup:** use planner worktree env for repo hints
+  ([63c8474](https://github.com/shaug/atelier/commit/63c84749812fec10d42618a3802d6db985f2354c))
+- **runtime-env:** align ambient warning text with explicit routing
+  ([7cc6538](https://github.com/shaug/atelier/commit/7cc6538ff8cf38c95088940f83bfd9fda7f0f121)),
+  closes [#526](https://github.com/shaug/atelier/issues/526)
+- **runtime:** suppress self-scoped agent env warnings
+  ([68afa88](https://github.com/shaug/atelier/commit/68afa884a73cd2ea2652ad6c0d4613d409926ab7)),
+  closes [#523](https://github.com/shaug/atelier/issues/523)
+- **worker:** allow startup worktree-path metadata override
+  ([284c657](https://github.com/shaug/atelier/commit/284c657cbd920da221a97a4d44469720c4e8889f)),
+  closes [#534](https://github.com/shaug/atelier/issues/534)
+- **worker:** guard epic release with explicit runtime identity
+  ([3c4aac5](https://github.com/shaug/atelier/commit/3c4aac5533dc5c8903321b8d7f2853ff3be28fea))
+- **worker:** handle finalize dependency-gate soft failures
+  ([c4bf366](https://github.com/shaug/atelier/commit/c4bf3668dabd6a30422a59519c0e8a203bebab92)),
+  closes [#528](https://github.com/shaug/atelier/issues/528)
 
 ## [0.8.1](https://github.com/shaug/atelier/compare/v0.8.0...v0.8.1) (2026-03-04)
 
-
 ### Bug Fixes
 
-* **agent-teardown:** fail closed on owner-only mismatch payloads ([de412fb](https://github.com/shaug/atelier/commit/de412fbcfa0d0905188d5be8160e8c41755be373))
-* **agent-teardown:** fail closed on owner-only ownership payloads ([43de4ce](https://github.com/shaug/atelier/commit/43de4ce4bbea8a3f0465fbfeba74bc084eed7a74))
-* **agent-teardown:** fail closed on ownership metadata drift ([c51f369](https://github.com/shaug/atelier/commit/c51f369832239f202ff0f5ab7c5874e536194955))
-* **agent-teardown:** require epic release confirmation before closing agent bead ([9a58469](https://github.com/shaug/atelier/commit/9a58469ca5c8648e8937cd9af34b010f0a0d1ac3))
-* **agent:** fail closed teardown close gate without hook target ([0d46a2c](https://github.com/shaug/atelier/commit/0d46a2c813ecdc8d861af361b3c02affb30f8ac6))
-* **agent:** fail closed teardown ownership on index drift ([ef21d45](https://github.com/shaug/atelier/commit/ef21d459e6dc25b91d93d8356f4859fc94e662fe))
-* **agent:** re-verify epic release before closing agent bead ([ea87161](https://github.com/shaug/atelier/commit/ea871617f13adb90d67910130004c48f06c857f6))
-* **beads:** prefer open agent bead over closed duplicates ([fdc80e0](https://github.com/shaug/atelier/commit/fdc80e0bcf17ff2458836aa46624b3036ed4dce5)), closes [#506](https://github.com/shaug/atelier/issues/506)
-* **doctor:** backfill missing mapping lineage in migration repair ([577f671](https://github.com/shaug/atelier/commit/577f671781c8bdd0c679c06dd1de990af5b4e1d6)), closes [#508](https://github.com/shaug/atelier/issues/508)
-* **doctor:** converge prefix drift normalization to canonical branch paths ([1281e18](https://github.com/shaug/atelier/commit/1281e18246a5e04a3dbcec6dd211e12ceba2d0bb)), closes [#509](https://github.com/shaug/atelier/issues/509)
-* **gc:** scan all agent beads during stale cleanup ([85600b1](https://github.com/shaug/atelier/commit/85600b11f1f5b0a0ea8bb277e7bc573a3addb4a9))
-* **git:** forward git_path in enlistment resolution ([bf23369](https://github.com/shaug/atelier/commit/bf2336966f93e7b07f041d40fad4712c69ce2c68))
-* **planner-startup:** resolve project identity from linked worktrees ([17672fb](https://github.com/shaug/atelier/commit/17672fb572cdcf7b22cede161b67200a992fc0a7)), closes [#519](https://github.com/shaug/atelier/issues/519)
-* **prefix-migration:** converge legacy namespace drift deterministically ([700a0a5](https://github.com/shaug/atelier/commit/700a0a5315e688752e41be741b056c6c30cd3fd6)), closes [#510](https://github.com/shaug/atelier/issues/510)
-* **prefix-migration:** enforce scoped changeset ownership ([6469171](https://github.com/shaug/atelier/commit/6469171b0a709e0e98af7745b0ccd38eb7f6bc7c))
-* **prefix-migration:** fail closed on ambiguous worktree candidates ([71e1eda](https://github.com/shaug/atelier/commit/71e1eda17c249f09e0343864d87c6dea72b1e4de))
-* **prefix-migration:** prefer remote canonical branch source ([1dedbf8](https://github.com/shaug/atelier/commit/1dedbf83138aae8312c20c30f5ef35afc8e34500))
-* **prefix-migration:** preflight branch checkout before worktree moves ([c4df26e](https://github.com/shaug/atelier/commit/c4df26e24773ba63000fd8d9fc703e478f51ee81))
-* **prefix-migration:** restore metadata worktree source resolution ([7a1c9e3](https://github.com/shaug/atelier/commit/7a1c9e37097669d9b9bc5f185ccec07c13487359))
-* **runtime:** gate agent-bead closure on verified hook cleanup ([327dc64](https://github.com/shaug/atelier/commit/327dc640987854bf18633279266e0caf3804c023))
-* **runtime:** harden planner teardown bead targeting ([e079574](https://github.com/shaug/atelier/commit/e079574d8225e41ce36314dbefda31db9c30aba0)), closes [#506](https://github.com/shaug/atelier/issues/506)
-* **runtime:** teardown agent beads and hooks on exit ([485695a](https://github.com/shaug/atelier/commit/485695a79eb3ce0120d22af7570afcb6c2510f1a)), closes [#506](https://github.com/shaug/atelier/issues/506)
-* **worker-review:** guard leaked review-branch pruning ([f9f2e4e](https://github.com/shaug/atelier/commit/f9f2e4e714bd07de07388cb5cbbd03e42a7678d8))
-* **worker:** pass concrete agent bead id through teardown ([cdf38d9](https://github.com/shaug/atelier/commit/cdf38d98563f1d0850205ad773a3f6bed019f818)), closes [#506](https://github.com/shaug/atelier/issues/506)
-* **worker:** stop leaking temporary pr-* review branches ([aa5a537](https://github.com/shaug/atelier/commit/aa5a537180d60c2f36ca15ef1edd7f1285fca0dc)), closes [#507](https://github.com/shaug/atelier/issues/507)
-* **worktrees:** fail closed on mismatched epic direct mapping ([d0d08ff](https://github.com/shaug/atelier/commit/d0d08ff56e27ef71bf8eef733197203d78e36f35))
-* **worktrees:** prefer live branch source and fail closed on invalid canonical path ([739cfc1](https://github.com/shaug/atelier/commit/739cfc1d6bda48fbc38a3c41bb598c235b3d0559))
-* **worktrees:** validate direct mapping owner on epic lookup ([d8bdd9f](https://github.com/shaug/atelier/commit/d8bdd9fefe89347f01077faac7fd6c9ac26e5aa2))
+- **agent-teardown:** fail closed on owner-only mismatch payloads
+  ([de412fb](https://github.com/shaug/atelier/commit/de412fbcfa0d0905188d5be8160e8c41755be373))
+- **agent-teardown:** fail closed on owner-only ownership payloads
+  ([43de4ce](https://github.com/shaug/atelier/commit/43de4ce4bbea8a3f0465fbfeba74bc084eed7a74))
+- **agent-teardown:** fail closed on ownership metadata drift
+  ([c51f369](https://github.com/shaug/atelier/commit/c51f369832239f202ff0f5ab7c5874e536194955))
+- **agent-teardown:** require epic release confirmation before closing agent
+  bead
+  ([9a58469](https://github.com/shaug/atelier/commit/9a58469ca5c8648e8937cd9af34b010f0a0d1ac3))
+- **agent:** fail closed teardown close gate without hook target
+  ([0d46a2c](https://github.com/shaug/atelier/commit/0d46a2c813ecdc8d861af361b3c02affb30f8ac6))
+- **agent:** fail closed teardown ownership on index drift
+  ([ef21d45](https://github.com/shaug/atelier/commit/ef21d459e6dc25b91d93d8356f4859fc94e662fe))
+- **agent:** re-verify epic release before closing agent bead
+  ([ea87161](https://github.com/shaug/atelier/commit/ea871617f13adb90d67910130004c48f06c857f6))
+- **beads:** prefer open agent bead over closed duplicates
+  ([fdc80e0](https://github.com/shaug/atelier/commit/fdc80e0bcf17ff2458836aa46624b3036ed4dce5)),
+  closes [#506](https://github.com/shaug/atelier/issues/506)
+- **doctor:** backfill missing mapping lineage in migration repair
+  ([577f671](https://github.com/shaug/atelier/commit/577f671781c8bdd0c679c06dd1de990af5b4e1d6)),
+  closes [#508](https://github.com/shaug/atelier/issues/508)
+- **doctor:** converge prefix drift normalization to canonical branch paths
+  ([1281e18](https://github.com/shaug/atelier/commit/1281e18246a5e04a3dbcec6dd211e12ceba2d0bb)),
+  closes [#509](https://github.com/shaug/atelier/issues/509)
+- **gc:** scan all agent beads during stale cleanup
+  ([85600b1](https://github.com/shaug/atelier/commit/85600b11f1f5b0a0ea8bb277e7bc573a3addb4a9))
+- **git:** forward git_path in enlistment resolution
+  ([bf23369](https://github.com/shaug/atelier/commit/bf2336966f93e7b07f041d40fad4712c69ce2c68))
+- **planner-startup:** resolve project identity from linked worktrees
+  ([17672fb](https://github.com/shaug/atelier/commit/17672fb572cdcf7b22cede161b67200a992fc0a7)),
+  closes [#519](https://github.com/shaug/atelier/issues/519)
+- **prefix-migration:** converge legacy namespace drift deterministically
+  ([700a0a5](https://github.com/shaug/atelier/commit/700a0a5315e688752e41be741b056c6c30cd3fd6)),
+  closes [#510](https://github.com/shaug/atelier/issues/510)
+- **prefix-migration:** enforce scoped changeset ownership
+  ([6469171](https://github.com/shaug/atelier/commit/6469171b0a709e0e98af7745b0ccd38eb7f6bc7c))
+- **prefix-migration:** fail closed on ambiguous worktree candidates
+  ([71e1eda](https://github.com/shaug/atelier/commit/71e1eda17c249f09e0343864d87c6dea72b1e4de))
+- **prefix-migration:** prefer remote canonical branch source
+  ([1dedbf8](https://github.com/shaug/atelier/commit/1dedbf83138aae8312c20c30f5ef35afc8e34500))
+- **prefix-migration:** preflight branch checkout before worktree moves
+  ([c4df26e](https://github.com/shaug/atelier/commit/c4df26e24773ba63000fd8d9fc703e478f51ee81))
+- **prefix-migration:** restore metadata worktree source resolution
+  ([7a1c9e3](https://github.com/shaug/atelier/commit/7a1c9e37097669d9b9bc5f185ccec07c13487359))
+- **runtime:** gate agent-bead closure on verified hook cleanup
+  ([327dc64](https://github.com/shaug/atelier/commit/327dc640987854bf18633279266e0caf3804c023))
+- **runtime:** harden planner teardown bead targeting
+  ([e079574](https://github.com/shaug/atelier/commit/e079574d8225e41ce36314dbefda31db9c30aba0)),
+  closes [#506](https://github.com/shaug/atelier/issues/506)
+- **runtime:** teardown agent beads and hooks on exit
+  ([485695a](https://github.com/shaug/atelier/commit/485695a79eb3ce0120d22af7570afcb6c2510f1a)),
+  closes [#506](https://github.com/shaug/atelier/issues/506)
+- **worker-review:** guard leaked review-branch pruning
+  ([f9f2e4e](https://github.com/shaug/atelier/commit/f9f2e4e714bd07de07388cb5cbbd03e42a7678d8))
+- **worker:** pass concrete agent bead id through teardown
+  ([cdf38d9](https://github.com/shaug/atelier/commit/cdf38d98563f1d0850205ad773a3f6bed019f818)),
+  closes [#506](https://github.com/shaug/atelier/issues/506)
+- **worker:** stop leaking temporary pr-\* review branches
+  ([aa5a537](https://github.com/shaug/atelier/commit/aa5a537180d60c2f36ca15ef1edd7f1285fca0dc)),
+  closes [#507](https://github.com/shaug/atelier/issues/507)
+- **worktrees:** fail closed on mismatched epic direct mapping
+  ([d0d08ff](https://github.com/shaug/atelier/commit/d0d08ff56e27ef71bf8eef733197203d78e36f35))
+- **worktrees:** prefer live branch source and fail closed on invalid canonical
+  path
+  ([739cfc1](https://github.com/shaug/atelier/commit/739cfc1d6bda48fbc38a3c41bb598c235b3d0559))
+- **worktrees:** validate direct mapping owner on epic lookup
+  ([d8bdd9f](https://github.com/shaug/atelier/commit/d8bdd9fefe89347f01077faac7fd6c9ac26e5aa2))
 
 ## [0.8.0](https://github.com/shaug/atelier/compare/v0.7.0...v0.8.0) (2026-03-04)
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -211,6 +211,9 @@ Atelier planning state. They are treated as external ticket sources.
 - `atelier gc`
 
   - Cleans up stale hooks, claims, orphaned worktrees, and stale queue claims.
+  - `--reconcile` classifies scanned changesets as `metadata-stale`,
+    `not-merged`, or `decision-required` before mutating lifecycle metadata. See
+    `docs/stale-state-reconciliation.md` for the operator runbook.
   - Scans the full `at:agent` bead set (`bd list --all --limit 0`) so a single
     pass can release all stale session agents.
   - Closes channel messages when explicit retention metadata is present.

--- a/docs/stale-state-reconciliation.md
+++ b/docs/stale-state-reconciliation.md
@@ -1,0 +1,35 @@
+# Stale-State Reconciliation
+
+`atelier gc --reconcile` now classifies stale-state findings with stable
+operator buckets before it mutates Beads metadata:
+
+- `metadata-stale`
+  - Live PR evidence is terminal (`merged` or `closed`), but Beads still has a
+    non-terminal `status` and/or stale `pr_state`.
+  - Expected action: rerun reconcile/finalize so metadata can converge.
+- `not-merged`
+  - Live PR lifecycle is still active, or terminal proof is not available.
+  - Expected action: leave the changeset active and wait for publish/merge
+    evidence instead of forcing closure.
+- `decision-required`
+  - PR lookup, branch metadata, or lineage proof is ambiguous.
+  - Expected action: repair the missing proof, then rerun reconcile.
+
+Example diagnostics:
+
+```text
+triage=metadata-stale reason=terminal_pr_merged live_pr=merged stored_pr=draft-pr stale_fields=status,pr_state action=reconcile-stale-metadata
+triage=not-merged reason=active_pr_lifecycle_pr-open live_pr=pr-open stored_pr=merged action=leave-state-as-is
+triage=decision-required reason=pr_lifecycle_lookup_failed detail=gh timeout action=manual-decision-required
+```
+
+When output lands in `decision-required`, use a deterministic repair path:
+
+1. Inspect the changeset metadata with `bd show <changeset-id>`.
+1. Verify `changeset.work_branch`, `changeset.parent_branch`, `pr_state`, and
+   `changeset.integrated_sha`.
+1. If the blocker is dependency lineage or `unknown-parent`, repair the single
+   deterministic parent branch using
+   [`docs/dependency-lineage-repair.md`](./dependency-lineage-repair.md).
+1. Rerun `atelier gc --reconcile --dry-run` to confirm the bucket changes away
+   from `decision-required` before applying the real reconcile run.

--- a/src/atelier/commands/gc.py
+++ b/src/atelier/commands/gc.py
@@ -70,6 +70,8 @@ def gc(args: object) -> None:
                     project_dir=project_data_dir,
                     beads_root=beads_root,
                     repo_root=repo_root,
+                    project_config=project_config,
+                    git_path=git_path,
                 ):
                     say(f"- {detail}")
             reconcile_result = work_cmd.reconcile_blocked_merged_changesets(
@@ -116,6 +118,8 @@ def gc(args: object) -> None:
                     project_dir=project_data_dir,
                     beads_root=beads_root,
                     repo_root=repo_root,
+                    project_config=project_config,
+                    git_path=git_path,
                 ):
                     say(f"- {detail}")
                 if not confirm(prompt_text, default=False):

--- a/src/atelier/gc/reconcile.py
+++ b/src/atelier/gc/reconcile.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .. import beads, worktrees
+from .. import beads, config, prs, worktrees
+from ..worker import stale_pr_lifecycle
 from .common import issue_integrated_sha, normalize_branch, try_show_issue
 
 
@@ -15,8 +16,15 @@ def reconcile_preview_lines(
     project_dir: Path | None,
     beads_root: Path,
     repo_root: Path,
+    project_config: config.ProjectConfig | None = None,
+    git_path: str | None = None,
 ) -> tuple[str, ...]:
     lines: list[str] = []
+    repo_slug: str | None = None
+    if project_config is not None:
+        repo_slug = prs.github_repo_slug(
+            project_config.project.origin or project_config.project.repo_url
+        )
     if project_dir is not None:
         mapping = worktrees.load_mapping(worktrees.mapping_path(project_dir, epic_id))
         if mapping is not None:
@@ -60,4 +68,16 @@ def reconcile_preview_lines(
         status = str(issue.get("status") or "unknown")
         integrated_sha = issue_integrated_sha(issue) or "missing"
         lines.append(f"{changeset_id}: status={status} integrated_sha={integrated_sha}")
+        if project_config is not None and project_config.branch.pr:
+            classification = stale_pr_lifecycle.classify_stale_terminal_pr_lifecycle(
+                issue,
+                repo_slug=repo_slug,
+                repo_root=repo_root,
+                branch_pr=True,
+                git_path=git_path,
+            )
+            if classification.is_candidate or classification.is_anomaly:
+                lines.append(
+                    f"{changeset_id}: {stale_pr_lifecycle.format_operator_triage(classification)}"
+                )
     return tuple(lines)

--- a/src/atelier/worker/reconcile.py
+++ b/src/atelier/worker/reconcile.py
@@ -22,6 +22,7 @@ class ReconcileCandidate:
     dependency_ids: tuple[str, ...]
     terminal_pr_state: str | None = None
     require_terminal_status: bool = False
+    triage_summary: str | None = None
 
 
 @dataclass(frozen=True)
@@ -714,34 +715,18 @@ def reconcile_blocked_merged_changesets(
                     log(
                         "reconcile anomaly: "
                         f"{changeset_id} -> epic={epic_id} "
-                        + (
-                            "in_progress+stale-terminal-pr-anomaly("
-                            f"reason={stale_terminal.reason},"
-                            f"detail={_format_lookup_error(stale_terminal.detail)}) "
-                            if stale_terminal.detail
-                            else (
-                                "in_progress+stale-terminal-pr-anomaly("
-                                f"reason={stale_terminal.reason}) "
-                            )
-                        )
-                        + "decision-required"
+                        f"status={status} "
+                        f"{stale_pr_lifecycle.format_operator_triage(stale_terminal)}"
                     )
                 continue
             if not stale_terminal.is_candidate:
                 if log:
-                    if stale_terminal.reason.startswith("active_pr_lifecycle_"):
-                        log(
-                            f"reconcile skip: {changeset_id} "
-                            "(in_progress pr lifecycle still active: "
-                            f"{stale_terminal.live_pr_state or 'none'})"
-                        )
-                    else:
-                        stored_state = _stored_review_state(issue) or "none"
-                        log(
-                            f"reconcile skip: {changeset_id} "
-                            "(in_progress terminal PR evidence unavailable; "
-                            f"stored={stored_state}, live={stale_terminal.live_pr_state or 'none'})"
-                        )
+                    log(
+                        "reconcile skip: "
+                        f"{changeset_id} -> epic={epic_id} "
+                        f"status={status} "
+                        f"{stale_pr_lifecycle.format_operator_triage(stale_terminal)}"
+                    )
                 continue
             integration_proven, integrated_sha = changeset_integration_signal(
                 issue,
@@ -761,6 +746,7 @@ def reconcile_blocked_merged_changesets(
                 dependency_ids=issue_dependency_ids(issue),
                 terminal_pr_state=stale_terminal.live_pr_state,
                 require_terminal_status=True,
+                triage_summary=stale_pr_lifecycle.format_operator_triage(stale_terminal),
             )
             continue
         if project_config.branch.pr and status in {"open", "blocked"}:
@@ -778,17 +764,8 @@ def reconcile_blocked_merged_changesets(
                     log(
                         "reconcile anomaly: "
                         f"{changeset_id} -> epic={epic_id} "
-                        + (
-                            f"{status}+stale-terminal-pr-anomaly("
-                            f"reason={stale_terminal.reason},"
-                            f"detail={_format_lookup_error(stale_terminal.detail)}) "
-                            if stale_terminal.detail
-                            else (
-                                f"{status}+stale-terminal-pr-anomaly("
-                                f"reason={stale_terminal.reason}) "
-                            )
-                        )
-                        + "decision-required"
+                        f"status={status} "
+                        f"{stale_pr_lifecycle.format_operator_triage(stale_terminal)}"
                     )
                 continue
             if stale_terminal.is_candidate:
@@ -810,8 +787,17 @@ def reconcile_blocked_merged_changesets(
                     dependency_ids=issue_dependency_ids(issue),
                     terminal_pr_state=stale_terminal.live_pr_state,
                     require_terminal_status=True,
+                    triage_summary=stale_pr_lifecycle.format_operator_triage(stale_terminal),
                 )
                 continue
+            if log:
+                log(
+                    "reconcile skip: "
+                    f"{changeset_id} -> epic={epic_id} "
+                    f"status={status} "
+                    f"{stale_pr_lifecycle.format_operator_triage(stale_terminal)}"
+                )
+            continue
         integration_proven, integrated_sha = changeset_integration_signal(
             issue,
             repo_slug=repo_slug,
@@ -959,6 +945,7 @@ def reconcile_blocked_merged_changesets(
                 if log:
                     log(
                         f"reconcile dry-run: {changeset_id} -> epic={candidate.epic_id}"
+                        + (f" {candidate.triage_summary}" if candidate.triage_summary else "")
                         + (
                             f" integrated_sha={candidate.integrated_sha}"
                             if candidate.integrated_sha
@@ -1081,6 +1068,7 @@ def reconcile_blocked_merged_changesets(
                 log(
                     f"reconcile ok: {changeset_id} -> epic={candidate.epic_id} "
                     f"(finalize reason={finalize_result.reason})"
+                    + (f" {candidate.triage_summary}" if candidate.triage_summary else "")
                     + (f" metadata={','.join(converged_updates)}" if converged_updates else "")
                 )
             reconciled += 1

--- a/src/atelier/worker/stale_pr_lifecycle.py
+++ b/src/atelier/worker/stale_pr_lifecycle.py
@@ -35,6 +35,15 @@ class StaleTerminalPrLifecycleClassification:
         """Return whether the classification represents ambiguous evidence."""
         return self.kind == "anomaly"
 
+    @property
+    def triage_bucket(self) -> str:
+        """Return the operator-facing triage bucket for this classification."""
+        if self.is_candidate:
+            return "metadata-stale"
+        if self.is_anomaly:
+            return "decision-required"
+        return "not-merged"
+
 
 def _classification(
     *,
@@ -161,7 +170,42 @@ def classify_stale_terminal_pr_lifecycle(
     )
 
 
+def format_operator_triage(
+    classification: StaleTerminalPrLifecycleClassification,
+) -> str:
+    """Render a stable operator-facing triage summary.
+
+    Args:
+        classification: Stale terminal lifecycle classification result.
+
+    Returns:
+        Stable summary string suitable for reconcile logs and diagnostics.
+    """
+    parts = [
+        f"triage={classification.triage_bucket}",
+        f"reason={classification.reason}",
+    ]
+    if classification.live_pr_state:
+        parts.append(f"live_pr={classification.live_pr_state}")
+    if classification.stored_pr_state:
+        parts.append(f"stored_pr={classification.stored_pr_state}")
+    if classification.stale_fields:
+        parts.append(f"stale_fields={','.join(classification.stale_fields)}")
+    if classification.detail:
+        detail = " ".join(classification.detail.split()) or "unknown"
+        parts.append(f"detail={detail}")
+
+    if classification.is_candidate:
+        parts.append("action=reconcile-stale-metadata")
+    elif classification.is_anomaly:
+        parts.append("action=manual-decision-required")
+    else:
+        parts.append("action=leave-state-as-is")
+    return " ".join(parts)
+
+
 __all__ = [
     "StaleTerminalPrLifecycleClassification",
     "classify_stale_terminal_pr_lifecycle",
+    "format_operator_triage",
 ]

--- a/tests/atelier/gc/test_gc_reconcile.py
+++ b/tests/atelier/gc/test_gc_reconcile.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import atelier.gc.reconcile as gc_reconcile
+from atelier import config, prs
 
 
 def test_reconcile_preview_lines_includes_epic_and_changeset_info() -> None:
@@ -70,3 +71,45 @@ def test_reconcile_preview_lines_includes_mapping_when_project_dir_given() -> No
 
     assert any("mapped branches" in line for line in lines)
     assert any("mapped worktrees" in line for line in lines)
+
+
+def test_reconcile_preview_lines_reports_operator_triage_for_stale_metadata() -> None:
+    project_config = config.ProjectConfig(
+        project=config.ProjectSection(origin="https://github.com/org/repo"),
+        branch=config.BranchConfig(pr=True),
+    )
+    issue = {
+        "id": "at-epic.1",
+        "status": "blocked",
+        "description": "changeset.work_branch: feat/root-at-epic.1\npr_state: draft-pr\n",
+    }
+
+    with (
+        patch("atelier.gc.reconcile.try_show_issue", return_value=issue),
+        patch("atelier.gc.reconcile.stale_pr_lifecycle.git.git_ref_exists", return_value=True),
+        patch(
+            "atelier.gc.reconcile.stale_pr_lifecycle.prs.lookup_github_pr_status",
+            return_value=prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 17,
+                    "state": "CLOSED",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                    "mergedAt": "2026-03-01T00:00:00Z",
+                    "closedAt": "2026-03-01T00:00:00Z",
+                },
+            ),
+        ),
+    ):
+        lines = gc_reconcile.reconcile_preview_lines(
+            "at-epic",
+            ["at-epic.1"],
+            project_dir=None,
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+            project_config=project_config,
+            git_path="git",
+        )
+
+    assert any("triage=metadata-stale" in line for line in lines)

--- a/tests/atelier/worker/test_reconcile.py
+++ b/tests/atelier/worker/test_reconcile.py
@@ -595,6 +595,120 @@ def test_reconcile_blocked_merged_changesets_keeps_finalize_integrated_sha_autho
     assert operations == [("review", "merged")]
 
 
+def test_reconcile_stale_terminal_metadata_next_run_uses_closed_path_without_refinalize() -> None:
+    project = config.ProjectConfig(
+        project=config.ProjectSection(origin="https://github.com/org/repo"),
+        branch=config.BranchConfig(pr=True),
+    )
+    issue = {
+        "id": "at-1.16",
+        "status": "blocked",
+        "labels": [],
+        "description": "changeset.work_branch: feat/at-1.16\npr_state: pushed\n",
+    }
+
+    def run_bd_json(args: list[str], **_kwargs: object) -> list[dict[str, object]]:
+        if args[:2] == ["show", "at-1.16"]:
+            return [issue]
+        return []
+
+    def finalize_changeset(**_kwargs: object) -> FinalizeResult:
+        issue["status"] = "closed"
+        issue["description"] = (
+            "changeset.work_branch: feat/at-1.16\n"
+            "pr_state: merged\n"
+            "changeset.integrated_sha: abc1234\n"
+        )
+        return FinalizeResult(continue_running=True, reason="changeset_complete")
+
+    with (
+        patch("atelier.worker.reconcile.beads.list_all_changesets", return_value=[issue]),
+        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
+        patch("atelier.worker.reconcile.git.git_ref_exists", return_value=True),
+        patch(
+            "atelier.worker.reconcile.prs.lookup_github_pr_status",
+            return_value=prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 16,
+                    "state": "CLOSED",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                    "mergedAt": "2026-03-01T00:00:00Z",
+                    "closedAt": "2026-03-01T00:00:00Z",
+                },
+            ),
+        ),
+        patch("atelier.worker.reconcile.beads.update_changeset_review"),
+        patch("atelier.worker.reconcile.beads.update_changeset_integrated_sha"),
+    ):
+        first = reconcile.reconcile_blocked_merged_changesets(
+            agent_id="worker/1",
+            agent_bead_id="at-agent",
+            project_config=project,
+            project_data_dir=Path("/project"),
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+            dry_run=False,
+            resolve_epic_id_for_changeset=lambda *_args, **_kwargs: "at-1",
+            changeset_integration_signal=lambda *_args, **_kwargs: (True, "abc1234"),
+            issue_dependency_ids=lambda _issue: tuple(),
+            issue_labels=lambda issue: {str(label) for label in issue.get("labels", [])},
+            finalize_changeset=finalize_changeset,
+            finalize_epic_if_complete=lambda **_kwargs: FinalizeResult(
+                continue_running=True, reason="changeset_complete"
+            ),
+        )
+
+    logs: list[str] = []
+    with (
+        patch("atelier.worker.reconcile.beads.list_all_changesets", return_value=[issue]),
+        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
+        patch("atelier.worker.reconcile.git.git_ref_exists", return_value=True),
+        patch(
+            "atelier.worker.reconcile.prs.lookup_github_pr_status",
+            return_value=prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 16,
+                    "state": "CLOSED",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                    "mergedAt": "2026-03-01T00:00:00Z",
+                    "closedAt": "2026-03-01T00:00:00Z",
+                },
+            ),
+        ),
+        patch("atelier.worker.reconcile.beads.reconcile_closed_issue_exported_github_tickets"),
+        patch("atelier.worker.reconcile.beads.update_changeset_integrated_sha"),
+    ):
+        second = reconcile.reconcile_blocked_merged_changesets(
+            agent_id="worker/1",
+            agent_bead_id="at-agent",
+            project_config=project,
+            project_data_dir=Path("/project"),
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+            dry_run=False,
+            log=logs.append,
+            resolve_epic_id_for_changeset=lambda *_args, **_kwargs: "at-1",
+            changeset_integration_signal=lambda *_args, **_kwargs: (True, "abc1234"),
+            issue_dependency_ids=lambda _issue: tuple(),
+            issue_labels=lambda issue: {str(label) for label in issue.get("labels", [])},
+            finalize_changeset=lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("closed follow-up run should not re-finalize")
+            ),
+            finalize_epic_if_complete=lambda **_kwargs: FinalizeResult(
+                continue_running=True, reason="changeset_complete"
+            ),
+        )
+
+    assert first.reconciled == 1
+    assert second.reconciled == 1
+    assert second.failed == 0
+    assert any("already closed" in line for line in logs)
+
+
 def test_reconcile_blocked_merged_changesets_fails_closed_when_stale_terminal_finalize_stays_open() -> (
     None
 ):
@@ -711,8 +825,8 @@ def test_reconcile_blocked_merged_changesets_reports_stale_terminal_lookup_anoma
     assert result.reconciled == 0
     assert result.failed == 1
     assert any(
-        "blocked+stale-terminal-pr-anomaly(reason=pr_lifecycle_lookup_failed,detail=gh timeout)"
-        in line
+        "triage=decision-required reason=pr_lifecycle_lookup_failed "
+        "stored_pr=draft-pr detail=gh timeout" in line
         for line in logs
     )
 
@@ -772,6 +886,117 @@ def test_reconcile_blocked_merged_changesets_reconciles_orphaned_in_progress_ter
     assert result.actionable == 1
     assert result.reconciled == 1
     assert result.failed == 0
+
+
+def test_reconcile_logs_metadata_stale_triage_for_blocked_terminal_pr_dry_run() -> None:
+    project = config.ProjectConfig(
+        project=config.ProjectSection(origin="https://github.com/org/repo"),
+        branch=config.BranchConfig(pr=True),
+    )
+    issue = {
+        "id": "at-1.21",
+        "status": "blocked",
+        "labels": [],
+        "description": "changeset.work_branch: feat/at-1.21\npr_state: draft-pr\n",
+    }
+    logs: list[str] = []
+
+    with (
+        patch("atelier.worker.reconcile.beads.list_all_changesets", return_value=[issue]),
+        patch("atelier.worker.reconcile.git.git_ref_exists", return_value=True),
+        patch(
+            "atelier.worker.reconcile.prs.lookup_github_pr_status",
+            return_value=prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 21,
+                    "state": "CLOSED",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                    "mergedAt": "2026-03-01T00:00:00Z",
+                    "closedAt": "2026-03-01T00:00:00Z",
+                },
+            ),
+        ),
+    ):
+        result = reconcile.reconcile_blocked_merged_changesets(
+            agent_id="worker/1",
+            agent_bead_id="at-agent",
+            project_config=project,
+            project_data_dir=Path("/project"),
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+            dry_run=True,
+            log=logs.append,
+            resolve_epic_id_for_changeset=lambda *_args, **_kwargs: "at-1",
+            changeset_integration_signal=lambda *_args, **_kwargs: (True, "abc1234"),
+            issue_dependency_ids=lambda _issue: tuple(),
+            issue_labels=lambda issue: {str(label) for label in issue.get("labels", [])},
+            finalize_changeset=lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("dry-run should not finalize")
+            ),
+            finalize_epic_if_complete=lambda **_kwargs: FinalizeResult(
+                continue_running=True, reason="changeset_complete"
+            ),
+        )
+
+    assert result.reconciled == 1
+    assert any("triage=metadata-stale reason=terminal_pr_merged" in line for line in logs)
+
+
+def test_reconcile_logs_not_merged_triage_when_live_pr_remains_open() -> None:
+    project = config.ProjectConfig(
+        project=config.ProjectSection(origin="https://github.com/org/repo"),
+        branch=config.BranchConfig(pr=True),
+    )
+    issue = {
+        "id": "at-1.22",
+        "status": "blocked",
+        "labels": [],
+        "description": "changeset.work_branch: feat/at-1.22\npr_state: merged\n",
+    }
+    logs: list[str] = []
+
+    with (
+        patch("atelier.worker.reconcile.beads.list_all_changesets", return_value=[issue]),
+        patch("atelier.worker.reconcile.git.git_ref_exists", return_value=True),
+        patch(
+            "atelier.worker.reconcile.prs.lookup_github_pr_status",
+            return_value=prs.GithubPrLookup(
+                outcome="found",
+                payload={
+                    "number": 22,
+                    "state": "OPEN",
+                    "isDraft": False,
+                    "reviewDecision": None,
+                },
+            ),
+        ),
+    ):
+        result = reconcile.reconcile_blocked_merged_changesets(
+            agent_id="worker/1",
+            agent_bead_id="at-agent",
+            project_config=project,
+            project_data_dir=Path("/project"),
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+            dry_run=False,
+            log=logs.append,
+            resolve_epic_id_for_changeset=lambda *_args, **_kwargs: "at-1",
+            changeset_integration_signal=lambda *_args, **_kwargs: (True, "abc1234"),
+            issue_dependency_ids=lambda _issue: tuple(),
+            issue_labels=lambda issue: {str(label) for label in issue.get("labels", [])},
+            finalize_changeset=lambda **_kwargs: (_ for _ in ()).throw(
+                AssertionError("live PR should not finalize as stale")
+            ),
+            finalize_epic_if_complete=lambda **_kwargs: FinalizeResult(
+                continue_running=True, reason="changeset_complete"
+            ),
+        )
+
+    assert result.reconciled == 0
+    assert result.failed == 0
+    assert any("triage=not-merged reason=active_pr_lifecycle_pr-open" in line for line in logs)
 
 
 def test_reconcile_blocked_merged_changesets_skips_in_progress_with_non_terminal_pr() -> None:

--- a/tests/atelier/worker/test_stale_pr_lifecycle.py
+++ b/tests/atelier/worker/test_stale_pr_lifecycle.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from atelier import prs
 from atelier.worker import stale_pr_lifecycle
 
@@ -140,3 +142,50 @@ def test_classify_stale_terminal_pr_lifecycle_marks_lookup_failure_as_anomaly() 
     assert result.kind == "anomaly"
     assert result.reason == "pr_lifecycle_lookup_failed"
     assert result.detail == "gh timeout"
+
+
+@pytest.mark.parametrize(
+    ("classification", "expected"),
+    [
+        (
+            stale_pr_lifecycle.StaleTerminalPrLifecycleClassification(
+                kind="candidate",
+                reason="terminal_pr_merged",
+                canonical_status="blocked",
+                stored_pr_state="draft-pr",
+                live_pr_state="merged",
+                stale_fields=("status", "pr_state"),
+            ),
+            "triage=metadata-stale reason=terminal_pr_merged "
+            "live_pr=merged stored_pr=draft-pr stale_fields=status,pr_state "
+            "action=reconcile-stale-metadata",
+        ),
+        (
+            stale_pr_lifecycle.StaleTerminalPrLifecycleClassification(
+                kind="none",
+                reason="active_pr_lifecycle_pr-open",
+                canonical_status="blocked",
+                stored_pr_state="merged",
+                live_pr_state="pr-open",
+            ),
+            "triage=not-merged reason=active_pr_lifecycle_pr-open "
+            "live_pr=pr-open stored_pr=merged action=leave-state-as-is",
+        ),
+        (
+            stale_pr_lifecycle.StaleTerminalPrLifecycleClassification(
+                kind="anomaly",
+                reason="pr_lifecycle_lookup_failed",
+                canonical_status="blocked",
+                stored_pr_state="draft-pr",
+                detail="gh timeout",
+            ),
+            "triage=decision-required reason=pr_lifecycle_lookup_failed "
+            "stored_pr=draft-pr detail=gh timeout action=manual-decision-required",
+        ),
+    ],
+)
+def test_format_operator_triage_matrix(
+    classification: stale_pr_lifecycle.StaleTerminalPrLifecycleClassification,
+    expected: str,
+) -> None:
+    assert stale_pr_lifecycle.format_operator_triage(classification) == expected


### PR DESCRIPTION
# Summary

Add operator-facing stale-state triage output and regression coverage for reconcile loops where terminal PR metadata lags behind Beads state.

# Changes

- add stable `metadata-stale`, `not-merged`, and `decision-required` triage buckets for stale terminal PR classification
- surface those diagnostics in worker reconcile logs and `atelier gc --reconcile` preview output
- add regression coverage for stale blocked follow-up runs, triage logging, and GC preview reporting
- document the operator runbook for decision-required repair paths

# Testing

- `just format`
- `just lint`
- `just test`

# Tickets

- Fixes #547

# Risks / Rollout

- low risk: changes are limited to reconcile diagnostics, GC preview messaging, and regression coverage around existing stale-state flows

# Notes

- `atelier gc --reconcile` now links to a dedicated stale-state reconciliation runbook for operator triage
- local workspace-shell `just test` under Python 3.14 still reproduces the pre-existing `from importlib.abc import Traversable` collection failure at `src/atelier/skills.py:13`; the canonical publish gate passed under the project Python 3.11 environment during push
