### PR TITLE
Enforce richer planner bead authoring context

### DIFF
--- a/src/atelier/planner_contract.py
+++ b/src/atelier/planner_contract.py
@@ -1,0 +1,149 @@
+"""Planner bead authoring contract helpers.
+
+This module defines the richer worker-facing context contract for executable
+work. Planner guardrails use it to verify that an executable path contains the
+context workers need before implementation starts.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Final
+
+from .executable_work_validation import normalize_text
+
+_KEY_PATTERN: Final[re.Pattern[str]] = re.compile(r"[^a-z0-9]+")
+_LINE_FIELD_PATTERN: Final[re.Pattern[str]] = re.compile(r"^\s*([^:]+):\s*(.+?)\s*$")
+_TEXT_FIELDS: Final[tuple[str, ...]] = ("description", "notes", "design")
+_REQUIRED_FIELD_ALIASES: Final[dict[str, tuple[str, ...]]] = {
+    "intent": ("intent",),
+    "rationale": ("rationale",),
+    "non_goals": ("non_goals", "non_goal"),
+    "constraints": ("constraints", "constraint"),
+    "edge_cases": ("edge_cases", "edge_case"),
+    "related_context": (
+        "related_context",
+        "related_beads",
+        "related_links",
+        "broader_context",
+    ),
+}
+_DONE_DEFINITION_ALIASES: Final[tuple[str, ...]] = (
+    "done_definition",
+    "success_definition",
+)
+_ACCEPTANCE_FIELDS: Final[tuple[str, ...]] = ("acceptance_criteria", "acceptance")
+_PLACEHOLDER_VALUES: Final[frozenset[str]] = frozenset(
+    {
+        "/",
+        "//",
+        "-",
+        "--",
+        ".",
+        "..",
+        "?",
+        "??",
+        "???",
+        "n/a",
+        "na",
+        "none",
+        "null",
+        "todo",
+        "tbd",
+        "placeholder",
+        "unknown",
+        "tmp",
+        "temp",
+    }
+)
+
+
+def validate_authoring_contract(
+    issue: Mapping[str, object],
+    *,
+    inherited_context: Sequence[Mapping[str, object]] = (),
+) -> tuple[str, ...]:
+    """Return missing planner authoring contract fields for an executable path.
+
+    The contract is evaluated across the target issue plus any inherited epic
+    context that will be presented to the worker alongside it.
+
+    Args:
+        issue: Target executable work bead payload.
+        inherited_context: Additional issues that provide shared planner context,
+            typically the parent epic for a child changeset.
+
+    Returns:
+        Tuple of canonical missing field names. Empty tuple means the combined
+        executable path has the required context sections.
+    """
+
+    combined_fields = _collect_fields([*inherited_context, issue])
+    missing: list[str] = []
+    for field_name, aliases in _REQUIRED_FIELD_ALIASES.items():
+        if any(_has_meaningful_value(combined_fields.get(alias, ())) for alias in aliases):
+            continue
+        missing.append(field_name)
+    if not _has_done_definition([*inherited_context, issue], combined_fields):
+        missing.append("done_definition")
+    return tuple(missing)
+
+
+def _collect_fields(issues: Sequence[Mapping[str, object]]) -> dict[str, tuple[str, ...]]:
+    values: dict[str, list[str]] = {}
+    for issue in issues:
+        for field_name in _TEXT_FIELDS:
+            raw_value = issue.get(field_name)
+            if not isinstance(raw_value, str) or not raw_value.strip():
+                continue
+            for key, value in _iter_field_lines(raw_value):
+                values.setdefault(key, []).append(value)
+    return {key: tuple(items) for key, items in values.items()}
+
+
+def _iter_field_lines(text: str) -> tuple[tuple[str, str], ...]:
+    parsed: list[tuple[str, str]] = []
+    for line in text.splitlines():
+        match = _LINE_FIELD_PATTERN.match(line)
+        if match is None:
+            continue
+        normalized_key = _normalize_key(match.group(1))
+        if not normalized_key:
+            continue
+        parsed.append((normalized_key, match.group(2).strip()))
+    return tuple(parsed)
+
+
+def _normalize_key(raw_key: str) -> str:
+    normalized = _KEY_PATTERN.sub("_", raw_key.strip().lower()).strip("_")
+    return normalized
+
+
+def _has_meaningful_value(values: Sequence[str]) -> bool:
+    for value in values:
+        normalized = normalize_text(value)
+        if not normalized:
+            continue
+        lowered = normalized.lower()
+        compacted = lowered.replace(" ", "")
+        if lowered in _PLACEHOLDER_VALUES or compacted in _PLACEHOLDER_VALUES:
+            continue
+        return True
+    return False
+
+
+def _has_done_definition(
+    issues: Sequence[Mapping[str, object]],
+    combined_fields: Mapping[str, tuple[str, ...]],
+) -> bool:
+    if any(
+        _has_meaningful_value(combined_fields.get(alias, ())) for alias in _DONE_DEFINITION_ALIASES
+    ):
+        return True
+    for issue in issues:
+        for field_name in _ACCEPTANCE_FIELDS:
+            raw_value = issue.get(field_name)
+            if isinstance(raw_value, str) and _has_meaningful_value((raw_value,)):
+                return True
+    return False

--- a/src/atelier/skills/beads/references/beads-conventions.md
+++ b/src/atelier/skills/beads/references/beads-conventions.md
@@ -43,11 +43,22 @@ Use key: value lines in descriptions for structured fields (human-readable and
 machine-parsable). Example:
 
 ```
+intent: <why this work exists>
+rationale: <why this unit is shaped this way>
 scope: <short scope>
+non_goals: <what not to change>
+constraints: <hard limits or invariants>
+edge_cases: <important edge cases or "none identified.">
+related_context: <other bead ids/links or "none identified.">
+done_definition: <explicit success definition if not fully captured in acceptance>
 changeset_strategy: <rules>
 worktree_path: <path>
 external_tickets: <json list>
 ```
+
+For executable work, the worker-facing path should cover intent, rationale,
+non-goals, constraints, edge cases, related context, and a done definition using
+description, notes, design, and acceptance fields together.
 
 Agent hook storage:
 

--- a/src/atelier/skills/plan-changeset-guardrails/SKILL.md
+++ b/src/atelier/skills/plan-changeset-guardrails/SKILL.md
@@ -19,6 +19,9 @@ description: >-
 - Each changeset should include a LOC estimate in notes.
 - If a changeset exceeds the approval threshold (default 800 LOC), notes should
   include an explicit approval record.
+- Each executable path should include explicit planner context: `intent`,
+  `rationale`, `non_goals`, `constraints`, `edge_cases`, `related_context`, and
+  a done definition.
 - Guardrails should be recorded in notes or description when exceptions apply.
 - Detect anti-pattern: an epic with exactly one child changeset and no
   decomposition rationale.
@@ -43,6 +46,8 @@ description: >-
    - If `changeset_ids` is provided, validate those.
    - Else list leaf work beads (changesets) under `epic_id`.
 1. For each changeset, inspect description/notes:
+   - Validate the planner authoring contract across the changeset plus inherited
+     epic context.
    - Look for a LOC estimate (e.g., `loc`, `LOC`, `estimate`).
    - If a large estimate is found (>800), ensure approval is recorded.
    - When lifecycle/contract invariant terms are present, verify the invariant
@@ -56,6 +61,8 @@ description: >-
 ## Verification
 
 - Violations are reported with bead ids and missing guardrail details.
+- Missing planner authoring contract sections are reported with actionable field
+  names.
 - One-child anti-pattern warnings are reported when rationale is missing.
 - Cross-cutting invariant violations identify missing impact map coverage,
   decomposition expectations, and re-split handling requirements.

--- a/src/atelier/skills/plan-changeset-guardrails/scripts/check_guardrails.py
+++ b/src/atelier/skills/plan-changeset-guardrails/scripts/check_guardrails.py
@@ -14,12 +14,14 @@ from pathlib import Path
 
 from atelier import beads
 from atelier.bd_invocation import with_bd_mode
+from atelier.planner_contract import validate_authoring_contract
 
 _LOC_TRIGGER = re.compile(r"\b(?:loc|estimate)\b", re.IGNORECASE)
 _NUMBER = re.compile(r"\b\d{2,5}\b")
 _APPROVAL = re.compile(r"\b(?:approve|approved|approval|sign[- ]?off|ok(?:ay)?)\b", re.IGNORECASE)
 _RATIONALE = re.compile(
-    r"\b(?:rationale|split because|split due to|reviewability|dependency|sequencing)\b",
+    r"\b(?:decomposition rationale|split because|split due to|reviewability|"
+    r"dependency sequencing|sequencing constraint)\b",
     re.IGNORECASE,
 )
 _CROSS_CUTTING_INVARIANT = re.compile(
@@ -226,6 +228,28 @@ def _evaluate_guardrails(
 
     for issue in target_changesets:
         issue_id = _issue_id(issue) or "(unknown)"
+        inherited_context = (
+            [epic_issue] if epic_issue is not None and epic_issue is not issue else []
+        )
+        missing_contract_fields = validate_authoring_contract(
+            issue,
+            inherited_context=inherited_context,
+        )
+        if missing_contract_fields:
+            missing_sections = tuple(
+                field for field in missing_contract_fields if field != "done_definition"
+            )
+            if missing_sections:
+                violations.append(
+                    f"{issue_id}: missing planner authoring contract fields "
+                    f"({', '.join(missing_sections)}); add explicit key/value context to the "
+                    "epic or changeset description/notes/design."
+                )
+            if "done_definition" in missing_contract_fields:
+                violations.append(
+                    f"{issue_id}: missing explicit done definition; add acceptance criteria or "
+                    "`done_definition:` to the executable path."
+                )
         text = _text_blob(issue)
         estimate = _extract_loc_estimate(text)
         if estimate is None:

--- a/src/atelier/skills/plan-changesets/SKILL.md
+++ b/src/atelier/skills/plan-changesets/SKILL.md
@@ -28,6 +28,11 @@ create/edit deferred work.
 - Separate renames from behavioral changes.
 - Prefer additive-first changesets.
 - Keep changesets reviewable (~200–400 LOC; split when >800 LOC).
+- Ensure the executable path for each changeset (the child plus inherited epic
+  context) explicitly records `intent`, `rationale`, `non_goals`, `constraints`,
+  `edge_cases`, `related_context`, and a done definition.
+- Shared context can live on the epic; child changesets should add only the
+  delta needed for worker execution.
 - For lifecycle/contract invariant bugs, record an upfront invariant impact map
   that calls out:
   - mutation entry points
@@ -63,6 +68,8 @@ create/edit deferred work.
      creating the child.
 1. Default new changesets to `status=deferred`; promote to `status=open` only
    via the explicit promotion flow.
+1. After creation, fill in any missing authoring-contract fields on the epic or
+   child bead before promotion.
 1. Capture an estimated LOC range and record it in notes.
 1. If a changeset violates guardrails (especially >800 LOC), pause and request
    explicit approval; record the approval decision in notes.
@@ -98,5 +105,7 @@ Scenario: `Prevent premature close of active-PR changesets`.
 - Decomposition happened only when needed for scope/dependency/reviewability.
 - Any one-child decomposition has explicit rationale recorded in notes or
   description.
+- Every executable path includes explicit worker-facing context fields plus
+  acceptance criteria or `done_definition`.
 - When auto-export is enabled and not opted out, each changeset gets its own
   exported external ticket link.

--- a/src/atelier/skills/plan-create-epic/SKILL.md
+++ b/src/atelier/skills/plan-create-epic/SKILL.md
@@ -27,6 +27,13 @@ Do not request approval to create or edit deferred beads.
    - `python skills/plan-create-epic/scripts/create_epic.py --title "<title>" --scope "<scope>" --acceptance "<acceptance>" [--changeset-strategy "<changeset_strategy>"] [--design "<design>"] [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"] [--no-export]`
    - This is the canonical top-level executable-work creation path; it sets both
      `issue_type=epic` and the required `at:epic` discovery label.
+1. Refine the epic into the executable-path authoring contract immediately:
+   - Record explicit `intent`, `rationale`, `non_goals`, `constraints`,
+     `edge_cases`, and `related_context` fields in description/notes/design.
+   - Use acceptance criteria as the done definition, or add
+     `done_definition: ...` when completion needs sharper wording.
+   - If there is no broader bead context, write
+     `related_context: none identified.`
 1. The script creates the bead, applies auto-export when enabled by project
    config, sets status to `deferred`, and prints non-fatal retry instructions if
    export fails.
@@ -41,6 +48,8 @@ Do not request approval to create or edit deferred beads.
 - Epic is created with `issue_type=epic`.
 - Epic status is `deferred` until explicit promotion.
 - Acceptance criteria stored in the acceptance field.
+- Epic description/notes/design capture the required planner authoring contract
+  before promotion.
 - When auto-export is enabled and not opted out, `external_tickets` is updated
   with `direction=exported` and `sync_mode=export`.
 - If startup diagnostics report identity drift, remediation is deterministic:

--- a/src/atelier/templates/AGENTS.planner.md.tmpl
+++ b/src/atelier/templates/AGENTS.planner.md.tmpl
@@ -115,6 +115,9 @@ If code changes are needed, create beads and leave implementation to workers.
 - A changeset is a review-sized unit of work, not a synonym for task/subtask.
 - Executable work beads must produce committable artifacts (code/config/docs/tests).
 - Do not dispatch cleanup-only beads as worker executable work.
+- Ensure every executable path (epic-as-single-changeset or epic + child
+  changeset) records explicit intent, rationale, non-goals, constraints, edge
+  cases, related-context links, and a done definition.
 - If the epic itself is within guardrails, keep it as a single executable
   changeset (no child changesets required).
 - Split into child changesets only when scope, dependencies, or reviewability
@@ -141,9 +144,19 @@ If code changes are needed, create beads and leave implementation to workers.
 
 Every epic/task/subtask should read like a proper issue ticket:
 - Intent and rationale
-- Non-goals and constraints
-- Acceptance criteria
+- Scope plus non-goals and constraints
+- Edge cases and related-context links to other beads
+- Acceptance criteria or explicit done definition
 - Dependencies and risks
+
+Use explicit key/value fields where possible, for example:
+- `intent:`
+- `rationale:`
+- `non_goals:`
+- `constraints:`
+- `edge_cases:`
+- `related_context:`
+- `done_definition:` (or detailed acceptance criteria)
 
 Both an agent and a developer should be able to implement from beads alone.
 

--- a/tests/atelier/skills/test_plan_changeset_guardrails_script.py
+++ b/tests/atelier/skills/test_plan_changeset_guardrails_script.py
@@ -24,12 +24,25 @@ def _load_script_module():
     return module
 
 
+def _planner_contract_text() -> str:
+    return (
+        "intent: Prevent planner beads from losing execution context.\n"
+        "rationale: Workers need stable scope and rationale before implementation.\n"
+        "non_goals: Do not change publish or worker runtime behavior.\n"
+        "constraints: Keep changesets reviewable and deterministic.\n"
+        "edge_cases: Imported tickets may omit key worker-facing context.\n"
+        "related_context: at-surch, at-ohj2."
+    )
+
+
 def test_evaluate_guardrails_accepts_single_unit_epic_path() -> None:
     module = _load_script_module()
     epic = {
         "id": "at-epic",
         "labels": ["at:epic"],
-        "description": "LOC estimate: 320",
+        "description": _planner_contract_text(),
+        "notes": "LOC estimate: 320",
+        "acceptance_criteria": "Done when planner beads expose executable worker context.",
     }
 
     report = module._evaluate_guardrails(
@@ -44,7 +57,12 @@ def test_evaluate_guardrails_accepts_single_unit_epic_path() -> None:
 
 def test_evaluate_guardrails_flags_one_child_without_rationale() -> None:
     module = _load_script_module()
-    epic = {"id": "at-epic", "labels": ["at:epic"], "description": "Intent: ship parser update"}
+    epic = {
+        "id": "at-epic",
+        "labels": ["at:epic"],
+        "description": _planner_contract_text(),
+        "acceptance_criteria": "Done when the executable path is actionable.",
+    }
     child = {"id": "at-epic.1", "labels": [], "description": "LOC estimate: 210"}
 
     report = module._evaluate_guardrails(
@@ -61,7 +79,9 @@ def test_evaluate_guardrails_allows_one_child_with_rationale() -> None:
     epic = {
         "id": "at-epic",
         "labels": ["at:epic"],
+        "description": _planner_contract_text(),
         "notes": "Decomposition rationale: split due to dependency sequencing.",
+        "acceptance_criteria": "Done when the executable path is actionable.",
     }
     child = {"id": "at-epic.1", "labels": [], "description": "LOC estimate: 260"}
 
@@ -80,7 +100,8 @@ def test_evaluate_guardrails_flags_large_changeset_without_approval() -> None:
     child = {
         "id": "at-epic.1",
         "labels": [],
-        "description": "LOC estimate: 920\nGuardrails: data migration",
+        "description": _planner_contract_text() + "\nLOC estimate: 920\nGuardrails: data migration",
+        "acceptance_criteria": "Done when the large migration scope is fully documented.",
     }
 
     report = module._evaluate_guardrails(
@@ -94,7 +115,12 @@ def test_evaluate_guardrails_flags_large_changeset_without_approval() -> None:
 
 def test_evaluate_guardrails_reports_multi_unit_decomposition() -> None:
     module = _load_script_module()
-    epic = {"id": "at-epic", "labels": ["at:epic"]}
+    epic = {
+        "id": "at-epic",
+        "labels": ["at:epic"],
+        "description": _planner_contract_text(),
+        "acceptance_criteria": "Done when each child changeset is actionable.",
+    }
     children = [
         {"id": "at-epic.1", "labels": [], "description": "LOC estimate: 220"},
         {"id": "at-epic.2", "labels": [], "description": "LOC estimate: 240"},
@@ -110,13 +136,61 @@ def test_evaluate_guardrails_reports_multi_unit_decomposition() -> None:
     assert report.violations == []
 
 
+def test_evaluate_guardrails_flags_missing_authoring_contract_fields() -> None:
+    module = _load_script_module()
+    epic = {
+        "id": "at-epic",
+        "labels": ["at:epic"],
+        "description": (
+            "intent: Raise planner bead quality.\n"
+            "rationale: Workers need better context.\n"
+            "non_goals: Do not change promotion UX.\n"
+            "constraints: Keep the change reviewable."
+        ),
+        "acceptance_criteria": "Done when missing context is caught before promotion.",
+    }
+    child = {"id": "at-epic.1", "labels": [], "description": "LOC estimate: 180"}
+
+    report = module._evaluate_guardrails(
+        epic_issue=epic,
+        child_changesets=[child],
+        target_changesets=[child],
+    )
+
+    assert any(
+        "missing planner authoring contract fields (edge_cases, related_context)" in item
+        for item in report.violations
+    )
+
+
+def test_evaluate_guardrails_flags_missing_done_definition() -> None:
+    module = _load_script_module()
+    child = {
+        "id": "at-epic.1",
+        "labels": [],
+        "description": _planner_contract_text() + "\nLOC estimate: 180",
+    }
+
+    report = module._evaluate_guardrails(
+        epic_issue=None,
+        child_changesets=[],
+        target_changesets=[child],
+    )
+
+    assert any("missing explicit done definition" in item for item in report.violations)
+
+
 def test_evaluate_guardrails_flags_cross_cutting_guardrail_gaps() -> None:
     module = _load_script_module()
     epic = {
         "id": "at-epic",
         "labels": ["at:epic"],
         "title": "Fix lifecycle invariant regression",
-        "description": ("Concern domains: lifecycle state machine and external provider sync."),
+        "description": (
+            _planner_contract_text()
+            + "\nConcern domains: lifecycle state machine and external provider sync."
+        ),
+        "acceptance_criteria": "Done when lifecycle fixes are fully reviewable.",
     }
     children = [
         {"id": "at-epic.1", "labels": [], "description": "LOC estimate: 230"},
@@ -144,6 +218,7 @@ def test_evaluate_guardrails_flags_cross_cutting_single_changeset_decomposition_
         "labels": ["at:epic"],
         "title": "Fix lifecycle invariant regression",
         "notes": (
+            _planner_contract_text() + "\n"
             "Decomposition rationale: split due to dependency sequencing.\n"
             "Invariant impact map:\n"
             "- mutation entry points\n"
@@ -154,6 +229,7 @@ def test_evaluate_guardrails_flags_cross_cutting_single_changeset_decomposition_
             "Review feedback: scope expansion during review is captured immediately."
         ),
         "description": ("Concern domains: lifecycle state machine and external provider sync."),
+        "acceptance_criteria": "Done when lifecycle fixes are fully reviewable.",
     }
     child = {"id": "at-epic.1", "labels": [], "description": "LOC estimate: 300"}
 
@@ -173,6 +249,7 @@ def test_evaluate_guardrails_accepts_cross_cutting_guardrails_when_complete() ->
         "labels": ["at:epic"],
         "title": "Fix lifecycle invariant regression",
         "notes": (
+            _planner_contract_text() + "\n"
             "Invariant impact map:\n"
             "- mutation entry points\n"
             "- recovery paths\n"
@@ -183,6 +260,7 @@ def test_evaluate_guardrails_accepts_cross_cutting_guardrails_when_complete() ->
             "Planner action: create deferred follow-on changeset or stack extension.\n"
             "Review feedback: scope expansion during review is captured immediately."
         ),
+        "acceptance_criteria": "Done when lifecycle fixes are fully reviewable.",
     }
     children = [
         {"id": "at-epic.1", "labels": [], "description": "LOC estimate: 230"},
@@ -205,6 +283,7 @@ def test_evaluate_guardrails_detects_numeric_threshold_trigger_without_phrase() 
         "labels": ["at:epic"],
         "title": "Fix lifecycle invariant regression",
         "notes": (
+            _planner_contract_text() + "\n"
             "Invariant impact map:\n"
             "- mutation entry points\n"
             "- recovery paths\n"
@@ -214,6 +293,7 @@ def test_evaluate_guardrails_detects_numeric_threshold_trigger_without_phrase() 
             "Planner action: create deferred follow-on changeset or stack extension.\n"
             "Review feedback: scope expansion during review is captured immediately."
         ),
+        "acceptance_criteria": "Done when lifecycle fixes are fully reviewable.",
     }
     children = [
         {"id": "at-epic.1", "labels": [], "description": "LOC estimate: 230"},

--- a/tests/atelier/test_planner_agents_template.py
+++ b/tests/atelier/test_planner_agents_template.py
@@ -28,6 +28,11 @@ def test_planner_agents_template_contains_core_sections() -> None:
     assert "Do not claim or keep assignee ownership" in content
     assert "Planner owns operator decision handling" in content
     assert "Do not dispatch cleanup-only beads as worker executable work." in content
+    assert "intent, rationale, non-goals, constraints, edge" in content
+    assert "related-context links" in content
+    assert "done definition" in content
+    assert "`related_context:`" in content
+    assert "`done_definition:`" in content
     assert "concrete issue, create or update a deferred bead immediately" in content
     assert "Create or update deferred beads immediately" in content
     assert "Capture first, then ask only for decisions" in content

--- a/tests/atelier/test_skills.py
+++ b/tests/atelier/test_skills.py
@@ -262,6 +262,8 @@ def test_plan_changesets_skill_requires_rationale_for_one_child_split() -> None:
     assert "one child changeset" in text
     assert "decomposition rationale" in text
     assert "Default new changesets to `status=deferred`" in text
+    assert "edge_cases" in text
+    assert "related_context" in text
 
 
 def test_plan_changeset_guardrails_skill_mentions_checker_script() -> None:
@@ -270,6 +272,8 @@ def test_plan_changeset_guardrails_skill_mentions_checker_script() -> None:
     assert "scripts/check_guardrails.py" in text
     assert "one child changeset" in text
     assert "decomposition rationale" in text
+    assert "done definition" in text
+    assert "related_context" in text
 
 
 def test_plan_promote_epic_skill_requires_one_child_rationale() -> None:
@@ -284,6 +288,8 @@ def test_plan_create_epic_skill_captures_drafts_without_approval() -> None:
     text = skill.files["SKILL.md"].decode("utf-8")
     assert "capture it as a deferred epic immediately" in text
     assert "not request approval to create or edit deferred beads." in text
+    assert "edge_cases" in text
+    assert "done_definition" in text
 
 
 def test_planner_startup_check_skill_captures_drafts_without_approval() -> None:


### PR DESCRIPTION
# Summary

- enforce a reusable planner authoring contract for executable work paths so
  workers get explicit intent, rationale, constraints, edge cases, related
  context, and done definitions
- surface actionable guardrail violations when those sections are missing

# Changes

- add `planner_contract.py` and integrate it into changeset guardrail checks
- tighten one-child decomposition rationale detection so general
  `rationale:` fields do not satisfy split rationale requirements
- update planner templates, skills, and bead conventions to document the
  required context fields
- extend tests for inherited epic context, missing contract fields, and
  missing done-definition failures

# Testing

- `just format`
- `UV_PYTHON=3.11 env -u VIRTUAL_ENV just test`
- `UV_PYTHON=3.11 env -u VIRTUAL_ENV just lint`

# Tickets

- Fixes #556

# Risks / Rollout

- Planner workflows that rely on sparse bead descriptions will now receive
  additional guardrail violations until the explicit context fields are added.

# Notes

- The repo's default shell environment resolves `uv run` to Python 3.14; the
  required gates pass under the repo's intended Python 3.11 runtime.
