### PR TITLE
Process blocking work-thread messages before worker startup

### DIFF
--- a/src/atelier/messages.py
+++ b/src/atelier/messages.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Final
 
 FRONTMATTER_DELIMITER = "---"
+_RUNTIME_ROLE_ORDER: Final[tuple[str, ...]] = ("worker", "planner", "operator")
+_RUNTIME_ROLES: Final[frozenset[str]] = frozenset(_RUNTIME_ROLE_ORDER)
+_NEEDS_DECISION_SUBJECT_PREFIX: Final[str] = "NEEDS-DECISION:"
 
 
 @dataclass(frozen=True)
@@ -13,9 +17,39 @@ class MessagePayload:
     body: str
 
 
+@dataclass(frozen=True)
+class WorkThreadRouting:
+    """Normalized work-thread routing metadata for one message issue.
+
+    Attributes:
+        issue_id: Message bead identifier, if present on the issue payload.
+        title: Issue title/subject.
+        body: Parsed message body without YAML frontmatter.
+        thread_id: Thread bead id when the message is work-threaded.
+        thread_target: Explicit thread target, usually ``epic`` or
+            ``changeset`` when supplied by the sender.
+        kind: Normalized message kind such as ``needs-decision``.
+        audiences: Runtime roles explicitly or compatibly targeted by the
+            message.
+        blocking_roles: Runtime roles that the message should block until the
+            message is processed.
+    """
+
+    issue_id: str | None
+    title: str
+    body: str
+    thread_id: str | None
+    thread_target: str | None
+    kind: str | None
+    audiences: tuple[str, ...]
+    blocking_roles: tuple[str, ...]
+
+
 def _format_value(value: object) -> str:
     if value is None:
         return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
     if isinstance(value, list):
         items = ", ".join(str(item) for item in value)
         return f"[{items}]"
@@ -39,6 +73,10 @@ def _parse_value(value: str) -> object:
     value = value.strip()
     if value.lower() == "null":
         return None
+    if value.lower() == "true":
+        return True
+    if value.lower() == "false":
+        return False
     if value.startswith("[") and value.endswith("]"):
         inner = value[1:-1].strip()
         if not inner:
@@ -76,3 +114,262 @@ def parse_message(description: str) -> MessagePayload:
         body_lines = body_lines[1:]
     body = "\n".join(body_lines).rstrip("\n")
     return MessagePayload(metadata=metadata, body=body)
+
+
+def _issue_title(issue: dict[str, object]) -> str:
+    title = issue.get("title")
+    if not isinstance(title, str):
+        return ""
+    return title.strip()
+
+
+def _issue_description(issue: dict[str, object]) -> str:
+    description = issue.get("description")
+    if not isinstance(description, str):
+        return ""
+    return description
+
+
+def _issue_id(issue: dict[str, object]) -> str | None:
+    issue_id = issue.get("id")
+    if not isinstance(issue_id, str):
+        return None
+    normalized = issue_id.strip()
+    return normalized or None
+
+
+def _normalize_runtime_role(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+    if "," in normalized:
+        return None
+    if "/" in normalized:
+        parts = [part for part in normalized.split("/") if part]
+        if not parts:
+            return None
+        normalized = parts[1] if parts[0] == "atelier" and len(parts) > 1 else parts[0]
+    if normalized == "overseer":
+        normalized = "operator"
+    if normalized not in _RUNTIME_ROLES:
+        return None
+    return normalized
+
+
+def _ordered_unique_roles(values: list[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for role in _RUNTIME_ROLE_ORDER:
+        if role in values and role not in seen:
+            seen.add(role)
+            ordered.append(role)
+    return tuple(ordered)
+
+
+def _coerce_roles(value: object) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, (list, tuple, set, frozenset)):
+        candidates = list(value)
+    elif isinstance(value, str):
+        candidates = [part.strip() for part in value.split(",")]
+    else:
+        candidates = [value]
+    roles = [
+        normalized
+        for candidate in candidates
+        if (normalized := _normalize_runtime_role(candidate)) is not None
+    ]
+    return _ordered_unique_roles(roles)
+
+
+def _message_thread_id(payload: MessagePayload) -> str | None:
+    thread = payload.metadata.get("thread")
+    if not isinstance(thread, str):
+        return None
+    normalized = thread.strip()
+    return normalized or None
+
+
+def _message_thread_target(payload: MessagePayload) -> str | None:
+    raw_target = payload.metadata.get("thread_target")
+    if not isinstance(raw_target, str):
+        return None
+    normalized = raw_target.strip().lower()
+    return normalized or None
+
+
+def _message_kind(payload: MessagePayload, *, title: str) -> str | None:
+    for key in ("kind", "msg_type"):
+        raw_value = payload.metadata.get(key)
+        if isinstance(raw_value, str):
+            normalized = raw_value.strip().lower()
+            if normalized:
+                return normalized
+    if title.startswith(_NEEDS_DECISION_SUBJECT_PREFIX):
+        return "needs-decision"
+    return None
+
+
+def _message_audiences(issue: dict[str, object], payload: MessagePayload) -> tuple[str, ...]:
+    explicit_roles = _coerce_roles(
+        payload.metadata.get("audiences", payload.metadata.get("audience"))
+    )
+    if explicit_roles:
+        return explicit_roles
+    compatibility_roles = list(
+        role
+        for role in (
+            _normalize_runtime_role(issue.get("assignee")),
+            _normalize_runtime_role(payload.metadata.get("queue")),
+        )
+        if role is not None
+    )
+    return _ordered_unique_roles(compatibility_roles)
+
+
+def _message_blocking_roles(
+    issue: dict[str, object],
+    payload: MessagePayload,
+    *,
+    thread_id: str | None,
+    title: str,
+    audiences: tuple[str, ...],
+) -> tuple[str, ...]:
+    explicit_roles = _coerce_roles(
+        payload.metadata.get("blocking_roles", payload.metadata.get("blocking_for"))
+    )
+    if explicit_roles:
+        return explicit_roles
+    blocking_value = payload.metadata.get("blocking")
+    if isinstance(blocking_value, bool):
+        return audiences if blocking_value else ()
+    if blocking_roles := _coerce_roles(blocking_value):
+        return blocking_roles
+    if title.startswith(_NEEDS_DECISION_SUBJECT_PREFIX):
+        return audiences
+    assignee_role = _normalize_runtime_role(issue.get("assignee"))
+    if thread_id and assignee_role == "worker":
+        return ("worker",)
+    return ()
+
+
+def work_thread_routing(issue: dict[str, object]) -> WorkThreadRouting:
+    """Normalize work-thread routing metadata for a message bead.
+
+    Args:
+        issue: Message issue payload from Beads.
+
+    Returns:
+        Parsed routing metadata with compatibility fallbacks for legacy
+        assignee/queue-based delivery.
+    """
+
+    payload = parse_message(_issue_description(issue))
+    title = _issue_title(issue)
+    thread_id = _message_thread_id(payload)
+    audiences = _message_audiences(issue, payload)
+    return WorkThreadRouting(
+        issue_id=_issue_id(issue),
+        title=title,
+        body=payload.body,
+        thread_id=thread_id,
+        thread_target=_message_thread_target(payload),
+        kind=_message_kind(payload, title=title),
+        audiences=audiences,
+        blocking_roles=_message_blocking_roles(
+            issue,
+            payload,
+            thread_id=thread_id,
+            title=title,
+            audiences=audiences,
+        ),
+    )
+
+
+def message_blocks_runtime(
+    issue: dict[str, object],
+    *,
+    runtime_role: str,
+    thread_ids: set[str] | None = None,
+) -> bool:
+    """Return whether a message blocks a specific runtime role.
+
+    Args:
+        issue: Message issue payload from Beads.
+        runtime_role: Runtime role to evaluate: ``worker``, ``planner``, or
+            ``operator``.
+        thread_ids: Optional thread ids allowed to block this runtime. When
+            omitted, any threaded message for the runtime is eligible.
+
+    Returns:
+        ``True`` when the message is threaded and blocks the requested role.
+    """
+
+    normalized_role = _normalize_runtime_role(runtime_role)
+    if normalized_role is None:
+        return False
+    routing = work_thread_routing(issue)
+    if routing.thread_id is None:
+        return False
+    if thread_ids is not None and routing.thread_id not in thread_ids:
+        return False
+    return normalized_role in routing.blocking_roles
+
+
+def message_targets_runtime(
+    issue: dict[str, object],
+    *,
+    runtime_role: str,
+    thread_ids: set[str] | None = None,
+) -> bool:
+    """Return whether a threaded message targets a runtime role.
+
+    Args:
+        issue: Message issue payload from Beads.
+        runtime_role: Runtime role to evaluate: ``worker``, ``planner``, or
+            ``operator``.
+        thread_ids: Optional thread ids allowed to match this runtime.
+
+    Returns:
+        ``True`` when the message is threaded and addressed to the runtime.
+    """
+
+    normalized_role = _normalize_runtime_role(runtime_role)
+    if normalized_role is None:
+        return False
+    routing = work_thread_routing(issue)
+    if routing.thread_id is None:
+        return False
+    if thread_ids is not None and routing.thread_id not in thread_ids:
+        return False
+    return normalized_role in routing.audiences
+
+
+def render_work_thread_summary(issue: dict[str, object]) -> str:
+    """Render a concise work-thread summary line for operator/agent prompts.
+
+    Args:
+        issue: Message issue payload from Beads.
+
+    Returns:
+        Compact summary text including thread, audience, kind, and body when
+        present.
+    """
+
+    routing = work_thread_routing(issue)
+    title = routing.title or "(untitled)"
+    detail_parts: list[str] = []
+    if routing.thread_id:
+        target = routing.thread_target or "work"
+        detail_parts.append(f"{target}={routing.thread_id}")
+    if routing.kind:
+        detail_parts.append(f"kind={routing.kind}")
+    if routing.audiences:
+        detail_parts.append(f"audience={','.join(routing.audiences)}")
+    detail = f" ({'; '.join(detail_parts)})" if detail_parts else ""
+    if routing.body:
+        return f"{title}{detail}\n{routing.body}"
+    return f"{title}{detail}"

--- a/src/atelier/planner_startup_check.py
+++ b/src/atelier/planner_startup_check.py
@@ -1,4 +1,4 @@
-"""Deterministic planner-startup command planning and Beads invocation helpers."""
+"""Deterministic planner-startup planning and Beads invocation helpers."""
 
 from __future__ import annotations
 
@@ -476,7 +476,8 @@ def validate_startup_list_invocation(args: list[str]) -> None:
         args: `bd` arguments without the leading binary name.
 
     Raises:
-        ValueError: If the invocation uses unsupported syntax or forbidden flags.
+        ValueError: If the invocation uses unsupported syntax or forbidden
+            flags.
     """
 
     if not args:
@@ -528,16 +529,31 @@ class StartupBeadsInvocationHelper:
     ) -> list[dict[str, object]]:
         """List planner inbox messages via the canonical startup helper path."""
 
-        args = [
-            "list",
-            "--label",
-            beads.issue_label("message", beads_root=self.beads_root),
-            "--assignee",
-            agent_id,
-        ]
+        args = ["list", "--label", beads.issue_label("message", beads_root=self.beads_root)]
         if unread_only:
             args.extend(["--label", beads.issue_label("unread", beads_root=self.beads_root)])
-        return self._run_list_query(args)
+        issues = self._run_list_query(args)
+        matches: list[dict[str, object]] = []
+        seen_ids: set[str] = set()
+        for issue in issues:
+            issue_id = str(issue.get("id") or "").strip()
+            assignee = issue.get("assignee")
+            assignee_match = isinstance(assignee, str) and assignee.strip() == agent_id
+            routed_attention = any(
+                messages.message_blocks_runtime(issue, runtime_role=role)
+                for role in ("planner", "operator")
+            )
+            if not assignee_match and not routed_attention:
+                continue
+            enriched = dict(issue)
+            if routed_attention:
+                enriched["title"] = messages.render_work_thread_summary(issue).replace("\n", " | ")
+            if issue_id and issue_id in seen_ids:
+                continue
+            if issue_id:
+                seen_ids.add(issue_id)
+            matches.append(enriched)
+        return matches
 
     def list_queue_messages(
         self,

--- a/src/atelier/worker/finalization_service.py
+++ b/src/atelier/worker/finalization_service.py
@@ -135,9 +135,10 @@ def has_blocking_messages(
         created_at = parse_issue_time(issue.get("created_at"))
         if created_at is not None and created_at < started_at:
             continue
-        description = issue.get("description")
-        payload = messages.parse_message(description if isinstance(description, str) else "")
-        thread = payload.metadata.get("thread")
-        if isinstance(thread, str) and thread in thread_ids:
+        if messages.message_blocks_runtime(
+            issue,
+            runtime_role="worker",
+            thread_ids=thread_ids,
+        ):
             return True
     return False

--- a/src/atelier/worker/session/runner.py
+++ b/src/atelier/worker/session/runner.py
@@ -9,11 +9,11 @@ from pathlib import Path
 from typing import Protocol
 
 from ... import beads as beads_runtime
-from ... import changeset_fields, git, lifecycle
+from ... import changeset_fields, git, lifecycle, messages
 from ... import exec as exec_util
 from ... import root_branch as root_branch_runtime
 from ..context import ChangesetSelectionContext, WorkerRunContext
-from ..models import StartupContractResult, WorkerRunSummary
+from ..models import StartupContractResult, StartupFinalizePreflightResult, WorkerRunSummary
 from ..models_boundary import parse_issue_boundary
 from ..ports import (
     BeadsService,
@@ -43,6 +43,54 @@ _FINALIZE_DEPENDENCY_GATE_SOFT_FAILURE_MARKERS = (
     "to in_progress: blocking dependencies",
 )
 _FINALIZE_DEPENDENCY_GATE_SUMMARY_REASON = "changeset_finalize_in_progress_dependency_gate_failed"
+
+
+def _load_worker_thread_blocking_messages(
+    *,
+    beads: BeadsService,
+    beads_root: Path,
+    repo_root: Path,
+    thread_ids: set[str],
+) -> list[dict[str, object]]:
+    issues = beads.run_bd_json(
+        [
+            "list",
+            "--label",
+            beads_runtime.issue_label("message", beads_root=beads_root),
+            "--label",
+            beads_runtime.issue_label("unread", beads_root=beads_root),
+        ],
+        beads_root=beads_root,
+        cwd=repo_root,
+    )
+    return [
+        issue
+        for issue in issues
+        if messages.message_blocks_runtime(
+            issue,
+            runtime_role="worker",
+            thread_ids=thread_ids,
+        )
+    ]
+
+
+def _append_work_thread_messages_to_prompt(
+    prompt: str, *, message_issues: list[dict[str, object]]
+) -> str:
+    if not message_issues:
+        return prompt
+    rendered_messages = [
+        f"- {messages.render_work_thread_summary(issue).replace(chr(10), chr(10) + '  ')}"
+        for issue in message_issues
+    ]
+    section = "\n".join(
+        [
+            "",
+            "Blocking work-thread messages to process before coding:",
+            *rendered_messages,
+        ]
+    )
+    return f"{prompt}{section}"
 
 
 def _list_local_branches(*, repo_root: Path, git_path: str | None) -> tuple[str, ...]:
@@ -1169,6 +1217,19 @@ def run_worker_once(
             control.dry_run_log(f"Next changeset: {changeset_id} {changeset_title}")
         else:
             control.say(f"Next changeset: {changeset_id} {changeset_title}")
+        finishstep = control.step("Load work-thread messages", timings=timings, trace=trace)
+        work_thread_messages = _load_worker_thread_blocking_messages(
+            beads=infra.beads,
+            beads_root=beads_root,
+            repo_root=repo_root,
+            thread_ids={selected_epic, str(changeset_id)},
+        )
+        if work_thread_messages:
+            control.say(
+                "Loaded blocking work-thread messages for worker startup: "
+                f"{len(work_thread_messages)}"
+            )
+        finishstep(extra=str(len(work_thread_messages)))
         finishstep = control.step("Startup finalize preflight", timings=timings, trace=trace)
         preflight = lifecycle.startup_finalize_preflight(
             issue=changeset,
@@ -1177,6 +1238,11 @@ def run_worker_once(
             repo_root=repo_root,
             git_path=git_path,
         )
+        if work_thread_messages and preflight.should_finalize_only:
+            preflight = StartupFinalizePreflightResult(
+                should_finalize_only=False,
+                reason=f"{preflight.reason}:worker_thread_messages_pending",
+            )
         finishstep(extra=preflight.reason)
         if preflight.should_finalize_only:
             if dry_run:
@@ -1462,6 +1528,10 @@ def run_worker_once(
             merge_conflict=merge_conflict,
             review_feedback=review_feedback,
             review_pr_url=review_pr_url,
+        )
+        opening_prompt = _append_work_thread_messages_to_prompt(
+            opening_prompt,
+            message_issues=work_thread_messages,
         )
         if review_feedback:
             feedback_before = lifecycle.capture_review_feedback_snapshot(

--- a/tests/atelier/test_messages.py
+++ b/tests/atelier/test_messages.py
@@ -14,7 +14,70 @@ def test_render_and_parse_message_roundtrip() -> None:
     assert parsed.body == body
 
 
+def test_render_and_parse_message_roundtrip_with_boolean_metadata() -> None:
+    metadata = {
+        "thread": "at-epic.1",
+        "blocking": True,
+        "reply_to": None,
+    }
+
+    rendered = messages.render_message(metadata, "Review this before starting")
+    parsed = messages.parse_message(rendered)
+
+    assert parsed.metadata == metadata
+
+
 def test_parse_message_without_frontmatter() -> None:
     payload = messages.parse_message("No frontmatter here\n")
     assert payload.metadata == {}
     assert payload.body == "No frontmatter here\n"
+
+
+def test_message_blocks_worker_for_threaded_worker_assignment() -> None:
+    issue = {
+        "id": "at-msg-1",
+        "title": "Worker handoff",
+        "assignee": "atelier/worker/codex/p100",
+        "description": messages.render_message(
+            {"from": "atelier/planner/codex/p200", "thread": "at-epic.1"},
+            "Resolve the review follow-up before coding.",
+        ),
+    }
+
+    assert messages.message_blocks_runtime(
+        issue,
+        runtime_role="worker",
+        thread_ids={"at-epic.1"},
+    )
+    assert not messages.message_blocks_runtime(
+        issue,
+        runtime_role="planner",
+        thread_ids={"at-epic.1"},
+    )
+
+
+def test_message_blocks_planner_for_threaded_needs_decision_queue() -> None:
+    issue = {
+        "id": "at-msg-2",
+        "title": "NEEDS-DECISION: Root branch conflict (at-epic)",
+        "description": messages.render_message(
+            {
+                "from": "atelier/worker/codex/p100",
+                "queue": "planner",
+                "thread": "at-epic",
+                "msg_type": "notification",
+            },
+            "Pick a different root branch.",
+        ),
+    }
+
+    assert messages.message_blocks_runtime(
+        issue,
+        runtime_role="planner",
+        thread_ids={"at-epic"},
+    )
+    assert not messages.message_blocks_runtime(
+        issue,
+        runtime_role="worker",
+        thread_ids={"at-epic"},
+    )

--- a/tests/atelier/test_planner_startup_check.py
+++ b/tests/atelier/test_planner_startup_check.py
@@ -91,6 +91,38 @@ def test_execute_startup_command_plan_runs_steps_in_order() -> None:
     assert [issue["id"] for issue in result.epics] == ["at-1"]
 
 
+def test_startup_helper_surfaces_threaded_planner_decisions_without_assignee() -> None:
+    helper = planner_startup_check.StartupBeadsInvocationHelper(
+        beads_root=Path("/beads"),
+        cwd=Path("/repo"),
+    )
+    object.__setattr__(
+        helper,
+        "_run_list_query",
+        lambda _args: [
+            {
+                "id": "at-msg-1",
+                "title": "NEEDS-DECISION: Publish incomplete (at-epic.1)",
+                "description": (
+                    "---\n"
+                    "from: atelier/worker/codex/p100\n"
+                    "queue: planner\n"
+                    "thread: at-epic.1\n"
+                    "msg_type: notification\n"
+                    "---\n\n"
+                    "Confirm the next publish step."
+                ),
+            }
+        ],
+    )
+
+    messages_for_planner = helper.list_inbox_messages("atelier/planner/codex/p200")
+
+    assert [issue["id"] for issue in messages_for_planner] == ["at-msg-1"]
+    assert "audience=planner" in str(messages_for_planner[0]["title"])
+    assert "at-epic.1" in str(messages_for_planner[0]["title"])
+
+
 def test_build_startup_triage_model_normalizes_and_sorts_sections() -> None:
     command_result = planner_startup_check.StartupCommandResult(
         inbox_messages=[

--- a/tests/atelier/worker/test_finalization_service.py
+++ b/tests/atelier/worker/test_finalization_service.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import datetime as dt
+from pathlib import Path
+
+import pytest
+
+from atelier import messages
+from atelier.worker import finalization_service
+
+
+def test_has_blocking_messages_ignores_planner_only_thread_notifications(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = dt.datetime.now(dt.timezone.utc)
+
+    issues = [
+        {
+            "id": "at-msg-1",
+            "title": "NEEDS-DECISION: Publish incomplete (at-epic.1)",
+            "created_at": now.isoformat(),
+            "description": messages.render_message(
+                {
+                    "from": "atelier/worker/codex/p100",
+                    "queue": "planner",
+                    "thread": "at-epic.1",
+                    "msg_type": "notification",
+                },
+                "Planner decision required before publish continues.",
+            ),
+        }
+    ]
+
+    monkeypatch.setattr(
+        finalization_service.beads,
+        "run_bd_json",
+        lambda *_args, **_kwargs: issues,
+    )
+
+    blocked = finalization_service.has_blocking_messages(
+        thread_ids={"at-epic.1"},
+        started_at=now - dt.timedelta(minutes=1),
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+        parse_issue_time=lambda value: dt.datetime.fromisoformat(str(value)),
+    )
+
+    assert blocked is False
+
+
+def test_has_blocking_messages_honors_worker_thread_messages(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = dt.datetime.now(dt.timezone.utc)
+
+    issues = [
+        {
+            "id": "at-msg-2",
+            "title": "Worker handoff",
+            "assignee": "atelier/worker/codex/p100",
+            "created_at": now.isoformat(),
+            "description": messages.render_message(
+                {
+                    "from": "atelier/planner/codex/p200",
+                    "thread": "at-epic.1",
+                },
+                "Resume the queued review-feedback work before finalize.",
+            ),
+        }
+    ]
+
+    monkeypatch.setattr(
+        finalization_service.beads,
+        "run_bd_json",
+        lambda *_args, **_kwargs: issues,
+    )
+
+    blocked = finalization_service.has_blocking_messages(
+        thread_ids={"at-epic.1"},
+        started_at=now - dt.timedelta(minutes=1),
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+        parse_issue_time=lambda value: dt.datetime.fromisoformat(str(value)),
+    )
+
+    assert blocked is True

--- a/tests/atelier/worker/test_session_runner_flow.py
+++ b/tests/atelier/worker/test_session_runner_flow.py
@@ -1658,6 +1658,100 @@ def test_run_worker_once_skips_redundant_mark_in_progress_for_in_progress_change
     deps.infra.worker_session_agent.start_agent_session.assert_called_once()
 
 
+def test_run_worker_once_loads_worker_thread_messages_before_agent_start() -> None:
+    agent = AgentHome(
+        name="worker",
+        agent_id="atelier/worker/codex/p-thread",
+        role="worker",
+        path=Path("/tmp/worker"),
+        session_key="p-thread",
+    )
+    deps = _build_runner_deps(
+        startup_result=StartupContractResult(
+            epic_id="at-epic",
+            changeset_id=None,
+            should_exit=False,
+            reason="selected_auto",
+        ),
+        preview_agent=agent,
+    )
+    changeset_issue = {
+        "id": "at-epic.1",
+        "title": "Handle threaded startup messages",
+        "status": "open",
+        "labels": [],
+        "description": "",
+    }
+    threaded_message = {
+        "id": "at-msg-1",
+        "title": "Worker handoff",
+        "assignee": "atelier/worker/codex/p-old",
+        "description": (
+            "---\n"
+            "from: atelier/planner/codex/p200\n"
+            "thread: at-epic.1\n"
+            "---\n\n"
+            "Review the work-thread handoff before proceeding."
+        ),
+    }
+
+    def run_bd_json(args: list[str], *, beads_root: Path, cwd: Path) -> list[dict[str, object]]:  # noqa: ARG001
+        if args[:2] == ["show", "at-epic.1"]:
+            return [changeset_issue]
+        if args and args[0] == "list":
+            return [threaded_message]
+        return []
+
+    deps.infra.beads.run_bd_json = Mock(side_effect=run_bd_json)
+    deps.lifecycle.next_changeset = lambda **_kwargs: changeset_issue
+    deps.lifecycle.startup_finalize_preflight = lambda **_kwargs: StartupFinalizePreflightResult(
+        should_finalize_only=True,
+        reason="finalize_only:pr_lifecycle_merged_integration_proven",
+    )
+    deps.infra.worker_session_worktree.prepare_worktrees = Mock(
+        return_value=SimpleNamespace(
+            epic_worktree_path=Path("/tmp/epic"),
+            changeset_worktree_path=Path("/tmp/changeset"),
+            branch="feat/root-at-epic.1",
+        )
+    )
+    deps.infra.worker_session_agent.prepare_agent_session = Mock(
+        return_value=SimpleNamespace(
+            agent_spec=SimpleNamespace(name="demo", display_name="Demo"),
+            agent_options=[],
+            project_enlistment=Path("/repo"),
+            workspace_branch="feat/root",
+            env={},
+        )
+    )
+    deps.infra.worker_session_agent.start_agent_session = Mock(
+        return_value=SimpleNamespace(
+            started_at=dt.datetime.now(dt.timezone.utc),
+            returncode=0,
+        )
+    )
+    deps.lifecycle.finalize_changeset = lambda **_kwargs: FinalizeResult(
+        continue_running=True,
+        reason="changeset_review_pending",
+    )
+    deps.commands.worker_opening_prompt = Mock(return_value="open-prompt")
+
+    summary = runner.run_worker_once(
+        SimpleNamespace(epic_id=None, queue=False, yes=False, reconcile=False),
+        run_context=WorkerRunContext(mode="auto", dry_run=False, session_key="p-thread"),
+        deps=deps,
+    )
+
+    assert summary.started is True
+    assert summary.reason == "agent_session_complete"
+    deps.infra.worker_session_agent.start_agent_session.assert_called_once()
+    start_kwargs = deps.infra.worker_session_agent.start_agent_session.call_args.kwargs
+    assert (
+        "Blocking work-thread messages to process before coding" in start_kwargs["opening_prompt"]
+    )
+    assert "Review the work-thread handoff before proceeding." in start_kwargs["opening_prompt"]
+
+
 def test_run_worker_once_followup_dependency_gate_skip_is_non_blocking() -> None:
     for startup_reason in ("review_feedback", "merge_conflict"):
         agent = AgentHome(


### PR DESCRIPTION
# Summary

- Load blocking worker-thread messages before worker startup proceeds.
- Surface planner and operator work-thread decisions without planner-assignee routing.
- Make finalize-time blocking role-aware so worker runs only stop for worker-relevant messages.

# Changes

- Added shared work-thread routing helpers in `src/atelier/messages.py` for audience, blocking-role, kind, and thread metadata normalization.
- Updated worker startup to load unread worker-targeted thread blockers into the opening prompt and bypass startup finalize-only shortcuts while those blockers are pending.
- Updated planner startup triage and worker finalization to consume the same role-aware message classifier.
- Added regression coverage for message parsing, planner startup surfacing, worker startup loading, and finalize-time worker-only blocking.

# Testing

- `pytest`
- `bash tests/shell/run.sh`

## Tickets
- Addresses #593

# Risks / Rollout

- Existing unthreaded agent-addressed messages remain compatibility behavior; the new blocking semantics apply to threaded messages with role-aware routing or compatible legacy hints.

# Notes

- The PR is based on the stacked parent branch so later changesets can keep the intended review order.
