### PR TITLE
Show full epic and child details during promotion

### DIFF
--- a/src/atelier/skills/plan-promote-epic/SKILL.md
+++ b/src/atelier/skills/plan-promote-epic/SKILL.md
@@ -21,6 +21,12 @@ description: >-
     changesets).
 - Changeset guardrails have been validated (run `plan-changeset-guardrails`
   first).
+- Promotion preview shows the full epic contract plus the full child changeset
+  contract(s) in deterministic order.
+- The preview includes description, notes, acceptance criteria, dependencies,
+  and related-context references for the epic and each child.
+- Missing required detail sections are surfaced explicitly before any
+  confirmation prompt.
 - Do not require child changesets when the epic itself is guardrail-sized.
 - If the epic has exactly one child changeset, explicit decomposition rationale
   must be recorded before promotion.
@@ -29,6 +35,17 @@ description: >-
 
 1. Show the epic and verify its status is `deferred`.
 1. List child changesets and confirm which are fully defined.
+1. Render the promotion preview in deterministic order:
+   - epic first, then child changesets sorted by bead id.
+   - For the epic and for each child, show:
+     - description
+     - notes
+     - acceptance criteria
+     - dependencies
+     - related-context references
+   - If any required section is absent or placeholder-only, print
+     `Missing detail sections: ...` for that epic/child before asking the user
+     anything.
 1. If there are no child changesets and the epic is single-changeset sized:
    - Keep execution state in status only (`deferred` now, `open` on promotion).
    - The epic is a changeset by graph inference (leaf in its own hierarchy).
@@ -38,9 +55,10 @@ description: >-
      rationale before promotion.
 1. If the epic is not single-changeset sized, create only the minimum child
    changesets needed for execution and reviewability.
-1. Summarize the executable unit(s) for the user (child changesets or the epic
-   itself).
-1. Ask for explicit confirmation to promote.
+1. Summarize the executable unit(s) for the user only after the full preview is
+   shown (child changesets or the epic itself).
+1. Ask for explicit confirmation to promote only after the full preview and any
+   missing-detail warnings are visible.
 1. On approval, set epic status to `open`.
 1. Promote each fully-defined child changeset from `deferred` to `open`
    regardless of current dependency blockers (dependency graph still gates
@@ -49,6 +67,10 @@ description: >-
 
 ## Verification
 
+- Confirmation prompt was preceded by the full epic and child detail preview.
+- Preview ordering is deterministic: epic first, then children by bead id.
+- Missing detail sections are shown explicitly instead of being skipped
+  silently.
 - Epic status is `open`.
 - If the epic has child changesets, all fully-defined children are status
   `open`.

--- a/src/atelier/templates/AGENTS.planner.md.tmpl
+++ b/src/atelier/templates/AGENTS.planner.md.tmpl
@@ -33,7 +33,9 @@ Capture first, then ask only for decisions that are actually required.
 
 **Exception:** Promotion of an epic from `deferred` to `open` requires explicit
 user approval. When you believe a deferred epic is ready for workers, ask the
-user to confirm promotion before changing its status.
+user to confirm promotion before changing its status. Before you ask, render the
+full epic contract and full child changeset contract details, and call out any
+missing sections explicitly.
 
 ## Theory of Operation: The Planning Engine
 
@@ -139,6 +141,12 @@ If code changes are needed, create beads and leave implementation to workers.
 5. Promotion:
 - When an epic is fully planned, use `plan-promote-epic` and request explicit
   approval before moving from `deferred` to `open`.
+- During promotion confirmation, show the epic first and then each child
+  changeset in deterministic order.
+- Include description, notes, acceptance criteria, dependencies, and
+  related-context references for the epic and each child.
+- If any required detail section is missing, show that gap explicitly instead of
+  silently proceeding.
 
 ## Bead Quality Standard
 

--- a/tests/atelier/test_planner_agents_template.py
+++ b/tests/atelier/test_planner_agents_template.py
@@ -25,6 +25,11 @@ def test_planner_agents_template_contains_core_sections() -> None:
     assert "epic-list" in content
     assert "one child changeset" in content
     assert "decomposition rationale" in content
+    assert "full epic contract and full child changeset contract details" in content
+    assert "deterministic order" in content
+    assert "dependencies, and" in content
+    assert "related-context references" in content
+    assert "show that gap explicitly" in content
     assert "Do not claim or keep assignee ownership" in content
     assert "Planner owns operator decision handling" in content
     assert "Do not dispatch cleanup-only beads as worker executable work." in content

--- a/tests/atelier/test_skills.py
+++ b/tests/atelier/test_skills.py
@@ -281,6 +281,10 @@ def test_plan_promote_epic_skill_requires_one_child_rationale() -> None:
     text = skill.files["SKILL.md"].decode("utf-8")
     assert "exactly one child changeset" in text
     assert "decomposition rationale" in text
+    assert "deterministic order" in text
+    assert "description, notes, acceptance criteria, dependencies," in text
+    assert "related-context references" in text
+    assert "Missing detail sections:" in text
 
 
 def test_plan_create_epic_skill_captures_drafts_without_approval() -> None:


### PR DESCRIPTION
# Summary

- Show the full epic and child promotion contract before an operator confirms promotion.

# Changes

- Require `plan-promote-epic` to render epic and child details in deterministic order before confirmation.
- Require explicit `Missing detail sections:` warnings when promotion context is absent or placeholder-only.
- Update the packaged planner template and assertions so the promotion-preview contract stays aligned.

# Testing

- `env -u VIRTUAL_ENV -u PYTHONPATH -u VIRTUAL_ENV_PROMPT UV_PYTHON=3.11 just format`
- `env -u VIRTUAL_ENV -u PYTHONPATH -u VIRTUAL_ENV_PROMPT UV_PYTHON=3.11 just lint`
- `env -u VIRTUAL_ENV -u PYTHONPATH -u VIRTUAL_ENV_PROMPT UV_PYTHON=3.11 just test`

## Tickets
- Fixes #557

# Risks / Rollout

- This only changes packaged planner guidance and its regression coverage.

# Notes

- None.
