### PR TITLE
Pin local Atelier publish and test gates to Python 3.11

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,12 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(cd "${script_dir}/.." && pwd)"
-if ! git -C "${repo_root}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  echo "pre-commit: ${repo_root} is not a git work tree" >&2
+resolve_repo_root() {
+  local git_dir worktree_gitdir script_dir
+
+  git_dir="$(git rev-parse --path-format=absolute --git-dir 2>/dev/null || true)"
+  if [[ -n "${git_dir}" && -f "${git_dir}/gitdir" ]]; then
+    worktree_gitdir="$(<"${git_dir}/gitdir")"
+    (
+      cd "$(dirname "${worktree_gitdir}")"
+      pwd -P
+    )
+    return 0
+  fi
+
+  if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    git rev-parse --show-toplevel
+    return 0
+  fi
+
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  git -C "${script_dir}/.." rev-parse --show-toplevel
+}
+
+repo_root="$(resolve_repo_root)" || {
+  echo "pre-commit: unable to resolve the active git work tree" >&2
   exit 1
-fi
+}
 
 mapfile -t staged_python_files < <(
   git -C "${repo_root}" diff --cached --name-only --diff-filter=ACMR \

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,12 +1,32 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(cd "${script_dir}/.." && pwd)"
-if ! git -C "${repo_root}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  echo "pre-push: ${repo_root} is not a git work tree" >&2
+resolve_repo_root() {
+  local git_dir worktree_gitdir script_dir
+
+  git_dir="$(git rev-parse --path-format=absolute --git-dir 2>/dev/null || true)"
+  if [[ -n "${git_dir}" && -f "${git_dir}/gitdir" ]]; then
+    worktree_gitdir="$(<"${git_dir}/gitdir")"
+    (
+      cd "$(dirname "${worktree_gitdir}")"
+      pwd -P
+    )
+    return 0
+  fi
+
+  if git rev-parse --show-toplevel >/dev/null 2>&1; then
+    git rev-parse --show-toplevel
+    return 0
+  fi
+
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  git -C "${script_dir}/.." rev-parse --show-toplevel
+}
+
+repo_root="$(resolve_repo_root)" || {
+  echo "pre-push: unable to resolve the active git work tree" >&2
   exit 1
-fi
+}
 
 just_bin="${ATELIER_JUST_BIN:-just}"
 if ! command -v "${just_bin}" >/dev/null 2>&1; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -305,6 +305,9 @@ alternatives; record the failure and reason.
   prompts disabled
 - Property-based tests use Hypothesis
 - Integration tests (`just test-integration`) require `codex` CLI on PATH
+- Local publish/test gates intentionally pin Python 3.11 to match CI until the
+  supported matrix expands; do not rely on an ambient interpreter or a
+  pre-existing `.venv`.
 
 ______________________________________________________________________
 

--- a/README.md
+++ b/README.md
@@ -679,8 +679,12 @@ Install `just` with `brew install just` or `cargo install just`.
 `just test-integration` runs publish-skill evals and requires the `codex` CLI to
 be installed and authenticated.
 
+Local quality gates intentionally pin `uv` to Python 3.11 to match the current
+CI baseline. Ambient Python 3.14 interpreters and pre-existing 3.14 `.venv`
+directories are not part of the supported publish/test matrix yet.
+
 ```sh
-uv venv
+bash scripts/supported-python.sh venv
 uv pip install -e .[dev]
 ```
 
@@ -693,8 +697,8 @@ uv run atelier --help
 Run tests:
 
 ```sh
-uv run python -m atelier.skill_frontmatter_validation
-pytest
+bash scripts/supported-python.sh run python -m atelier.skill_frontmatter_validation
+bash scripts/supported-python.sh run pytest
 bash tests/shell/run.sh
 ```
 

--- a/justfile
+++ b/justfile
@@ -20,14 +20,15 @@ install-editable:
 
 # Editable install in a local venv
 install-dev:
-  uv venv
-  uv pip install -e .[dev]
+  bash scripts/supported-python.sh venv
+  env -u VIRTUAL_ENV uv pip install -e .[dev]
 
 # Run the test suite
 test:
-  uv pip install -e .[dev]
-  uv run python -m atelier.skill_frontmatter_validation
-  uv run pytest
+  bash scripts/supported-python.sh venv
+  env -u VIRTUAL_ENV uv pip install -e .[dev]
+  bash scripts/supported-python.sh run python -m atelier.skill_frontmatter_validation
+  bash scripts/supported-python.sh run pytest
   bash tests/shell/run.sh
 
 # Run integration evals (requires codex CLI on PATH)
@@ -40,10 +41,10 @@ lint:
 
 # Run static type checks
 typecheck:
-  uv run --extra dev pyright
+  bash scripts/supported-python.sh run --extra dev pyright
 
 # Auto-format code
 format:
-  uv run ruff check --select I,RUF022 --fix .
-  uv run ruff format .
-  uv run --extra dev mdformat --wrap 80 .
+  bash scripts/supported-python.sh run ruff check --select I,RUF022 --fix .
+  bash scripts/supported-python.sh run ruff format .
+  bash scripts/supported-python.sh run --extra dev mdformat --wrap 80 .

--- a/scripts/lint-gate.sh
+++ b/scripts/lint-gate.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "${script_dir}/.." && pwd)"
+supported_python_cmd=(bash "${repo_root}/scripts/supported-python.sh")
 
 resolve_ruff_cmd() {
   if [[ -n "${ATELIER_RUFF_BIN:-}" ]]; then
@@ -10,7 +11,7 @@ resolve_ruff_cmd() {
     return 0
   fi
   if command -v uv >/dev/null 2>&1; then
-    RUFF_CMD=(uv run ruff)
+    RUFF_CMD=("${supported_python_cmd[@]}" run ruff)
     return 0
   fi
   if command -v ruff >/dev/null 2>&1; then
@@ -27,7 +28,7 @@ resolve_pyright_cmd() {
     return 0
   fi
   if command -v uv >/dev/null 2>&1; then
-    PYRIGHT_CMD=(uv run --extra dev pyright)
+    PYRIGHT_CMD=("${supported_python_cmd[@]}" run --extra dev pyright)
     return 0
   fi
   if command -v pyright >/dev/null 2>&1; then
@@ -40,7 +41,7 @@ resolve_pyright_cmd() {
 
 resolve_shellcheck_cmd() {
   if command -v uv >/dev/null 2>&1; then
-    SHELLCHECK_CMD=(uv run --extra dev shellcheck)
+    SHELLCHECK_CMD=("${supported_python_cmd[@]}" run --extra dev shellcheck)
     return 0
   fi
   if command -v shellcheck >/dev/null 2>&1; then

--- a/scripts/supported-python.sh
+++ b/scripts/supported-python.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SUPPORTED_PYTHON_VERSION="3.11"
+
+usage() {
+  echo "Usage: scripts/supported-python.sh <version|run|venv> [args...]" >&2
+}
+
+main() {
+  unset VIRTUAL_ENV
+
+  if [[ $# -lt 1 ]]; then
+    usage
+    exit 2
+  fi
+
+  case "$1" in
+    version)
+      printf '%s\n' "${SUPPORTED_PYTHON_VERSION}"
+      ;;
+    run)
+      shift
+      exec uv run --python "${SUPPORTED_PYTHON_VERSION}" "$@"
+      ;;
+    venv)
+      shift
+      exec uv venv --python "${SUPPORTED_PYTHON_VERSION}" "$@"
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+}
+
+main "$@"

--- a/tests/shell/python_policy_test.sh
+++ b/tests/shell/python_policy_test.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SUPPORTED_PYTHON="${ROOT_DIR}/scripts/supported-python.sh"
+
+setup_fake_uv() {
+  local bin_dir="$1"
+  local fake_uv="${bin_dir}/uv"
+
+  cat > "${fake_uv}" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${ATELIER_TEST_ARGS_FILE}"
+SCRIPT
+  chmod +x "${fake_uv}"
+}
+
+teardown() {
+  if [[ -n "${TMP_DIR:-}" && -d "${TMP_DIR}" ]]; then
+    rm -rf "${TMP_DIR}"
+  fi
+  unset TMP_DIR
+}
+
+test_supported_python_reports_current_policy_version() {
+  local actual
+  actual="$(bash "${SUPPORTED_PYTHON}" version)"
+  assert_equals "3.11" "${actual}"
+}
+
+test_supported_python_run_pins_uv_to_python_311() {
+  TMP_DIR="$(mktemp -d)"
+
+  local args_file actual
+  args_file="${TMP_DIR}/uv-args.txt"
+  setup_fake_uv "${TMP_DIR}"
+
+  PATH="${TMP_DIR}:${PATH}" \
+    ATELIER_TEST_ARGS_FILE="${args_file}" \
+    bash "${SUPPORTED_PYTHON}" run pytest >/dev/null 2>&1
+  assert_equals 0 "$?"
+
+  actual="$(cat "${args_file}")"
+  assert_equals "run --python 3.11 pytest" "${actual}"
+}
+
+test_supported_python_venv_pins_uv_to_python_311() {
+  TMP_DIR="$(mktemp -d)"
+
+  local args_file actual
+  args_file="${TMP_DIR}/uv-args.txt"
+  setup_fake_uv "${TMP_DIR}"
+
+  PATH="${TMP_DIR}:${PATH}" \
+    ATELIER_TEST_ARGS_FILE="${args_file}" \
+    bash "${SUPPORTED_PYTHON}" venv --clear >/dev/null 2>&1
+  assert_equals 0 "$?"
+
+  actual="$(cat "${args_file}")"
+  assert_equals "venv --python 3.11 --clear" "${actual}"
+}
+
+test_lint_gate_pins_uv_tooling_to_python_311() {
+  TMP_DIR="$(mktemp -d)"
+
+  local args_file first second third fourth shellcheck_uses_policy
+  args_file="${TMP_DIR}/uv-args.txt"
+  setup_fake_uv "${TMP_DIR}"
+
+  PATH="${TMP_DIR}:${PATH}" \
+    ATELIER_TEST_ARGS_FILE="${args_file}" \
+    bash "${ROOT_DIR}/scripts/lint-gate.sh" >/dev/null 2>&1
+  assert_equals 0 "$?"
+
+  first="$(sed -n '1p' "${args_file}")"
+  second="$(sed -n '2p' "${args_file}")"
+  third="$(sed -n '3p' "${args_file}")"
+  fourth="$(sed -n '4p' "${args_file}")"
+
+  assert_equals "run --python 3.11 ruff check --select I,RUF022 ." "${first}"
+  assert_equals "run --python 3.11 ruff format --check ." "${second}"
+
+  shellcheck_uses_policy=1
+  if [[ "${third}" == run\ --python\ 3.11\ --extra\ dev\ shellcheck\ -x\ * ]]; then
+    shellcheck_uses_policy=0
+  fi
+  assert_equals 0 "${shellcheck_uses_policy}"
+
+  assert_equals "run --python 3.11 --extra dev pyright" "${fourth}"
+}

--- a/tests/shell/repo_hooks_test.sh
+++ b/tests/shell/repo_hooks_test.sh
@@ -22,16 +22,25 @@ create_temp_repo() {
   cp "${ROOT_DIR}/.githooks/post-checkout" "${repo}/.githooks/post-checkout"
   mkdir -p "${repo}/scripts"
   cp "${ROOT_DIR}/scripts/lint-gate.sh" "${repo}/scripts/lint-gate.sh"
+  cp "${ROOT_DIR}/scripts/supported-python.sh" "${repo}/scripts/supported-python.sh"
   chmod +x "${repo}/.githooks/worktree-bootstrap.sh" \
     "${repo}/.githooks/pre-commit" \
     "${repo}/.githooks/pre-push" \
     "${repo}/.githooks/commit-msg" \
     "${repo}/.githooks/post-checkout" \
     "${repo}/scripts/lint-gate.sh"
-  git -C "$repo" add commitlint.config.cjs .githooks scripts/lint-gate.sh
+  git -C "$repo" add commitlint.config.cjs .githooks scripts/lint-gate.sh \
+    scripts/supported-python.sh
   git -C "$repo" commit -m "chore(repo): add hooks" -q
 
   echo "$repo"
+}
+
+canonical_path() {
+  (
+    cd "$1"
+    pwd -P
+  )
 }
 
 teardown() {
@@ -102,9 +111,12 @@ SCRIPT
   echo "not python" > "${TMP_REPO}/notes.txt"
   git -C "${TMP_REPO}" add hook_target.py notes.txt
 
-  ATELIER_RUFF_BIN="${fake_ruff}" \
-    ATELIER_TEST_ARGS_FILE="${args_file}" \
-    "${TMP_REPO}/.githooks/pre-commit" >/dev/null 2>&1
+  (
+    cd "${TMP_REPO}" && \
+      ATELIER_RUFF_BIN="${fake_ruff}" \
+      ATELIER_TEST_ARGS_FILE="${args_file}" \
+      "${TMP_REPO}/.githooks/pre-commit"
+  ) >/dev/null 2>&1
   assert_equals 0 "$?"
 
   expected_first="check --select I,RUF022 hook_target.py"
@@ -155,9 +167,12 @@ printf '%s' "$*" > "${ATELIER_TEST_ARGS_FILE}"
 SCRIPT
   chmod +x "${fake_just}"
 
-  ATELIER_JUST_BIN="${fake_just}" \
-    ATELIER_TEST_ARGS_FILE="${args_file}" \
-    "${TMP_REPO}/.githooks/pre-push" origin git@example.com/repo.git >/dev/null 2>&1
+  (
+    cd "${TMP_REPO}" && \
+      ATELIER_JUST_BIN="${fake_just}" \
+      ATELIER_TEST_ARGS_FILE="${args_file}" \
+      "${TMP_REPO}/.githooks/pre-push" origin git@example.com/repo.git
+  ) >/dev/null 2>&1
   assert_equals 0 "$?"
 
   expected="test"
@@ -179,9 +194,11 @@ exit 3
 SCRIPT
   chmod +x "${fake_just}"
 
-  ATELIER_JUST_BIN="${fake_just}" \
-    "${TMP_REPO}/.githooks/pre-push" origin git@example.com/repo.git \
-    > /dev/null 2> "${stderr_file}"
+  (
+    cd "${TMP_REPO}" && \
+      ATELIER_JUST_BIN="${fake_just}" \
+      "${TMP_REPO}/.githooks/pre-push" origin git@example.com/repo.git
+  ) > /dev/null 2> "${stderr_file}"
   assert_equals 1 "$?"
 
   local guidance_present
@@ -212,11 +229,83 @@ fi
 SCRIPT
   chmod +x "${fake_just}"
 
-  GIT_DIR="${git_dir}" \
-    GIT_WORK_TREE="${git_work_tree}" \
-    ATELIER_JUST_BIN="${fake_just}" \
-    "${TMP_REPO}/.githooks/pre-push" origin git@example.com/repo.git >/dev/null 2>&1
+  (
+    cd "${TMP_REPO}" && \
+      GIT_DIR="${git_dir}" \
+      GIT_WORK_TREE="${git_work_tree}" \
+      ATELIER_JUST_BIN="${fake_just}" \
+      "${TMP_REPO}/.githooks/pre-push" origin git@example.com/repo.git
+  ) >/dev/null 2>&1
   assert_equals 0 "$?"
+}
+
+test_pre_commit_uses_active_worktree_root() {
+  TMP_REPO="$(create_temp_repo)"
+  "${TMP_REPO}/.githooks/worktree-bootstrap.sh" >/dev/null 2>&1
+
+  TMP_WORKTREE="${TMP_REPO}-wt"
+  git -C "${TMP_REPO}" worktree add -q -b test/pre-commit-worktree "${TMP_WORKTREE}" HEAD
+  local physical_worktree
+  physical_worktree="$(canonical_path "${TMP_WORKTREE}")"
+
+  local fake_ruff args_file actual_first
+  fake_ruff="${TMP_REPO}/fake-ruff.sh"
+  args_file="${TMP_REPO}/ruff-args.txt"
+
+  cat > "${fake_ruff}" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s|%s\n' "$PWD" "$*" >> "${ATELIER_TEST_ARGS_FILE}"
+SCRIPT
+  chmod +x "${fake_ruff}"
+
+  echo 'print("hi")' > "${TMP_WORKTREE}/worktree_hook_target.py"
+  git -C "${TMP_WORKTREE}" add worktree_hook_target.py
+
+  (
+    cd "${TMP_WORKTREE}" && \
+      ATELIER_RUFF_BIN="${fake_ruff}" \
+      ATELIER_TEST_ARGS_FILE="${args_file}" \
+      "${TMP_REPO}/.githooks/pre-commit"
+  ) >/dev/null 2>&1
+  assert_equals 0 "$?"
+
+  actual_first="$(sed -n '1p' "${args_file}")"
+  assert_equals \
+    "${physical_worktree}|check --select I,RUF022 worktree_hook_target.py" \
+    "${actual_first}"
+}
+
+test_pre_push_uses_active_worktree_root() {
+  TMP_REPO="$(create_temp_repo)"
+  "${TMP_REPO}/.githooks/worktree-bootstrap.sh" >/dev/null 2>&1
+
+  TMP_WORKTREE="${TMP_REPO}-wt"
+  git -C "${TMP_REPO}" worktree add -q -b test/pre-push-worktree "${TMP_WORKTREE}" HEAD
+  local physical_worktree
+  physical_worktree="$(canonical_path "${TMP_WORKTREE}")"
+
+  local fake_just args_file actual
+  fake_just="${TMP_REPO}/fake-just.sh"
+  args_file="${TMP_REPO}/just-args.txt"
+
+  cat > "${fake_just}" <<'SCRIPT'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s|%s' "$PWD" "$*" > "${ATELIER_TEST_ARGS_FILE}"
+SCRIPT
+  chmod +x "${fake_just}"
+
+  (
+    cd "${TMP_WORKTREE}" && \
+      ATELIER_JUST_BIN="${fake_just}" \
+      ATELIER_TEST_ARGS_FILE="${args_file}" \
+      "${TMP_REPO}/.githooks/pre-push" origin git@example.com/repo.git
+  ) >/dev/null 2>&1
+  assert_equals 0 "$?"
+
+  actual="$(cat "${args_file}")"
+  assert_equals "${physical_worktree}|test" "${actual}"
 }
 
 test_post_checkout_repairs_hookspath_from_worktree() {

--- a/tests/shell/run.sh
+++ b/tests/shell/run.sh
@@ -7,4 +7,5 @@ BASHUNIT="${SCRIPT_DIR}/vendor/bashunit"
 
 cd "${ROOT_DIR}"
 "${BASHUNIT}" test "tests/shell/publish_scripts_test.sh"
+"${BASHUNIT}" test "tests/shell/python_policy_test.sh"
 "${BASHUNIT}" test "tests/shell/repo_hooks_test.sh"


### PR DESCRIPTION
# Summary

- Pin Atelier's local publish and test gates to Python 3.11 so worktree verification matches the current CI baseline instead of ambient interpreter discovery.

# Changes

- Add `scripts/supported-python.sh` as the single local Python policy entry point for `uv run` and `uv venv`.
- Route `just test`, `just format`, `just lint`, and `scripts/lint-gate.sh` through the pinned Python 3.11 path and clear inherited `VIRTUAL_ENV`.
- Document the local Python 3.11 publish/test policy in the repo docs.
- Fix `.githooks/pre-commit` and `.githooks/pre-push` so linked worktrees resolve the active checkout before invoking local gates.
- Add shell regression coverage for the pinned helper and linked-worktree hook behavior.

# Testing

- `just format`
- `just lint`
- `just test`

# Tickets

- None

# Risks / Rollout

- Python 3.14 is still intentionally out of scope for the supported publish/test matrix; this change makes the current 3.11 baseline explicit locally instead of expanding CI coverage.
- Linked-worktree hook routing changes affect local developer workflows, so the shell coverage now exercises both repo-root and worktree execution paths.

# Notes

- This intentionally preserves the existing Python 3.11 CI baseline and defers any broader Python 3.14 matrix expansion to follow-up work.
