### PR TITLE
Reclaim stale epic assignees on claim-time conflicts

### DIFF
--- a/src/atelier/worker/selection.py
+++ b/src/atelier/worker/selection.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import datetime as dt
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Literal
 
 from .. import agent_home, beads, lifecycle
 from .models_boundary import parse_issue_boundary
@@ -25,6 +26,36 @@ class EpicAssigneeReclaimEvaluation:
     assignee: str | None
     reclaimable: bool
     detail: str
+
+
+@dataclass(frozen=True)
+class AgentHookObservation:
+    """Describe whether an assignee hook lookup succeeded.
+
+    Args:
+        hook: Hooked epic id when explicitly known.
+        state: Whether the lookup found a hook, confirmed no hook, or failed.
+        detail: Stable diagnostic detail for unknown/error states.
+    """
+
+    hook: str | None
+    state: Literal["present", "absent", "unknown"]
+    detail: str | None = None
+
+    @classmethod
+    def present(cls, hook: str) -> AgentHookObservation:
+        """Return an observation for a confirmed hook value."""
+        return cls(hook=hook, state="present")
+
+    @classmethod
+    def absent(cls) -> AgentHookObservation:
+        """Return an observation for a confirmed missing hook."""
+        return cls(hook=None, state="absent")
+
+    @classmethod
+    def unknown(cls, detail: str) -> AgentHookObservation:
+        """Return an observation for an indeterminate hook lookup."""
+        return cls(hook=None, state="unknown", detail=detail)
 
 
 def _normalized_text(value: object) -> str | None:
@@ -61,12 +92,23 @@ def _agent_heartbeat_at(agent_issue: dict[str, object] | None) -> str | None:
     return heartbeat_at if isinstance(heartbeat_at, str) else None
 
 
+def _hook_observation(
+    value: AgentHookObservation | str | None,
+) -> AgentHookObservation:
+    if isinstance(value, AgentHookObservation):
+        return value
+    hook = _normalized_text(value)
+    if hook is not None:
+        return AgentHookObservation.present(hook)
+    return AgentHookObservation.absent()
+
+
 def evaluate_epic_assignee_reclaimability(
     issue: dict[str, object],
     *,
     is_session_active: Callable[[str], bool],
     find_agent_issue: Callable[[str], dict[str, object] | None] | None = None,
-    get_agent_hook: Callable[[dict[str, object]], str | None] | None = None,
+    get_agent_hook: Callable[[dict[str, object]], AgentHookObservation | str | None] | None = None,
     now: dt.datetime | None = None,
     stale_heartbeat_delta: dt.timedelta | None = None,
 ) -> EpicAssigneeReclaimEvaluation:
@@ -81,8 +123,8 @@ def evaluate_epic_assignee_reclaimability(
         issue: Epic payload being evaluated.
         is_session_active: Callback that validates PID-backed session liveness.
         find_agent_issue: Optional callback returning the assignee agent bead.
-        get_agent_hook: Optional callback returning the hooked epic id for an
-            assignee agent bead.
+        get_agent_hook: Optional callback returning either the hooked epic id or
+            an explicit hook lookup observation for an assignee agent bead.
         now: Optional timestamp override for deterministic tests.
         stale_heartbeat_delta: Optional heartbeat staleness window.
 
@@ -141,18 +183,25 @@ def evaluate_epic_assignee_reclaimability(
             detail=f"{session_detail}({assignee})",
         )
 
-    hook = _normalized_text(get_agent_hook(agent_issue))
-    if epic_id is not None and hook == epic_id:
+    hook_observation = _hook_observation(get_agent_hook(agent_issue))
+    if hook_observation.state == "unknown":
+        return EpicAssigneeReclaimEvaluation(
+            assignee=assignee,
+            reclaimable=False,
+            detail=hook_observation.detail or f"hook_lookup_failed({assignee})",
+        )
+
+    if epic_id is not None and hook_observation.hook == epic_id:
         return EpicAssigneeReclaimEvaluation(
             assignee=assignee,
             reclaimable=False,
             detail=f"active_hook({assignee})",
         )
-    if hook is not None:
+    if hook_observation.hook is not None:
         return EpicAssigneeReclaimEvaluation(
             assignee=assignee,
             reclaimable=True,
-            detail=f"hooked_elsewhere({assignee}->{hook})",
+            detail=f"hooked_elsewhere({assignee}->{hook_observation.hook})",
         )
     return EpicAssigneeReclaimEvaluation(
         assignee=assignee,
@@ -311,7 +360,7 @@ def stale_family_assigned_epics(
     agent_id: str,
     is_session_active: Callable[[str], bool],
     find_agent_issue: Callable[[str], dict[str, object] | None] | None = None,
-    get_agent_hook: Callable[[dict[str, object]], str | None] | None = None,
+    get_agent_hook: Callable[[dict[str, object]], AgentHookObservation | str | None] | None = None,
     now: dt.datetime | None = None,
     stale_heartbeat_delta: dt.timedelta | None = None,
 ) -> list[dict[str, object]]:

--- a/src/atelier/worker/session/runner.py
+++ b/src/atelier/worker/session/runner.py
@@ -129,31 +129,36 @@ def _agent_hook_for_issue(
     agent_issue: dict[str, object],
     beads_root: Path,
     repo_root: Path,
-) -> str | None:
+) -> worker_selection.AgentHookObservation:
     agent_bead_id = _normalized_text(agent_issue.get("id"))
     if agent_bead_id is None:
-        return None
+        return worker_selection.AgentHookObservation.unknown("agent_bead_id_missing")
     result = beads.run_bd_command(
         ["slot", "show", agent_bead_id, "--json"],
         beads_root=beads_root,
         cwd=repo_root,
         allow_failure=True,
     )
-    if result.returncode == 0:
-        raw = result.stdout.strip() if result.stdout else ""
-        if raw:
-            try:
-                payload = json.loads(raw)
-            except json.JSONDecodeError:
-                payload = None
-            hook = _extract_hook_from_slot_payload(payload)
-            if hook:
-                return hook
+    if result.returncode != 0:
+        return worker_selection.AgentHookObservation.unknown("hook_lookup_failed")
+    raw = result.stdout.strip() if result.stdout else ""
+    if not raw:
+        return worker_selection.AgentHookObservation.unknown("hook_payload_missing")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return worker_selection.AgentHookObservation.unknown("hook_payload_invalid")
+    hook = _extract_hook_from_slot_payload(payload)
+    if hook:
+        return worker_selection.AgentHookObservation.present(hook)
     description = agent_issue.get("description")
     fields = beads_runtime.parse_description_fields(
         description if isinstance(description, str) else ""
     )
-    return _normalized_text(fields.get("hook_bead"))
+    fallback_hook = _normalized_text(fields.get("hook_bead"))
+    if fallback_hook is not None:
+        return worker_selection.AgentHookObservation.present(fallback_hook)
+    return worker_selection.AgentHookObservation.absent()
 
 
 def _classify_claim_failure(

--- a/src/atelier/worker/work_startup_runtime.py
+++ b/src/atelier/worker/work_startup_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import json
 from collections.abc import Callable
 from pathlib import Path
 
@@ -37,6 +38,36 @@ MergeConflictSelection = worker_review.MergeConflictSelection
 GlobalStartupSelections = worker_review.GlobalStartupSelections
 
 _WORKER_QUEUE_NAME = "worker"
+
+
+def _normalized_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def _extract_hook_from_slot_payload(payload: object) -> str | None:
+    if isinstance(payload, str):
+        return _normalized_text(payload)
+    if isinstance(payload, list):
+        for item in payload:
+            hook = _extract_hook_from_slot_payload(item)
+            if hook:
+                return hook
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if "hook" in payload:
+        return _extract_hook_from_slot_payload(payload.get("hook"))
+    slots = payload.get("slots")
+    if isinstance(slots, dict):
+        return _extract_hook_from_slot_payload(slots.get("hook"))
+    for key in ("id", "issue_id", "bead_id", "bead"):
+        value = _normalized_text(payload.get(key))
+        if value:
+            return value
+    return None
 
 
 def startup_finalize_preflight(
@@ -863,18 +894,42 @@ class _StartupContractService(worker_startup.StartupContractService):
                 cwd=self._repo_root,
             )
 
-        def get_agent_hook(agent_issue: dict[str, object]) -> str | None:
-            agent_bead_id = str(agent_issue.get("id") or "").strip()
-            if not agent_bead_id:
-                return None
+        def get_agent_hook(
+            agent_issue: dict[str, object],
+        ) -> worker_selection.AgentHookObservation:
+            agent_bead_id = _normalized_text(agent_issue.get("id"))
+            if agent_bead_id is None:
+                return worker_selection.AgentHookObservation.unknown("agent_bead_id_missing")
+
+            result = beads.run_bd_command(
+                ["slot", "show", agent_bead_id, "--json"],
+                beads_root=self._beads_root,
+                cwd=self._repo_root,
+                allow_failure=True,
+            )
+            if result.returncode != 0:
+                return worker_selection.AgentHookObservation.unknown("hook_lookup_failed")
+
+            raw = result.stdout.strip() if result.stdout else ""
+            if not raw:
+                return worker_selection.AgentHookObservation.unknown("hook_payload_missing")
             try:
-                return beads.get_agent_hook(
-                    agent_bead_id,
-                    beads_root=self._beads_root,
-                    cwd=self._repo_root,
-                )
-            except SystemExit:
-                return None
+                payload = json.loads(raw)
+            except json.JSONDecodeError:
+                return worker_selection.AgentHookObservation.unknown("hook_payload_invalid")
+
+            hook = _extract_hook_from_slot_payload(payload)
+            if hook is not None:
+                return worker_selection.AgentHookObservation.present(hook)
+
+            description = agent_issue.get("description")
+            fields = beads.parse_description_fields(
+                description if isinstance(description, str) else ""
+            )
+            fallback_hook = _normalized_text(fields.get("hook_bead"))
+            if fallback_hook is not None:
+                return worker_selection.AgentHookObservation.present(fallback_hook)
+            return worker_selection.AgentHookObservation.absent()
 
         return worker_selection.stale_family_assigned_epics(
             issues,

--- a/tests/atelier/worker/test_runtime.py
+++ b/tests/atelier/worker/test_runtime.py
@@ -1,3 +1,4 @@
+import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
@@ -853,3 +854,42 @@ def test_startup_service_reports_planner_owned_executable_violations() -> None:
     assert any(
         "Ownership-policy blockers may prevent review-feedback pickup." in line for line in emitted
     )
+
+
+def test_startup_service_preserves_live_worker_when_hook_lookup_fails() -> None:
+    issue = {
+        "id": "at-hook-error",
+        "status": "in_progress",
+        "labels": ["at:epic"],
+        "assignee": "atelier/worker/codex/p222",
+    }
+    service = work_startup_runtime._StartupContractService(  # pyright: ignore[reportPrivateUsage]
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    with (
+        patch(
+            "atelier.worker.work_startup_runtime.agent_home.is_session_agent_active",
+            return_value=True,
+        ),
+        patch(
+            "atelier.worker.work_startup_runtime.beads.find_agent_bead",
+            return_value={"id": "at-agent-live"},
+        ),
+        patch(
+            "atelier.worker.work_startup_runtime.beads.run_bd_command",
+            return_value=subprocess.CompletedProcess(
+                args=["slot", "show", "at-agent-live", "--json"],
+                returncode=1,
+                stdout="",
+                stderr="slot read failed",
+            ),
+        ),
+    ):
+        stale = service.stale_family_assigned_epics(
+            [issue],
+            agent_id="atelier/worker/codex/p999",
+        )
+
+    assert stale == []

--- a/tests/atelier/worker/test_selection.py
+++ b/tests/atelier/worker/test_selection.py
@@ -278,6 +278,28 @@ def test_stale_family_assigned_epics_reclaims_live_worker_when_hook_missing() ->
     assert [item["id"] for item in stale] == ["at-unhooked"]
 
 
+def test_stale_family_assigned_epics_preserves_live_worker_when_hook_lookup_fails() -> None:
+    issue = {
+        "id": "at-hook-error",
+        "status": "in_progress",
+        "labels": ["at:epic"],
+        "assignee": "atelier/worker/codex/p222",
+        "created_at": "2026-02-20T00:00:00+00:00",
+    }
+
+    stale = selection.stale_family_assigned_epics(
+        [issue],
+        agent_id="atelier/worker/codex/p999",
+        is_session_active=lambda _assignee: True,
+        find_agent_issue=lambda _assignee: {"id": "at-agent-live"},
+        get_agent_hook=lambda _agent_issue: selection.AgentHookObservation.unknown(
+            "hook_lookup_failed"
+        ),
+    )
+
+    assert stale == []
+
+
 def test_stale_family_assigned_epics_preserves_live_worker_with_matching_hook() -> None:
     issue = {
         "id": "at-active-hook",

--- a/tests/atelier/worker/test_session_runner_flow.py
+++ b/tests/atelier/worker/test_session_runner_flow.py
@@ -731,6 +731,39 @@ def test_run_worker_once_retries_claim_as_stale_reclaim_after_claim_time_conflic
     )
 
 
+def test_classify_claim_failure_fails_closed_when_hook_lookup_fails() -> None:
+    stale_assignee = "atelier/worker/codex/p777"
+    beads = SimpleNamespace(
+        run_bd_json=Mock(return_value=[{"id": "at-conflict", "assignee": stale_assignee}]),
+        find_agent_bead=Mock(return_value={"id": "at-stale-agent"}),
+        run_bd_command=Mock(
+            return_value=subprocess.CompletedProcess(
+                args=["slot", "show", "at-stale-agent", "--json"],
+                returncode=1,
+                stdout="",
+                stderr="slot read failed",
+            )
+        ),
+    )
+
+    with patch(
+        "atelier.worker.session.runner.agent_home.is_session_agent_active",
+        return_value=True,
+    ):
+        failure = runner._classify_claim_failure(  # pyright: ignore[reportPrivateUsage]
+            beads=beads,
+            epic_id="at-conflict",
+            agent_id="atelier/worker/codex/p3c",
+            allow_takeover_from=None,
+            beads_root=Path("/project/.atelier/.beads"),
+            repo_root=Path("/repo"),
+        )
+
+    assert failure.kind == "assignee_conflict"
+    assert failure.assignee == stale_assignee
+    assert failure.detail == "hook_lookup_failed"
+
+
 def test_run_worker_once_reclaims_stale_explicit_assignment_and_clears_old_hook() -> None:
     agent = AgentHome(
         name="worker",


### PR DESCRIPTION
# Summary

- reclaim startup-selected epics when claim-time assignee conflicts expose a dead or inactive worker
- use heartbeat and hook evidence, not only PID liveness, when deciding whether a foreign worker assignment is reclaimable

# Changes

- added a shared stale-assignee reclaim evaluator in the worker selection path
- wired startup reclaim scanning to inspect agent-bead heartbeat and live hook ownership
- retried claim-time assignee conflicts as safe takeovers when the current assignee is stale or unhooked
- added regressions for stale heartbeat, missing hook, active matching hook, and claim-time reclaim retry

# Testing

- `just lint`
- `just test`

## Tickets
- Fixes #588

# Risks / Rollout

- low risk, scoped to worker startup and claim fallback behavior
- active worker ownership is preserved by rejecting planner-owned epics and workers that still hold the matching hook

# Notes

- the changeset remains `in_progress` because this project uses draft PR flow
