### PR TITLE
Document planner clarification loop before promotion

### DIFF
--- a/src/atelier/skills/beads/references/beads-conventions.md
+++ b/src/atelier/skills/beads/references/beads-conventions.md
@@ -60,6 +60,22 @@ For executable work, the worker-facing path should cover intent, rationale,
 non-goals, constraints, edge cases, related context, and a done definition using
 description, notes, design, and acceptance fields together.
 
+Write concrete fields, not placeholders. Useful patterns:
+
+- Motivation capture:
+  `rationale: Split the promotion renderer from the planner template update so review stays scoped and operator-facing guidance can ship independently.`
+- Negative scope:
+  `non_goals: Do not change worker finalization or publish sequencing in this changeset.`
+- Related-bead linking:
+  `related_context: at-surch (worker north-star review contract), at-ohj2 (formal review mode design), GH-555 (operator-facing planning request).`
+- Acceptance criterion wording:
+  `Done when the promotion preview shows description, notes, acceptance criteria, dependencies, and related-context references for the epic and every child changeset.`
+- Clarification-loop wording:
+  `edge_cases: Confirm with the operator whether deferred children stay out of scope, which ambiguity must be resolved before promotion, and which failure paths need explicit notes.`
+
+If a field is intentionally empty, say so explicitly rather than using a
+placeholder. For example: `related_context: none identified.`
+
 Agent hook storage:
 
 - Store the active hook in the agent bead slot

--- a/src/atelier/skills/plan-promote-epic/SKILL.md
+++ b/src/atelier/skills/plan-promote-epic/SKILL.md
@@ -27,6 +27,9 @@ description: >-
   and related-context references for the epic and each child.
 - Missing required detail sections are surfaced explicitly before any
   confirmation prompt.
+- Any remaining ambiguity has an explicit clarification loop with the operator
+  before promotion. That loop must cover unclear scope boundaries, edge cases,
+  explicit non-goals ("what not to do"), and missing related-context links.
 - Do not require child changesets when the epic itself is guardrail-sized.
 - If the epic has exactly one child changeset, explicit decomposition rationale
   must be recorded before promotion.
@@ -46,6 +49,15 @@ description: >-
    - If any required section is absent or placeholder-only, print
      `Missing detail sections: ...` for that epic/child before asking the user
      anything.
+1. If the preview still leaves ambiguity, stop before any promotion prompt and
+   run a clarification loop with the operator:
+   - Ask which behavior or scope boundary must stay out of scope.
+   - Ask which edge cases or failure modes must be represented before workers
+     start.
+   - Ask which related beads/documents provide essential context.
+   - Record the answers on the epic or child changeset before continuing.
+   - Do not ask for confirmation while the executable path still reads as
+     ambiguous.
 1. If there are no child changesets and the epic is single-changeset sized:
    - Keep execution state in status only (`deferred` now, `open` on promotion).
    - The epic is a changeset by graph inference (leaf in its own hierarchy).
@@ -71,9 +83,22 @@ description: >-
 - Preview ordering is deterministic: epic first, then children by bead id.
 - Missing detail sections are shown explicitly instead of being skipped
   silently.
+- Clarification questions are asked and captured before promotion whenever scope
+  or negative scope is still ambiguous.
 - Epic status is `open`.
 - If the epic has child changesets, all fully-defined children are status
   `open`.
 - If the epic has no child changesets, the epic is the executable leaf work unit
   (changeset by graph inference) and status `open`.
 - Any one-child decomposition has explicit rationale in notes/description.
+
+## Example clarification prompt
+
+Before promotion I still need the following clarified in the bead:
+
+- What must this epic explicitly not change?
+- Which edge cases should workers preserve or test?
+- Which related beads or design docs explain the broader context?
+
+Only ask for promotion after those answers are written into the previewed epic
+or child changesets.

--- a/src/atelier/templates/AGENTS.planner.md.tmpl
+++ b/src/atelier/templates/AGENTS.planner.md.tmpl
@@ -147,6 +147,12 @@ If code changes are needed, create beads and leave implementation to workers.
   related-context references for the epic and each child.
 - If any required detail section is missing, show that gap explicitly instead of
   silently proceeding.
+- If previewed scope is still ambiguous, run an explicit operator clarification
+  loop before promotion: ask about edge cases, record explicit non-goals ("what
+  not to do"), and capture any missing related-context references on the bead
+  before you ask for confirmation.
+- Do not ask for promotion while ambiguity remains. Resolve it in the bead or
+  capture the operator's explicit decision about the remaining uncertainty.
 
 ## Bead Quality Standard
 
@@ -165,6 +171,18 @@ Use explicit key/value fields where possible, for example:
 - `edge_cases:`
 - `related_context:`
 - `done_definition:` (or detailed acceptance criteria)
+
+Use concrete wording instead of placeholders. Examples:
+- `rationale: Split promotion-preview docs from renderer changes so review stays
+  focused and the operator contract is explicit.`
+- `non_goals: Do not change worker publish/finalize behavior in this slice.`
+- `related_context: at-surch (worker north-star gate), at-ohj2 (formal review
+  mode design).`
+- `done_definition: Done when promotion preview shows all required sections and
+  planner docs explain how to close ambiguity before promotion.`
+- Acceptance criterion example: `Done when the planner records explicit
+  non-goals, edge cases, and related beads before asking the operator to
+  promote.`
 
 Both an agent and a developer should be able to implement from beads alone.
 
@@ -186,6 +204,7 @@ Both an agent and a developer should be able to implement from beads alone.
 
 - Waiting for approval before writing drafts.
 - Leaving ambiguity unstated.
+- Asking for promotion before ambiguity, non-goals, and edge cases are recorded.
 - Creating changesets without guardrails.
 - Promoting an epic without explicit approval.
 

--- a/tests/atelier/test_planner_agents_template.py
+++ b/tests/atelier/test_planner_agents_template.py
@@ -30,6 +30,9 @@ def test_planner_agents_template_contains_core_sections() -> None:
     assert "dependencies, and" in content
     assert "related-context references" in content
     assert "show that gap explicitly" in content
+    assert "operator clarification" in content
+    assert 'non-goals ("what' in content
+    assert "Do not ask for promotion while ambiguity remains." in content
     assert "Do not claim or keep assignee ownership" in content
     assert "Planner owns operator decision handling" in content
     assert "Do not dispatch cleanup-only beads as worker executable work." in content
@@ -38,6 +41,8 @@ def test_planner_agents_template_contains_core_sections() -> None:
     assert "done definition" in content
     assert "`related_context:`" in content
     assert "`done_definition:`" in content
+    assert "Use concrete wording instead of placeholders." in content
+    assert "Acceptance criterion example:" in content
     assert "concrete issue, create or update a deferred bead immediately" in content
     assert "Create or update deferred beads immediately" in content
     assert "Capture first, then ask only for decisions" in content

--- a/tests/atelier/test_skills.py
+++ b/tests/atelier/test_skills.py
@@ -285,6 +285,10 @@ def test_plan_promote_epic_skill_requires_one_child_rationale() -> None:
     assert "description, notes, acceptance criteria, dependencies," in text
     assert "related-context references" in text
     assert "Missing detail sections:" in text
+    assert "clarification loop with the operator" in text
+    assert 'explicit non-goals ("what not to do")' in text
+    assert "Do not ask for confirmation while the executable path still reads as" in text
+    assert "Example clarification prompt" in text
 
 
 def test_plan_create_epic_skill_captures_drafts_without_approval() -> None:
@@ -294,6 +298,27 @@ def test_plan_create_epic_skill_captures_drafts_without_approval() -> None:
     assert "not request approval to create or edit deferred beads." in text
     assert "edge_cases" in text
     assert "done_definition" in text
+
+
+def test_beads_conventions_reference_includes_concrete_authoring_examples() -> None:
+    reference_path = (
+        Path(__file__).resolve().parents[2]
+        / "src"
+        / "atelier"
+        / "skills"
+        / "beads"
+        / "references"
+        / "beads-conventions.md"
+    )
+    text = reference_path.read_text(encoding="utf-8")
+
+    assert "Write concrete fields, not placeholders." in text
+    assert "Motivation capture:" in text
+    assert "Negative scope:" in text
+    assert "Related-bead linking:" in text
+    assert "Acceptance criterion wording:" in text
+    assert "Clarification-loop wording:" in text
+    assert "related_context: none identified." in text
 
 
 def test_planner_startup_check_skill_captures_drafts_without_approval() -> None:


### PR DESCRIPTION
# Summary

- Document how planners must resolve ambiguity, edge cases, and negative scope before asking an operator to promote an epic.

# Changes

- Require the packaged planner template and `plan-promote-epic` skill to run an explicit clarification loop before promotion when scope is still ambiguous.
- Add concrete examples for motivation capture, acceptance-criterion wording, and related-bead linking in the Beads conventions reference.
- Extend planner and packaged-skill tests so the promotion-preview detail contract and clarification guidance stay pinned.

# Testing

- `pytest -q tests/atelier/test_planner_agents_template.py tests/atelier/test_skills.py`
- `just format`
- `just lint`
- `env -u PYTHONPATH -u VIRTUAL_ENV just test`

## Tickets
- Fixes #558

# Risks / Rollout

- This changes only packaged documentation/templates and regression coverage.

# Notes

- None.
