### PR TITLE
Restart workers at idle boundaries after runtime updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,8 @@ atelier work --mode auto
 atelier work --select first-eligible
 atelier work --run-mode once
 atelier work --run-mode watch
+atelier work --run-mode watch --no-restart-on-update
+atelier work --run-mode default --restart-on-update
 atelier work --run-mode watch --watch-interval 30
 atelier work --reconcile
 ```
@@ -525,6 +527,8 @@ Options:
 - `--select`: Startup selector policy (`first-eligible` or `oldest-feedback`).
   Defaults to `worker.select` in config, then `oldest-feedback`.
 - `--run-mode`: Worker loop mode (`once`, `default`, or `watch`).
+- `--restart-on-update`: Self-reexec at idle boundaries after runtime changes.
+  Defaults to on in `watch` mode and off in other run modes.
 - `--yes`: Accept defaults for interactive choices (`ATELIER_WORK_YES`).
 - `--reconcile`: Run a fail-closed reconcile sweep before startup selection.
   This auto-finalizes orphaned `in_progress` changesets only when PR lifecycle

--- a/src/atelier/cli.py
+++ b/src/atelier/cli.py
@@ -626,6 +626,20 @@ def work_command(
             click_type=_choice(_RUN_MODE_CHOICES),
         ),
     ] = None,
+    restart_on_update: Annotated[
+        bool,
+        typer.Option(
+            "--restart-on-update",
+            help="restart workers at idle boundaries after runtime updates",
+        ),
+    ] = False,
+    no_restart_on_update: Annotated[
+        bool,
+        typer.Option(
+            "--no-restart-on-update",
+            help="disable idle-boundary restart even when watch mode would enable it",
+        ),
+    ] = False,
     watch_interval: Annotated[
         int | None,
         typer.Option(
@@ -671,12 +685,20 @@ def work_command(
     ] = False,
 ) -> None:
     """Start a worker session."""
+    if restart_on_update and no_restart_on_update:
+        raise typer.BadParameter("cannot use both --restart-on-update and --no-restart-on-update")
+    resolved_restart_on_update: bool | None = None
+    if restart_on_update:
+        resolved_restart_on_update = True
+    elif no_restart_on_update:
+        resolved_restart_on_update = False
     work_cmd.start_worker(
         SimpleNamespace(
             epic_id=epic_id,
             mode=mode,
             select=select,
             run_mode=run_mode,
+            restart_on_update=resolved_restart_on_update,
             watch_interval=watch_interval,
             queue=queue,
             dry_run=dry_run,

--- a/src/atelier/commands/work.py
+++ b/src/atelier/commands/work.py
@@ -62,6 +62,13 @@ def start_worker(args: object) -> None:
     setattr(args, "startup_runtime", worker_restart_runtime.capture_worker_startup_runtime())
     mode = normalize_mode(getattr(args, "mode", None))
     run_mode = normalize_run_mode(getattr(args, "run_mode", None))
+    explicit_restart_on_update = getattr(args, "restart_on_update", None)
+    restart_on_update = (
+        bool(explicit_restart_on_update)
+        if explicit_restart_on_update is not None
+        else run_mode == "watch"
+    )
+    setattr(args, "restart_on_update", restart_on_update)
     watch_interval = watch_interval_seconds(getattr(args, "watch_interval", None))
     dry_run = bool(getattr(args, "dry_run", False))
     session_key = agent_home.generate_session_key()

--- a/src/atelier/worker/restart_runtime.py
+++ b/src/atelier/worker/restart_runtime.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import os
 import sys
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
@@ -137,6 +137,31 @@ class WorkerStartupRuntime:
         """
         current = self.capture_current_fingerprint(version=version, package_root=package_root)
         return current.changed_from(self.startup_fingerprint)
+
+
+def relaunch_worker_process(
+    startup_runtime: WorkerStartupRuntime,
+    *,
+    chdir_fn: Callable[[Path], None] = os.chdir,
+    execvpe_fn: Callable[[str, list[str], dict[str, str]], None] = os.execvpe,
+) -> None:
+    """Re-exec the current worker using its preserved launch contract.
+
+    Args:
+        startup_runtime: Startup snapshot containing the relaunch contract.
+        chdir_fn: Injectable working-directory changer for tests.
+        execvpe_fn: Injectable exec function for tests.
+
+    Returns:
+        This function does not return on successful ``execvpe``.
+    """
+    contract = startup_runtime.relaunch_contract
+    chdir_fn(contract.cwd)
+    execvpe_fn(
+        contract.exec_target(),
+        list(contract.exec_argv()),
+        contract.exec_env(),
+    )
 
 
 def capture_worker_startup_runtime(

--- a/src/atelier/worker/runtime.py
+++ b/src/atelier/worker/runtime.py
@@ -16,6 +16,7 @@ from .. import root_branch as root_branch_module
 from ..config import ProjectConfig
 from ..models import BranchHistory, BranchPrMode, BranchSquashMessage
 from ..work_feedback import ReviewFeedbackSnapshot
+from . import restart_runtime as worker_restart_runtime
 from . import work_command_helpers as worker_work
 from .models import (
     FinalizeResult,
@@ -72,6 +73,23 @@ class ImplicitContinuationDecision:
     should_continue: bool
     reason: str
     epic_id: str | None = None
+
+
+def _restart_runtime_if_updated(args: object, *, emit: Callable[[str], None]) -> None:
+    """Re-exec the worker at an idle boundary when startup runtime changed."""
+    if not bool(getattr(args, "restart_on_update", False)):
+        return
+    startup_runtime = getattr(args, "startup_runtime", None)
+    if startup_runtime is None or not startup_runtime.runtime_changed():
+        return
+    emit("Runtime update detected; restarting worker before the next idle check.")
+    try:
+        worker_restart_runtime.relaunch_worker_process(startup_runtime)
+    except OSError as exc:
+        emit(
+            "Runtime update detected but restart failed; continuing with the current "
+            f"runtime ({type(exc).__name__}: {exc})."
+        )
 
 
 def classify_non_watch_exit_outcome(
@@ -598,6 +616,7 @@ def run_worker_sessions(
         iteration_args = build_iteration_args()
         summary = run_worker_once(iteration_args, mode=mode, dry_run=False, session_key=session_key)
         report_worker_summary(summary, False)
+        _restart_runtime_if_updated(args, emit=emit)
         if summary.started:
             if run_mode == "once":
                 return

--- a/tests/atelier/commands/test_cli_constrained_options.py
+++ b/tests/atelier/commands/test_cli_constrained_options.py
@@ -37,6 +37,8 @@ def test_work_help_shows_mode_select_and_run_mode_choices() -> None:
     assert "oldest-feedback" in clean_output
     assert "--run-mode" in clean_output
     assert "[once|default|watch]" in clean_output
+    assert "--restart-on-update" in clean_output
+    assert "--no-restart-on-update" in clean_output
 
 
 def test_global_help_shows_log_level_choices() -> None:
@@ -70,6 +72,7 @@ def test_choice_flags_accept_case_insensitive_and_underscore_aliases() -> None:
         work_capture["mode"] = args.mode
         work_capture["select"] = args.select
         work_capture["run_mode"] = args.run_mode
+        work_capture["restart_on_update"] = args.restart_on_update
 
     runner = CliRunner()
     with (
@@ -87,6 +90,7 @@ def test_choice_flags_accept_case_insensitive_and_underscore_aliases() -> None:
                 "oldest_feedback",
                 "--run-mode",
                 "ONCE",
+                "--restart-on-update",
             ],
             color=False,
         )
@@ -99,6 +103,7 @@ def test_choice_flags_accept_case_insensitive_and_underscore_aliases() -> None:
         "mode": "auto",
         "select": "oldest-feedback",
         "run_mode": "once",
+        "restart_on_update": True,
     }
 
 

--- a/tests/atelier/commands/test_work.py
+++ b/tests/atelier/commands/test_work.py
@@ -148,6 +148,7 @@ def test_start_worker_applies_env_translated_yes_default(
     assert kwargs["mode"] == "prompt"
     assert kwargs["run_mode"] == "default"
     assert kwargs["args"].yes is True
+    assert kwargs["args"].restart_on_update is False
 
 
 def test_start_worker_cli_values_override_env_defaults(
@@ -164,6 +165,55 @@ def test_start_worker_cli_values_override_env_defaults(
     assert kwargs["mode"] == "auto"
     assert kwargs["run_mode"] == "watch"
     assert kwargs["args"].yes is True
+    assert kwargs["args"].restart_on_update is True
+
+
+def test_start_worker_watch_mode_defaults_restart_on_update() -> None:
+    args = SimpleNamespace(
+        epic_id=None,
+        mode="auto",
+        run_mode="watch",
+        dry_run=True,
+        yes=False,
+        restart_on_update=None,
+    )
+
+    with patch("atelier.commands.work.worker_runtime.run_worker_sessions") as run_sessions:
+        work_cmd.start_worker(args)
+
+    assert run_sessions.call_args.kwargs["args"].restart_on_update is True
+
+
+def test_start_worker_watch_mode_allows_restart_opt_out() -> None:
+    args = SimpleNamespace(
+        epic_id=None,
+        mode="auto",
+        run_mode="watch",
+        dry_run=True,
+        yes=False,
+        restart_on_update=False,
+    )
+
+    with patch("atelier.commands.work.worker_runtime.run_worker_sessions") as run_sessions:
+        work_cmd.start_worker(args)
+
+    assert run_sessions.call_args.kwargs["args"].restart_on_update is False
+
+
+def test_start_worker_default_mode_requires_restart_opt_in() -> None:
+    args = SimpleNamespace(
+        epic_id=None,
+        mode="auto",
+        run_mode="default",
+        dry_run=True,
+        yes=False,
+        restart_on_update=True,
+    )
+
+    with patch("atelier.commands.work.worker_runtime.run_worker_sessions") as run_sessions:
+        work_cmd.start_worker(args)
+
+    assert run_sessions.call_args.kwargs["args"].restart_on_update is True
 
 
 def test_start_worker_invalid_mode_exits() -> None:

--- a/tests/atelier/commands/test_work_cli.py
+++ b/tests/atelier/commands/test_work_cli.py
@@ -14,6 +14,7 @@ def test_work_passes_yolo_flag_to_command() -> None:
         captured["mode"] = args.mode
         captured["select"] = args.select
         captured["run_mode"] = args.run_mode
+        captured["restart_on_update"] = args.restart_on_update
         captured["yes"] = args.yes
         captured["reconcile"] = args.reconcile
         captured["yolo"] = args.yolo
@@ -31,6 +32,7 @@ def test_work_passes_yolo_flag_to_command() -> None:
                 "first-eligible",
                 "--run-mode",
                 "once",
+                "--restart-on-update",
                 "--yes",
                 "--reconcile",
                 "--yolo",
@@ -43,6 +45,7 @@ def test_work_passes_yolo_flag_to_command() -> None:
         "mode": "auto",
         "select": "first-eligible",
         "run_mode": "once",
+        "restart_on_update": True,
         "yes": True,
         "reconcile": True,
         "yolo": True,

--- a/tests/atelier/worker/test_restart_runtime.py
+++ b/tests/atelier/worker/test_restart_runtime.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 
+import pytest
+
 from atelier.worker import restart_runtime
 
 
@@ -76,3 +78,42 @@ def test_capture_worker_startup_runtime_detects_package_tree_updates(
     os.utime(module_path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
 
     assert startup.runtime_changed(version="1.2.3", package_root=package_root) is True
+
+
+def test_relaunch_worker_process_uses_preserved_contract(tmp_path: Path) -> None:
+    startup = restart_runtime.capture_worker_startup_runtime(
+        argv=("atelier", "work", "--restart-on-update"),
+        orig_argv=("/venv/bin/python", "-m", "atelier.cli", "work", "--restart-on-update"),
+        env={"PATH": "/venv/bin:/usr/bin", "ATELIER_AGENT_ID": "atelier/worker/codex/p1"},
+        cwd=tmp_path,
+        executable="/venv/bin/python",
+        version="1.2.3",
+        package_root=tmp_path,
+    )
+    captured: dict[str, object] = {}
+
+    def fake_chdir(path: Path) -> None:
+        captured["cwd"] = path
+
+    def fake_execvpe(target: str, argv: list[str], env: dict[str, str]) -> None:
+        captured["target"] = target
+        captured["argv"] = argv
+        captured["env"] = env
+        raise RuntimeError("reexec")
+
+    with pytest.raises(RuntimeError, match="reexec"):
+        restart_runtime.relaunch_worker_process(
+            startup,
+            chdir_fn=fake_chdir,
+            execvpe_fn=fake_execvpe,
+        )
+
+    assert captured == {
+        "cwd": tmp_path,
+        "target": "/venv/bin/python",
+        "argv": ["/venv/bin/python", "-m", "atelier.cli", "work", "--restart-on-update"],
+        "env": {
+            "ATELIER_AGENT_ID": "atelier/worker/codex/p1",
+            "PATH": "/venv/bin:/usr/bin",
+        },
+    }

--- a/tests/atelier/worker/test_runtime.py
+++ b/tests/atelier/worker/test_runtime.py
@@ -516,6 +516,192 @@ def test_run_worker_sessions_watch_logs_and_sleeps_on_no_ready() -> None:
     assert emitted == ["No ready work; watching for updates (sleeping 9s)."]
 
 
+def test_run_worker_sessions_watch_reexecs_before_sleep_when_update_detected() -> None:
+    calls = 0
+    emitted: list[str] = []
+    slept: list[float] = []
+    startup_runtime = type("StartupRuntime", (), {"runtime_changed": lambda self: True})()
+
+    def run_once(args: object, *, mode: str, dry_run: bool, session_key: str) -> WorkerRunSummary:
+        del args, mode, dry_run, session_key
+        nonlocal calls
+        calls += 1
+        return WorkerRunSummary(started=False, reason="no_ready_changesets")
+
+    with pytest.raises(RuntimeError, match="reexec"):
+        with patch(
+            "atelier.worker.runtime.worker_restart_runtime.relaunch_worker_process",
+            side_effect=RuntimeError("reexec"),
+        ) as relaunch:
+            runtime.run_worker_sessions(
+                args=type(
+                    "Args",
+                    (),
+                    {
+                        "queue": False,
+                        "startup_runtime": startup_runtime,
+                        "restart_on_update": True,
+                    },
+                )(),
+                mode="auto",
+                run_mode="watch",
+                dry_run=False,
+                session_key="sess",
+                run_worker_once=run_once,
+                report_worker_summary=lambda _summary, _dry: None,
+                watch_interval_seconds=lambda: 9,
+                dry_run_log=lambda _message: None,
+                emit=emitted.append,
+                sleep_fn=lambda seconds: slept.append(seconds),
+            )
+
+    assert calls == 1
+    assert slept == []
+    assert emitted == ["Runtime update detected; restarting worker before the next idle check."]
+    relaunch.assert_called_once_with(startup_runtime)
+
+
+def test_run_worker_sessions_default_mode_reexecs_only_when_opted_in() -> None:
+    calls = 0
+    emitted: list[str] = []
+    startup_runtime = type("StartupRuntime", (), {"runtime_changed": lambda self: True})()
+
+    def run_once(args: object, *, mode: str, dry_run: bool, session_key: str) -> WorkerRunSummary:
+        del args, mode, dry_run, session_key
+        nonlocal calls
+        calls += 1
+        return WorkerRunSummary(started=True, reason="agent_session_complete")
+
+    with pytest.raises(RuntimeError, match="reexec"):
+        with patch(
+            "atelier.worker.runtime.worker_restart_runtime.relaunch_worker_process",
+            side_effect=RuntimeError("reexec"),
+        ) as relaunch:
+            runtime.run_worker_sessions(
+                args=type(
+                    "Args",
+                    (),
+                    {
+                        "queue": False,
+                        "startup_runtime": startup_runtime,
+                        "restart_on_update": True,
+                    },
+                )(),
+                mode="auto",
+                run_mode="default",
+                dry_run=False,
+                session_key="sess",
+                run_worker_once=run_once,
+                report_worker_summary=lambda _summary, _dry: None,
+                watch_interval_seconds=lambda: 5,
+                dry_run_log=lambda _message: None,
+                emit=emitted.append,
+            )
+
+    assert calls == 1
+    assert emitted == ["Runtime update detected; restarting worker before the next idle check."]
+    relaunch.assert_called_once_with(startup_runtime)
+
+
+def test_run_worker_sessions_no_update_skips_reexec() -> None:
+    emitted: list[str] = []
+    slept: list[float] = []
+    startup_runtime = type("StartupRuntime", (), {"runtime_changed": lambda self: False})()
+    calls = 0
+
+    def run_once(args: object, *, mode: str, dry_run: bool, session_key: str) -> WorkerRunSummary:
+        del args, mode, dry_run, session_key
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return WorkerRunSummary(started=False, reason="no_ready_changesets")
+        raise RuntimeError("stop-loop")
+
+    try:
+        with patch(
+            "atelier.worker.runtime.worker_restart_runtime.relaunch_worker_process"
+        ) as relaunch:
+            runtime.run_worker_sessions(
+                args=type(
+                    "Args",
+                    (),
+                    {
+                        "queue": False,
+                        "startup_runtime": startup_runtime,
+                        "restart_on_update": True,
+                    },
+                )(),
+                mode="auto",
+                run_mode="watch",
+                dry_run=False,
+                session_key="sess",
+                run_worker_once=run_once,
+                report_worker_summary=lambda _summary, _dry: None,
+                watch_interval_seconds=lambda: 11,
+                dry_run_log=lambda _message: None,
+                emit=emitted.append,
+                sleep_fn=lambda seconds: slept.append(seconds),
+            )
+    except RuntimeError as exc:
+        assert str(exc) == "stop-loop"
+
+    assert emitted == ["No ready work; watching for updates (sleeping 11s)."]
+    assert slept == [11]
+    relaunch.assert_not_called()
+
+
+def test_run_worker_sessions_failed_reexec_logs_and_continues() -> None:
+    emitted: list[str] = []
+    slept: list[float] = []
+    startup_runtime = type("StartupRuntime", (), {"runtime_changed": lambda self: True})()
+    calls = 0
+
+    def run_once(args: object, *, mode: str, dry_run: bool, session_key: str) -> WorkerRunSummary:
+        del args, mode, dry_run, session_key
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return WorkerRunSummary(started=False, reason="no_ready_changesets")
+        raise RuntimeError("stop-loop")
+
+    try:
+        with patch(
+            "atelier.worker.runtime.worker_restart_runtime.relaunch_worker_process",
+            side_effect=OSError("exec failed"),
+        ) as relaunch:
+            runtime.run_worker_sessions(
+                args=type(
+                    "Args",
+                    (),
+                    {
+                        "queue": False,
+                        "startup_runtime": startup_runtime,
+                        "restart_on_update": True,
+                    },
+                )(),
+                mode="auto",
+                run_mode="watch",
+                dry_run=False,
+                session_key="sess",
+                run_worker_once=run_once,
+                report_worker_summary=lambda _summary, _dry: None,
+                watch_interval_seconds=lambda: 13,
+                dry_run_log=lambda _message: None,
+                emit=emitted.append,
+                sleep_fn=lambda seconds: slept.append(seconds),
+            )
+    except RuntimeError as exc:
+        assert str(exc) == "stop-loop"
+
+    assert emitted == [
+        "Runtime update detected; restarting worker before the next idle check.",
+        "Runtime update detected but restart failed; continuing with the current runtime (OSError: exec failed).",
+        "No ready work; watching for updates (sleeping 13s).",
+    ]
+    assert slept == [13]
+    assert relaunch.call_count == 1
+
+
 def test_run_worker_sessions_dry_watch_uses_dry_run_log() -> None:
     calls = 0
     logs: list[str] = []


### PR DESCRIPTION
# Summary

- restart workers at idle boundaries when the runtime fingerprint changes so long-lived sessions pick up updated Atelier code without manual restarts
- make watch mode default to restart-on-update while keeping non-watch modes opt-in via explicit CLI flags

# Changes

- check for runtime updates only after `run_worker_once` returns and re-exec the worker before the next selection or watch sleep using the preserved launch contract
- add `relaunch_worker_process` plus `--restart-on-update` and `--no-restart-on-update`, with watch-mode default resolution in the work command wiring
- add README guidance and regression coverage for watch-mode reexec, non-watch opt-in, no-update, failed-reexec continuation, and relaunch-contract preservation

# Testing

- `pytest tests/atelier/worker/test_restart_runtime.py tests/atelier/worker/test_runtime.py tests/atelier/commands/test_work.py tests/atelier/commands/test_work_cli.py tests/atelier/commands/test_work_runtime_wiring.py tests/atelier/commands/test_cli_constrained_options.py tests/atelier/test_cli_defaults.py`
- `just format`
- `just lint`
- `env -u PYTHONPATH -u VIRTUAL_ENV -u VIRTUAL_ENV_PROMPT UV_PYTHON=3.11 just test`

## Tickets
- Addresses #570

# Risks / Rollout

- Restart-loop backoff and tighter failure diagnostics remain in the follow-on hardening slice; this PR only performs the idle-boundary handoff and logs failed exec attempts before continuing.

# Notes

- Restart checks run only in the outer worker loop after a session returns, so active changeset execution and finalize/publish flows are never interrupted.
