### PR TITLE
Require bead-first review before PR feedback handling

### DIFF
--- a/src/atelier/agent_home.py
+++ b/src/atelier/agent_home.py
@@ -48,6 +48,12 @@ _WORKER_SAFE_PRIME_ADDENDUM = "\n".join(
         "`completion_checklist` commit/file evidence.",
         "- Do not treat comment closure alone as completion; finish only when "
         "the full bead goal is implemented or send `NEEDS-DECISION`.",
+        "- For PR feedback runs, re-read the seeded epic and changeset beads "
+        "first. Confirm scope, non-goals, acceptance criteria, and done "
+        "definition before fetching or addressing PR comments.",
+        "- After that bead-first review, handle inline review comments in "
+        "their existing threads and resolve the same thread; do not replace "
+        "inline replies with new top-level PR comments.",
         "- Keep `pr_state` accurate: `pushed`, `draft-pr`, `pr-open`, "
         "`in-review`, `approved`, `merged`, `closed`.",
         "- Do not set `status=closed` while PR lifecycle is active "

--- a/src/atelier/templates/AGENTS.worker.md.tmpl
+++ b/src/atelier/templates/AGENTS.worker.md.tmpl
@@ -96,6 +96,18 @@ Skills link: ./skills
 5. Do not commit/push/publish while any acceptance criterion remains unmet or
    the completion checklist is incomplete.
 
+## PR Feedback Runs
+
+1. In review-feedback mode, re-read the seeded epic and changeset beads first.
+   Confirm scope, non-goals, acceptance criteria, and done definition before
+   fetching or addressing PR comments.
+2. After the bead-first review, fetch open PR feedback and address it without
+   narrowing the goal to comment closure alone.
+3. For inline review comments, reply inline and resolve the same thread; do not
+   post a new top-level PR comment in place of an inline reply.
+4. Use the `github-prs` skill scripts (`list_review_threads.py`,
+   `reply_inline_thread.py`) for deterministic inline handling.
+
 ## Lifecycle Protocol (Required)
 
 - Use canonical lifecycle statuses only:
@@ -109,10 +121,6 @@ Skills link: ./skills
 - Set `status=closed` only when terminal proof exists:
   - PR lifecycle is terminal (`pr_state=merged` or `pr_state=closed`), OR
   - non-PR integration is proven (`changeset.integrated_sha` recorded).
-- For PR feedback runs, inline review comments must be answered inline and then
-  resolved; do not post a new top-level PR comment in place of an inline reply.
-  Use the `github-prs` skill scripts (`list_review_threads.py`,
-  `reply_inline_thread.py`) for deterministic thread handling.
 
 ## Messaging Rules
 

--- a/src/atelier/worker/prompts.py
+++ b/src/atelier/worker/prompts.py
@@ -98,8 +98,15 @@ def worker_opening_prompt(
                 "",
                 "Priority mode: review-feedback",
                 (
-                    "This run is for PR feedback resolution. First fetch open PR "
-                    "feedback comments and address them directly."
+                    "This run is for PR feedback resolution. Before fetching or "
+                    "addressing PR comments, re-read the seeded epic and "
+                    "changeset beads and confirm scope, non-goals, acceptance "
+                    "criteria, and done definition."
+                ),
+                (
+                    "After that bead-first review, fetch open PR feedback "
+                    "comments and address them directly without narrowing the "
+                    "goal to comment closure alone."
                 ),
                 (
                     "For inline review comments, reply inline to each comment and "

--- a/tests/atelier/test_agent_home.py
+++ b/tests/atelier/test_agent_home.py
@@ -432,6 +432,14 @@ def test_apply_beads_prime_addendum_worker_role_replaces_generic_prime_guidance(
     assert "run a north-star self-review" in updated
     assert "north_star_review.<timestamp>" in updated
     assert "Do not treat comment closure alone as completion" in updated
+    bead_review = "For PR feedback runs, re-read the seeded epic and changeset beads first."
+    fetch_feedback = (
+        "After that bead-first review, handle inline review comments in their existing "
+        "threads and resolve the same thread"
+    )
+    assert bead_review in updated
+    assert fetch_feedback in updated
+    assert updated.index(bead_review) < updated.index(fetch_feedback)
 
 
 def test_apply_beads_prime_addendum_planner_role_keeps_addendum_body() -> None:

--- a/tests/atelier/test_worker_agents_template.py
+++ b/tests/atelier/test_worker_agents_template.py
@@ -15,6 +15,7 @@ def test_worker_agents_template_contains_core_sections() -> None:
     assert "Single-Bead Contract" in content
     assert "Execution Workflow" in content
     assert "North-Star Review Loop" in content
+    assert "PR Feedback Runs" in content
     assert "Messaging Rules" in content
     assert "Finish" in content
     assert "Do not look for more" in content
@@ -23,6 +24,11 @@ def test_worker_agents_template_contains_core_sections() -> None:
     assert "Do not mutate sibling/unclaimed work-bead lifecycle state." in content
     assert "north_star_review.<timestamp>" in content
     assert "Do not treat comment closure alone as completion." in content
+    bead_review = "In review-feedback mode, re-read the seeded epic and changeset beads first."
+    fetch_feedback = "After the bead-first review, fetch open PR feedback and address it"
+    assert bead_review in content
+    assert fetch_feedback in content
+    assert content.index(bead_review) < content.index(fetch_feedback)
     assert "Update changeset metadata and labels." not in content
     assert "do not set `status=closed`" in content
     assert "Set `status=closed` only when terminal proof exists" in content

--- a/tests/atelier/worker/test_prompts.py
+++ b/tests/atelier/worker/test_prompts.py
@@ -37,6 +37,18 @@ def test_worker_opening_prompt_review_feedback_avoids_label_reset_guidance() -> 
     assert (
         "Do not mark this changeset complete while review feedback remains unaddressed." in prompt
     )
+    bead_review = (
+        "Before fetching or addressing PR comments, re-read the seeded epic and "
+        "changeset beads and confirm scope, non-goals, acceptance criteria, and "
+        "done definition."
+    )
+    fetch_feedback = (
+        "After that bead-first review, fetch open PR feedback comments and address "
+        "them directly without narrowing the goal to comment closure alone."
+    )
+    assert bead_review in prompt
+    assert fetch_feedback in prompt
+    assert prompt.index(bead_review) < prompt.index(fetch_feedback)
     assert "Do not create local pr-* branches for temporary PR inspection." in prompt
     assert "refs/atelier/review/* refs and clean them up after use." in prompt
     assert (


### PR DESCRIPTION
# Summary

- Require review-feedback runs to re-read the seeded epic and changeset bead before fetching or addressing PR comments.

# Changes

- update the worker opening prompt so bead review explicitly precedes PR feedback handling
- add a `PR Feedback Runs` section to the worker AGENTS template and align the worker-safe runtime addendum on the same ordering
- add regression assertions for prompt, template, and runtime addendum ordering while preserving full-goal completion language

# Testing

- `env -u PYTHONPATH UV_PYTHON=3.11 just format`
- `env -u PYTHONPATH UV_PYTHON=3.11 just lint`
- `env -u PYTHONPATH UV_PYTHON=3.11 just test`

## Tickets
- Fixes #563

# Risks / Rollout

- This is a guidance-only change for worker review-feedback runs; it does not change publish-gate enforcement logic in this slice.

# Notes

- The branch was rebased onto `main` before publish because the parent worker-contract PR had already merged.
- The authoritative `north_star_review` bead note was refreshed after the rebase and before the first push.
