### PR TITLE
Add north-star gate regression tests and runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ atelier doctor --fix --format=json
 Operator triage + rollback runbook and convergence harness:
 
 - [docs/beads-prefix-migration.md](docs/beads-prefix-migration.md)
+- [docs/north-star-review-gate.md](docs/north-star-review-gate.md)
 
 List workspaces:
 

--- a/docs/north-star-review-gate.md
+++ b/docs/north-star-review-gate.md
@@ -1,0 +1,83 @@
+# North-Star Review Gate
+
+Use this runbook when a worker changeset is ready to commit, push, or publish.
+The worker must prove that the assigned bead's acceptance criteria are fully
+implemented before any outbound change is allowed.
+
+## Required Artifact
+
+Before the first push, append a note to the changeset bead with this shape:
+
+```text
+north_star_review.<timestamp>:
+1) unmet_acceptance_criteria: none
+2) required_code_changes_per_criterion:
+- AC1: <required code change>
+- AC2: <required code change>
+3) implementation_summary:
+- <what changed to satisfy the criteria>
+4) completion_checklist:
+- AC1 satisfied by commit <sha>; files: path/to/file.py.
+- AC2 satisfied by verification: <result>; files: path/to/test_file.py.
+```
+
+Rules:
+
+- `unmet_acceptance_criteria` must be `none` before publish.
+- Every acceptance criterion in the bead must appear in
+  `required_code_changes_per_criterion`.
+- Every acceptance criterion in the bead must appear in `completion_checklist`.
+- Each checklist line must include evidence such as a commit SHA, a file path,
+  or an explicit verification record.
+- If multiple north-star notes exist, the latest `authoritative: true` block
+  wins. Otherwise the latest block wins.
+
+## Worker Flow
+
+1. Read the epic and assigned changeset bead.
+1. Copy every acceptance criterion and non-goal into a working checklist.
+1. Implement the code, tests, docs, or config required by the changeset.
+1. Before any commit, push, or publish attempt, append the
+   `north_star_review.<timestamp>:` note.
+1. Confirm the note says `unmet_acceptance_criteria: none`.
+1. Confirm each criterion has both:
+   - a required-code-change entry
+   - a completion-checklist entry with commit/file evidence
+1. Rerun finalize or publish only after the bead note is complete.
+
+If the gate blocks publish, the worker should expect a blocked reason of
+`north-star review checklist incomplete` plus an audit note beginning with
+`publish_blocked: north-star review gate failed`.
+
+## Planner Audit
+
+Use this checklist before accepting worker completion:
+
+1. Open the changeset bead with `bd show <changeset-id>`.
+1. Find the active `north_star_review.<timestamp>:` block.
+1. Verify all four sections exist:
+   - `unmet_acceptance_criteria`
+   - `required_code_changes_per_criterion`
+   - `implementation_summary`
+   - `completion_checklist`
+1. Verify `unmet_acceptance_criteria` is `none`.
+1. Count the bead acceptance criteria and confirm the note maps each one.
+1. Confirm every checklist entry cites concrete evidence:
+   - commit SHA
+   - file path
+   - explicit verification result
+1. If any mapping or evidence is missing, keep the changeset blocked and send
+   the worker back to repair the note before another publish attempt.
+
+## Migration Notes
+
+This gate applies immediately to in-flight worker sessions.
+
+- If a session started before the prompt/template rollout but has not pushed
+  yet, append the north-star note before the first push.
+- If a session is already blocked by the publish gate, repair the bead note and
+  rerun finalize. Do not clear the block with comments alone.
+- If a branch was pushed before the rollout and no terminal PR/integration proof
+  exists yet, add the north-star note before the next publish or PR update.
+- Planner review should treat missing or partial north-star notes as a failed
+  handoff, not a best-effort warning.

--- a/tests/atelier/worker/test_finalize_pipeline.py
+++ b/tests/atelier/worker/test_finalize_pipeline.py
@@ -1449,6 +1449,72 @@ def test_run_finalize_pipeline_blocks_pr_creation_without_north_star_review(
     assert blocked == ["north-star review checklist incomplete"]
 
 
+def test_run_finalize_pipeline_blocks_push_when_required_mapping_omits_criterion(
+    monkeypatch,
+) -> None:
+    issue = {
+        "id": "at-epic.1",
+        "status": "in_progress",
+        "labels": [],
+        "description": "changeset.work_branch: feat/root-at-epic.1\n",
+        "acceptance_criteria": "1) First criterion.\n2) Second criterion.\n",
+        "notes": (
+            "north_star_review.2026-03-07T12:30:00Z:\n"
+            "1) unmet_acceptance_criteria: none\n"
+            "2) required_code_changes_per_criterion:\n"
+            "- AC1: add the publish gate.\n"
+            "3) implementation_summary:\n"
+            "- Added the publish gate and tests.\n"
+            "4) completion_checklist:\n"
+            "- AC1 satisfied by commit abc1234; "
+            "files: src/atelier/worker/finalize_publish_gate.py.\n"
+            "- AC2 satisfied by commit abc1234; "
+            "files: tests/atelier/worker/test_finalize_pipeline.py.\n"
+        ),
+    }
+    monkeypatch.setattr(
+        finalize_pipeline.beads,
+        "run_bd_json",
+        lambda *_args, **_kwargs: [issue],
+    )
+    monkeypatch.setattr(
+        finalize_pipeline.git,
+        "git_ref_exists",
+        lambda *_args, **_kwargs: False,
+    )
+
+    audit_notes: list[str] = []
+    monkeypatch.setattr(
+        finalize_pipeline.beads,
+        "run_bd_command",
+        lambda args, **_kwargs: audit_notes.append(" ".join(args)),
+    )
+
+    service = _FinalizeServiceStub()
+    blocked: list[str] = []
+    notifications: list[str] = []
+    service.mark_changeset_blocked_fn = lambda _changeset_id, *, reason: blocked.append(reason)
+    service.send_planner_notification_fn = lambda **kwargs: notifications.append(
+        str(kwargs.get("body"))
+    )
+    service.attempt_push_work_branch_fn = lambda _work_branch: (_ for _ in ()).throw(
+        AssertionError("push must not run when criterion mapping is incomplete")
+    )
+
+    result = finalize_pipeline.run_finalize_pipeline(
+        context=_pipeline_context(),
+        service=service,
+    )
+
+    assert result.reason == "changeset_blocked_north_star_review"
+    assert result.continue_running is False
+    assert blocked == ["north-star review checklist incomplete"]
+    assert any(
+        "required_code_changes_per_criterion" in body and "AC2" in body for body in notifications
+    )
+    assert any("publish_blocked: north-star review gate failed" in note for note in audit_notes)
+
+
 def test_run_finalize_pipeline_finalizes_integrated_pushed_changeset_without_pr_gate(
     monkeypatch,
 ) -> None:

--- a/tests/atelier/worker/test_finalize_publish_gate.py
+++ b/tests/atelier/worker/test_finalize_publish_gate.py
@@ -75,3 +75,28 @@ def test_validate_north_star_review_gate_rejects_unmet_and_incomplete_checklist(
     assert any("unmet_acceptance_criteria" in line for line in result.diagnostics)
     assert any("required_code_changes_per_criterion" in line for line in result.diagnostics)
     assert any("completion_checklist" in line and "AC2" in line for line in result.diagnostics)
+
+
+def test_validate_north_star_review_gate_rejects_missing_checklist_evidence() -> None:
+    issue = {
+        "acceptance_criteria": "1) First criterion.\n2) Second criterion.\n",
+        "notes": (
+            "north_star_review.2026-03-07T13:00:00Z:\n"
+            "1) unmet_acceptance_criteria: none\n"
+            "2) required_code_changes_per_criterion:\n"
+            "- AC1: add publish gating before outbound push.\n"
+            "- AC2: surface explicit operator diagnostics.\n"
+            "3) implementation_summary:\n"
+            "- Added the publish gate and warning path.\n"
+            "4) completion_checklist:\n"
+            "- AC1 satisfied by commit abc1234; "
+            "files: src/atelier/worker/finalize_publish_gate.py.\n"
+            "- AC2 satisfied after planner audit.\n"
+        ),
+    }
+
+    result = validate_north_star_review_gate(issue)
+
+    assert result.ok is False
+    assert result.artifact_name == "north_star_review.2026-03-07T13:00:00Z"
+    assert any("missing evidence tokens for AC2" in line for line in result.diagnostics)


### PR DESCRIPTION
# Summary

- Add regression coverage and operator documentation for the north-star review publish gate.

# Changes

- Add publish-gate regression coverage for missing checklist evidence tokens.
- Add finalize-pipeline regression coverage for incomplete criterion mapping blocking outbound push.
- Add an operator runbook that documents the artifact format, planner audit flow, and migration steps for in-flight worker sessions.
- Link the runbook from the repository README.

# Testing

- `env -u PYTHONPATH -u VIRTUAL_ENV UV_PYTHON=3.11 just format`
- `env -u PYTHONPATH -u VIRTUAL_ENV UV_PYTHON=3.11 just lint`
- `env -u PYTHONPATH -u VIRTUAL_ENV UV_PYTHON=3.11 just test`

# Tickets

- Fixes #554

# Risks / Rollout

- Worker sessions that started before the gate rollout now need the north-star artifact before their first push; the new runbook documents the repair path.

# Notes

- The branch was rebased onto current `main` after the parent changeset merged so the review diff stays limited to this tests-and-docs slice.
