### PR TITLE
Require north-star self-review in worker sessions

### DIFF
--- a/src/atelier/agent_home.py
+++ b/src/atelier/agent_home.py
@@ -40,6 +40,14 @@ _WORKER_SAFE_PRIME_ADDENDUM = "\n".join(
         "## Worker Runtime Context",
         "",
         "- The assigned epic/changeset bead is the only execution scope.",
+        "- Before any commit/push/publish attempt, run a north-star self-review "
+        "against the assigned bead acceptance criteria.",
+        "- Append a `north_star_review.<timestamp>:` note to the changeset bead "
+        "before first push with `unmet_acceptance_criteria`, "
+        "`required_code_changes_per_criterion`, `implementation_summary`, and "
+        "`completion_checklist` commit/file evidence.",
+        "- Do not treat comment closure alone as completion; finish only when "
+        "the full bead goal is implemented or send `NEEDS-DECISION`.",
         "- Keep `pr_state` accurate: `pushed`, `draft-pr`, `pr-open`, "
         "`in-review`, `approved`, `merged`, `closed`.",
         "- Do not set `status=closed` while PR lifecycle is active "
@@ -47,6 +55,8 @@ _WORKER_SAFE_PRIME_ADDENDUM = "\n".join(
         "- Set `status=closed` only when terminal proof exists:",
         "  - PR lifecycle is terminal (`pr_state=merged` or `pr_state=closed`), or",
         "  - non-PR integration proof exists (`changeset.integrated_sha`).",
+        "- Do not commit/push/publish while unmet acceptance criteria remain or "
+        "the completion checklist is incomplete.",
         "- Do not run backlog/planning workflows from worker sessions "
         "(`bd ready`, `bd create`, `bd dep add`, `bd close` for unrelated work).",
     )

--- a/src/atelier/templates/AGENTS.worker.md.tmpl
+++ b/src/atelier/templates/AGENTS.worker.md.tmpl
@@ -79,6 +79,23 @@ Skills link: ./skills
      occurs.
    - Update the bead as complete and exit.
 
+## North-Star Review Loop
+
+1. After reading the seeded epic and changeset beads, extract every acceptance
+   criterion and non-goal into a working checklist.
+2. Before any commit/push/publish attempt, run a north-star self-review against
+   the assigned bead contract.
+3. Append a `north_star_review.<timestamp>:` note to the changeset bead before
+   first push. The note must include:
+   - `unmet_acceptance_criteria` (explicit list or `none`)
+   - `required_code_changes_per_criterion`
+   - `implementation_summary`
+   - `completion_checklist` with commit/file evidence for every criterion
+4. Do not treat comment closure alone as completion. Keep working until the
+   full bead goal is implemented, or send `NEEDS-DECISION` and stop.
+5. Do not commit/push/publish while any acceptance criterion remains unmet or
+   the completion checklist is incomplete.
+
 ## Lifecycle Protocol (Required)
 
 - Use canonical lifecycle statuses only:

--- a/src/atelier/worker/prompts.py
+++ b/src/atelier/worker/prompts.py
@@ -28,8 +28,22 @@ def worker_opening_prompt(
         f"Epic: {epic_id}",
         f"Changeset: {summary}",
         (
+            "Before any commit/push/publish attempt, run a north-star "
+            "self-review against the assigned bead acceptance criteria."
+        ),
+        (
+            "Append a `north_star_review.<timestamp>:` note to the changeset "
+            "bead before first push with unmet_acceptance_criteria, "
+            "required_code_changes_per_criterion, implementation_summary, "
+            "and a completion_checklist citing commit/file evidence."
+        ),
+        (
             "Role boundary: implement only committable changeset artifacts "
             "(code/config/docs/tests) for the assigned changeset."
+        ),
+        (
+            "Do not treat comment closure alone as completion; finish only "
+            "when the full bead goal is implemented or send NEEDS-DECISION."
         ),
         (
             "Do not promote, clean up, or otherwise mutate sibling/unclaimed "
@@ -48,6 +62,10 @@ def worker_opening_prompt(
             "(`pushed`,`draft-pr`,`pr-open`,`in-review`,`approved`). "
             "Close only when PR is terminal (`merged`/`closed`) or non-PR "
             "integration proof exists (`changeset.integrated_sha`)."
+        ),
+        (
+            "Do not commit/push/publish while unmet acceptance criteria "
+            "remain or the completion checklist is incomplete."
         ),
         (
             "When done, update beads status/metadata for this changeset and required "

--- a/tests/atelier/test_agent_home.py
+++ b/tests/atelier/test_agent_home.py
@@ -429,6 +429,9 @@ def test_apply_beads_prime_addendum_worker_role_replaces_generic_prime_guidance(
     assert "bd close at-123" not in updated
     assert "SESSION CLOSE PROTOCOL" not in updated
     assert "assigned epic/changeset bead is the only execution scope" in updated
+    assert "run a north-star self-review" in updated
+    assert "north_star_review.<timestamp>" in updated
+    assert "Do not treat comment closure alone as completion" in updated
 
 
 def test_apply_beads_prime_addendum_planner_role_keeps_addendum_body() -> None:

--- a/tests/atelier/test_worker_agents_template.py
+++ b/tests/atelier/test_worker_agents_template.py
@@ -14,12 +14,15 @@ def test_worker_agents_template_contains_core_sections() -> None:
     content = template_path.read_text(encoding="utf-8")
     assert "Single-Bead Contract" in content
     assert "Execution Workflow" in content
+    assert "North-Star Review Loop" in content
     assert "Messaging Rules" in content
     assert "Finish" in content
     assert "Do not look for more" in content
     assert "Update changeset status and metadata." in content
     assert "committable artifacts (code/config/docs/tests)" in content
     assert "Do not mutate sibling/unclaimed work-bead lifecycle state." in content
+    assert "north_star_review.<timestamp>" in content
+    assert "Do not treat comment closure alone as completion." in content
     assert "Update changeset metadata and labels." not in content
     assert "do not set `status=closed`" in content
     assert "Set `status=closed` only when terminal proof exists" in content

--- a/tests/atelier/worker/test_prompts.py
+++ b/tests/atelier/worker/test_prompts.py
@@ -15,9 +15,13 @@ def test_worker_opening_prompt_uses_status_metadata_wording() -> None:
     assert "update beads status/metadata for this changeset" in prompt
     assert "update beads state/labels for this changeset" not in prompt
     assert "implement only committable changeset artifacts" in prompt
+    assert "run a north-star self-review" in prompt
+    assert "north_star_review.<timestamp>" in prompt
+    assert "Do not treat comment closure alone as completion" in prompt
     assert "planner owns non-commit orchestration" in prompt
     assert "Do not set status=closed while PR lifecycle is active" in prompt
     assert "Close only when PR is terminal (`merged`/`closed`)" in prompt
+    assert "Do not commit/push/publish while unmet acceptance criteria remain" in prompt
 
 
 def test_worker_opening_prompt_review_feedback_avoids_label_reset_guidance() -> None:


### PR DESCRIPTION
# Summary

- Require worker sessions to run and record a north-star self-review before claiming readiness.

# Changes

- add the north-star review loop to the worker opening prompt, generated worker AGENTS template, and worker-safe runtime addendum
- require a structured `north_star_review.<timestamp>` bead note with unmet criteria, required code changes, implementation summary, and completion evidence
- make the worker contract explicit that comment closure alone is not completion and that commit/push/publish must stop on unmet criteria or incomplete checklists
- extend prompt and template regression coverage for the new session contract

# Testing

- `env -u PYTHONPATH -u VIRTUAL_ENV just format`
- `env -u PYTHONPATH -u VIRTUAL_ENV just lint`
- `env -u PYTHONPATH -u VIRTUAL_ENV just test`

## Tickets
- Fixes #552

# Risks / Rollout

- This changes worker guidance only; the hard publish gate for checklist enforcement lands in the follow-on changeset.

# Notes

- The authoritative `north_star_review` bead note was recorded before the first push for this branch.
