### PR TITLE
Demote agent inbox routing to compatibility for work-threaded messaging

### DIFF
--- a/docs/rethinking-atelier.md
+++ b/docs/rethinking-atelier.md
@@ -697,8 +697,8 @@ Messaging skills:
 
 ## Messaging Policy (When to Send Mail)
 
-Messages are for coordination and exceptions. The hook is the assignment
-channel.
+Messages are for coordination and exceptions. Durable coordination belongs on
+the epic or changeset thread; the hook remains the assignment channel.
 
 ### Send a message when:
 
@@ -709,6 +709,14 @@ channel.
 - **Scope changes**: epic needs splitting/merging, or new epics are required.
 - **Handoff**: a session is ending mid-work; summarize state and next steps.
 - **Status exceptions**: repeated failures or no eligible epics available.
+
+Default durable pattern:
+
+- Attach the message to the relevant epic or changeset with `thread`.
+- Add explicit routing metadata (`thread_target`, `audiences`, `kind`, and
+  `blocking_roles` when execution should stop).
+- Use assignee or queue only as compatibility routing on top of the threaded
+  message.
 
 ### Do NOT message when:
 
@@ -723,6 +731,9 @@ Overseer and planner may message workers for meta-coordination:
 - Size guardrails tightened
 - Work paused or resumed
 - Epic split/merge instructions
+
+See `docs/work-threaded-message-migration.md` for the migration policy and the
+remaining compatibility-only cases.
 
 ### Subject Conventions (Optional)
 

--- a/docs/work-threaded-message-migration.md
+++ b/docs/work-threaded-message-migration.md
@@ -1,0 +1,57 @@
+# Work-Threaded Message Migration
+
+Work-threaded messages are the durable coordination model for Atelier. Attach
+decisions and instructions to the epic or changeset bead that owns the work so a
+later worker or planner session can recover the same context.
+
+Agent-addressed delivery is still supported, but only as a compatibility routing
+hint. An assignee or queue may help the current runtime notice a message
+quickly, but it must not be the only place where durable intent lives.
+
+## Default policy
+
+- Put durable coordination on a work thread with `thread: <epic-or-changeset>`.
+- Set explicit routing metadata when the message is work-scoped:
+  - `thread_target: epic|changeset`
+  - `audiences: [worker|planner|operator]`
+  - `kind: instruction|notification|needs-decision`
+  - `blocking_roles: [worker|planner|operator]` when the message should gate
+    execution
+- Treat `assignee` and `queue` as compatibility metadata layered on top of the
+  work thread, not as the primary source of truth.
+
+## Planner flows
+
+- Planner-to-worker guidance should be threaded to the selected epic or
+  changeset.
+- Use the worker assignee only as a compatibility nudge for the currently active
+  worker session.
+- If a target worker is inactive, reroute the request into durable executable
+  work instead of leaving a stranded worker inbox message.
+
+## Worker flows
+
+- Worker `NEEDS-DECISION` and publish/finalize diagnostics should be threaded to
+  the affected epic or changeset whenever the decision is about active work.
+- Queue metadata may still surface the message in planner/operator startup, but
+  the thread owns the durable context.
+- Non-work-wide exceptions, such as "no eligible epics", may remain queue-only
+  because there is no specific work thread to attach.
+
+## Operator flows
+
+- Operator-required decisions should surface through planner or operator queues
+  while still referencing the underlying work thread when one exists.
+- Do not route durable work decisions only to a planner process id.
+
+## Compatibility-only cases
+
+Agent-addressed delivery remains acceptable only when one of these is true:
+
+- The message is a transient compatibility nudge layered on top of a threaded
+  work message.
+- The flow has no specific epic or changeset thread to attach.
+- The runtime is claiming a queued message and recording `claimed_by` metadata.
+
+If a work-threaded message contains explicit audience or blocking metadata,
+legacy assignee or queue routing must not override it.

--- a/src/atelier/messages.py
+++ b/src/atelier/messages.py
@@ -91,8 +91,8 @@ class WorkThreadRouting:
         thread_target: Explicit thread target, usually ``epic`` or
             ``changeset``.
         kind: Normalized message kind such as ``needs-decision``.
-        audiences: Runtime roles explicitly or compatibly targeted by the
-            message.
+        audiences: Runtime roles explicitly targeted by the message or inferred
+            from compatibility-only legacy routing metadata.
         blocking_roles: Runtime roles that the message should block until the
             message is processed.
     """
@@ -395,6 +395,13 @@ def _coerce_roles(value: object) -> tuple[str, ...]:
     return _ordered_unique_roles(roles)
 
 
+def _metadata_value(payload: MessagePayload, *keys: str) -> tuple[object, bool]:
+    for key in keys:
+        if key in payload.metadata:
+            return payload.metadata[key], True
+    return None, False
+
+
 def _normalize_audience(
     value: object,
     *,
@@ -434,6 +441,23 @@ def _normalize_thread_kind(
     if _EPIC_THREAD_PATTERN.fullmatch(thread_id):
         return "epic"
     return "work"
+
+
+def infer_thread_target(thread_id: str) -> str | None:
+    """Infer the work-thread target type from a bead id.
+
+    Args:
+        thread_id: Epic or changeset bead id attached to the message.
+
+    Returns:
+        ``changeset`` for dotted bead ids, ``epic`` for top-level bead ids, or
+        ``None`` when the thread id is blank.
+    """
+
+    normalized = thread_id.strip()
+    if not normalized:
+        return None
+    return _normalize_thread_kind(None, thread_id=normalized)
 
 
 def _normalize_delivery(
@@ -498,9 +522,7 @@ def _issue_id(issue: dict[str, object]) -> str | None:
 
 
 def _message_thread_target(contract: MessageContract) -> str | None:
-    if contract.thread_kind is not None:
-        return contract.thread_kind
-    return _clean_optional_string(contract.metadata.get("thread_target"))
+    return contract.thread_kind
 
 
 def _message_kind_from_contract(
@@ -517,26 +539,31 @@ def _message_kind_from_contract(
 
 def _message_blocking_roles(
     issue: dict[str, object],
+    payload: MessagePayload,
     contract: MessageContract,
     *,
     title: str,
     audiences: tuple[str, ...],
 ) -> tuple[str, ...]:
-    explicit_roles = _coerce_roles(
-        contract.metadata.get("blocking_roles", contract.metadata.get("blocking_for"))
+    explicit_blocking_value, has_explicit_blocking = _metadata_value(
+        payload,
+        "blocking_roles",
+        "blocking_for",
     )
-    if explicit_roles:
-        return explicit_roles
-    blocking_value = contract.metadata.get("blocking")
-    if isinstance(blocking_value, bool):
-        return audiences if blocking_value else ()
-    blocking_roles = _coerce_roles(blocking_value)
-    if blocking_roles:
-        return blocking_roles
-    if title.startswith(_NEEDS_DECISION_SUBJECT_PREFIX):
+    if has_explicit_blocking:
+        return _coerce_roles(explicit_blocking_value)
+    blocking_value, has_blocking_flag = _metadata_value(payload, "blocking")
+    if has_blocking_flag:
+        if isinstance(blocking_value, bool):
+            return audiences if blocking_value else ()
+        return _coerce_roles(blocking_value)
+    if title.startswith(_NEEDS_DECISION_SUBJECT_PREFIX) and audiences:
         return audiences
     assignee_role = _normalize_runtime_role(issue.get("assignee"))
     if contract.thread_id and assignee_role == "worker":
+        _, has_explicit_audience = _metadata_value(payload, "audiences", "audience")
+        if has_explicit_audience:
+            return ()
         return ("worker",)
     return ()
 
@@ -553,8 +580,10 @@ def work_thread_routing(issue: dict[str, object]) -> WorkThreadRouting:
     """
 
     title = _issue_title(issue)
-    contract = parse_message_contract(
-        _issue_description(issue),
+    payload = parse_message(_issue_description(issue))
+    contract = build_message_contract(
+        payload.metadata,
+        body=payload.body,
         assignee=_clean_optional_string(issue.get("assignee")),
     )
     audiences = contract.audience
@@ -568,6 +597,7 @@ def work_thread_routing(issue: dict[str, object]) -> WorkThreadRouting:
         audiences=audiences,
         blocking_roles=_message_blocking_roles(
             issue,
+            payload,
             contract,
             title=title,
             audiences=audiences,

--- a/src/atelier/skills/mail-inbox/SKILL.md
+++ b/src/atelier/skills/mail-inbox/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: mail-inbox
 description: >-
-  List message beads assigned to the current agent, optionally filtering to
-  unread messages.
+  List compatibility-routed message beads assigned to the current agent,
+  optionally filtering to unread messages.
 ---
 
 # Mail inbox
@@ -18,6 +18,11 @@ description: >-
 1. List messages assigned to the agent:
    - `bd list --label at:message --assignee <agent_id> [--label at:unread]`
 1. Parse frontmatter from each message description if needed.
+1. Treat assignee-based inbox delivery as compatibility-only routing:
+   - durable work decisions should also be attached to an epic or changeset
+     thread
+   - startup/finalize flows may surface threaded blocking messages even without
+     a matching assignee
 
 ## Verification
 

--- a/src/atelier/skills/mail-send/SKILL.md
+++ b/src/atelier/skills/mail-send/SKILL.md
@@ -1,19 +1,23 @@
 ---
 name: mail-send
 description: >-
-  Send a message bead to an agent by creating a message issue with YAML
-  frontmatter and assigning it to the recipient.
+  Send a work-threaded message with compatibility routing to an agent by
+  creating a message issue with YAML frontmatter.
 ---
 
 # Mail send
+
+Work-threaded messages are the durable default. Use `to`/assignee only as a
+compatibility routing hint for the currently active runtime.
 
 ## Inputs
 
 - subject: Message subject line.
 - body: Message body content.
-- to: Recipient agent id (assignee).
+- to: Recipient agent id used for compatibility routing.
 - from: Sender agent id.
-- thread: Optional thread id (bead id).
+- thread: Optional work thread id (epic or changeset bead id). Required for
+  durable work-scoped coordination.
 - reply_to: Optional message id being replied to.
 - beads_dir: Optional Beads store path.
 
@@ -21,6 +25,12 @@ description: >-
 
 1. Use the dispatch script:
    - `python skills/mail-send/scripts/send_message.py --subject "<subject>" --body "<body>" --to "<to>" --from "<from>" [--thread "<thread>"] [--reply-to "<reply_to>"] [--beads-dir "<beads_dir>"]`
+1. For durable work coordination, always provide `--thread <epic-or-changeset>`:
+   - the script adds `thread_target`, `audiences`, and default `kind` metadata
+   - worker-targeted threaded messages also add `blocking_roles: [worker]`
+1. Treat agent-addressed delivery as compatibility routing only:
+   - assignee helps the current runtime notice the message
+   - thread metadata remains the durable source of truth
 1. Do not create planner-to-worker message beads directly with `bd create`.
 1. Treat work-threaded delivery as the durable default:
    - when `thread` is present, the script emits work-thread metadata (`thread`,
@@ -36,6 +46,10 @@ description: >-
 
 ## Verification
 
-- Active recipient path: message bead exists and is assigned to the recipient.
+- Active recipient path: message bead exists, is assigned to the recipient for
+  compatibility routing, and carries explicit work-thread metadata when
+  `--thread` is provided.
 - Inactive worker path: no worker-targeted message bead is created; reroute epic
   exists with `routing.inactive_worker` and `routing.decision`.
+- Follow `docs/work-threaded-message-migration.md` for planner/worker/operator
+  migration guidance.

--- a/src/atelier/skills/mail-send/scripts/send_message.py
+++ b/src/atelier/skills/mail-send/scripts/send_message.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Send a planner message or reroute to executable work for inactive workers."""
+"""Send a threaded work message with compatibility routing for active agents."""
 
 from __future__ import annotations
 
@@ -45,6 +45,26 @@ def _agent_role(agent_id: str) -> str | None:
 
 def _is_inactive_worker(agent_id: str) -> bool:
     return _agent_role(agent_id) == "worker" and not agent_home.is_session_agent_active(agent_id)
+
+
+def _thread_metadata(
+    *,
+    thread: str | None,
+    recipient: str,
+    subject: str,
+) -> dict[str, object]:
+    if not thread:
+        return {}
+    metadata: dict[str, object] = {}
+    recipient_role = _agent_role(recipient)
+    if recipient_role is None:
+        return metadata
+    if recipient_role == "worker":
+        metadata["blocking_roles"] = ["worker"]
+        return metadata
+    if subject.startswith("NEEDS-DECISION:"):
+        metadata["blocking_roles"] = [recipient_role]
+    return metadata
 
 
 def _build_reroute_acceptance() -> str:
@@ -195,17 +215,20 @@ def dispatch_message(
         "from": from_agent,
         "kind": _message_kind(subject=subject, reply_to=reply_to),
     }
-    if thread:
-        metadata["thread"] = thread
-        metadata["thread_kind"] = messages.build_message_contract(
-            {"thread": thread},
-        ).thread_kind
-        metadata["delivery"] = "work-threaded"
-    else:
-        metadata["delivery"] = "agent-addressed"
     audience = _agent_role(to)
     if audience in {"worker", "planner", "operator"}:
         metadata["audience"] = [audience]
+        metadata["audiences"] = [audience]
+    if thread:
+        metadata["thread"] = thread
+        thread_target = messages.infer_thread_target(thread)
+        if thread_target is not None:
+            metadata["thread_kind"] = thread_target
+            metadata["thread_target"] = thread_target
+        metadata["delivery"] = "work-threaded"
+        metadata.update(_thread_metadata(thread=thread, recipient=to, subject=subject))
+    else:
+        metadata["delivery"] = "agent-addressed"
     if subject.startswith("NEEDS-DECISION:"):
         metadata["blocking"] = True
     if reply_to:

--- a/src/atelier/templates/AGENTS.planner.md.tmpl
+++ b/src/atelier/templates/AGENTS.planner.md.tmpl
@@ -20,8 +20,10 @@ The CLI does not enforce planning correctness. You do, via skills.
 - Run `planner-startup-check` before any planning work.
 - Run `plan-changeset-guardrails` after creating or updating changesets.
 - Use `plan-promote-epic` to promote epics, with explicit user confirmation.
-- Use `mail-send` script for planner-to-worker dispatch; if a worker is inactive,
-  reroute by creating new executable work instead of sending direct messages.
+- Use `mail-send` for planner-to-worker dispatch on the epic/changeset thread;
+  agent-addressed delivery is compatibility routing only. If a worker is
+  inactive, reroute by creating new executable work instead of sending direct
+  messages.
 
 ## No Approval Step (Except Promotion)
 

--- a/src/atelier/worker/queueing.py
+++ b/src/atelier/worker/queueing.py
@@ -6,7 +6,7 @@ import datetime as dt
 from collections.abc import Callable
 from pathlib import Path
 
-from .. import beads
+from .. import beads, messages
 
 EmitFn = Callable[[str], None]
 PromptFn = Callable[[str], str]
@@ -78,11 +78,18 @@ def send_planner_notification(
         "queue": "planner",
         "msg_type": "notification",
         "kind": "needs-decision" if subject.startswith("NEEDS-DECISION:") else "notification",
-        "blocking": subject.startswith("NEEDS-DECISION:"),
         "audience": ["planner"],
+        "audiences": ["planner"],
     }
     if thread_id:
         metadata["thread"] = thread_id
+        thread_target = messages.infer_thread_target(thread_id)
+        if thread_target is not None:
+            metadata["thread_kind"] = thread_target
+            metadata["thread_target"] = thread_target
+    if subject.startswith("NEEDS-DECISION:"):
+        metadata["blocking"] = True
+        metadata["blocking_roles"] = ["planner"]
     beads.create_message_bead(
         subject=subject,
         body=body,

--- a/tests/atelier/skills/test_mail_send_script.py
+++ b/tests/atelier/skills/test_mail_send_script.py
@@ -40,7 +40,7 @@ def test_dispatch_message_delivers_to_active_worker() -> None:
             body="Please investigate.",
             to="atelier/worker/codex/p101-t1",
             from_agent="atelier/planner/codex/p202-t2",
-            thread="at-thread-1",
+            thread="at-thread-1.1",
             reply_to="at-msg-0",
             beads_root=Path("/beads"),
             cwd=Path("/repo"),
@@ -52,9 +52,12 @@ def test_dispatch_message_delivers_to_active_worker() -> None:
     assert call["assignee"] == "atelier/worker/codex/p101-t1"
     assert call["metadata"]["from"] == "atelier/planner/codex/p202-t2"
     assert call["metadata"]["delivery"] == "work-threaded"
-    assert call["metadata"]["thread"] == "at-thread-1"
-    assert call["metadata"]["thread_kind"] == "epic"
+    assert call["metadata"]["thread"] == "at-thread-1.1"
+    assert call["metadata"]["thread_kind"] == "changeset"
+    assert call["metadata"]["thread_target"] == "changeset"
     assert call["metadata"]["audience"] == ["worker"]
+    assert call["metadata"]["audiences"] == ["worker"]
+    assert call["metadata"]["blocking_roles"] == ["worker"]
     assert call["metadata"]["kind"] == "reply"
     assert call["metadata"]["reply_to"] == "at-msg-0"
 
@@ -170,28 +173,32 @@ def test_dispatch_message_non_planner_sender_does_not_reroute() -> None:
     reroute.assert_not_called()
 
 
-def test_dispatch_message_marks_needs_decision_as_blocking() -> None:
+def test_dispatch_message_threaded_needs_decision_to_planner_sets_explicit_routing() -> None:
     module = _load_script_module()
-    with (
-        patch.object(module.agent_home, "is_session_agent_active", return_value=True),
-        patch.object(
-            module.beads, "create_message_bead", return_value={"id": "at-msg-3"}
-        ) as create,
-    ):
-        module.dispatch_message(
-            subject="NEEDS-DECISION: Pick a fallback",
-            body="Choose the safer path.",
+    with patch.object(
+        module.beads, "create_message_bead", return_value={"id": "at-msg-3"}
+    ) as create:
+        result = module.dispatch_message(
+            subject="NEEDS-DECISION: Publish incomplete (at-epic.1)",
+            body="Pick the next publish action.",
             to="atelier/planner/codex/p202-t2",
             from_agent="atelier/worker/codex/p101-t1",
-            thread="at-ue6aj",
+            thread="at-epic.1",
             reply_to=None,
             beads_root=Path("/beads"),
             cwd=Path("/repo"),
         )
 
-    assert create.call_args.kwargs["metadata"]["kind"] == "needs-decision"
-    assert create.call_args.kwargs["metadata"]["blocking"] is True
-    assert create.call_args.kwargs["metadata"]["audience"] == ["planner"]
+    assert result.decision == "delivered"
+    call = create.call_args.kwargs
+    assert call["metadata"]["delivery"] == "work-threaded"
+    assert call["metadata"]["thread_target"] == "changeset"
+    assert call["metadata"]["thread_kind"] == "changeset"
+    assert call["metadata"]["audience"] == ["planner"]
+    assert call["metadata"]["audiences"] == ["planner"]
+    assert call["metadata"]["blocking"] is True
+    assert call["metadata"]["blocking_roles"] == ["planner"]
+    assert call["metadata"]["kind"] == "needs-decision"
 
 
 @pytest.mark.parametrize(

--- a/tests/atelier/test_messages.py
+++ b/tests/atelier/test_messages.py
@@ -148,3 +148,43 @@ def test_message_blocks_planner_for_threaded_needs_decision_queue() -> None:
         runtime_role="worker",
         thread_ids={"at-epic"},
     )
+
+
+def test_explicit_threaded_routing_metadata_wins_over_worker_assignee_fallback() -> None:
+    issue = {
+        "id": "at-msg-3",
+        "title": "Review the publish decision",
+        "assignee": "atelier/worker/codex/p100",
+        "description": messages.render_message(
+            {
+                "from": "atelier/planner/codex/p200",
+                "thread": "at-epic.1",
+                "thread_target": "changeset",
+                "audiences": ["planner"],
+                "blocking_roles": ["planner"],
+                "kind": "needs-decision",
+            },
+            "Planner should choose the next publish step.",
+        ),
+    }
+
+    assert not messages.message_blocks_runtime(
+        issue,
+        runtime_role="worker",
+        thread_ids={"at-epic.1"},
+    )
+    assert not messages.message_targets_runtime(
+        issue,
+        runtime_role="worker",
+        thread_ids={"at-epic.1"},
+    )
+    assert messages.message_blocks_runtime(
+        issue,
+        runtime_role="planner",
+        thread_ids={"at-epic.1"},
+    )
+    assert messages.message_targets_runtime(
+        issue,
+        runtime_role="planner",
+        thread_ids={"at-epic.1"},
+    )

--- a/tests/atelier/worker/test_queueing.py
+++ b/tests/atelier/worker/test_queueing.py
@@ -51,8 +51,13 @@ def test_send_no_ready_changesets_uses_summary_counts() -> None:
     assert "Ready changesets: 0" in kwargs["body"]
     assert kwargs["metadata"]["queue"] == "planner"
     assert kwargs["metadata"]["audience"] == ["planner"]
+    assert kwargs["metadata"]["thread"] == "at-1"
+    assert kwargs["metadata"]["thread_kind"] == "epic"
+    assert kwargs["metadata"]["thread_target"] == "epic"
+    assert kwargs["metadata"]["audiences"] == ["planner"]
     assert kwargs["metadata"]["kind"] == "needs-decision"
     assert kwargs["metadata"]["blocking"] is True
+    assert kwargs["metadata"]["blocking_roles"] == ["planner"]
 
 
 def test_prompt_queue_claim_assume_yes_claims_first_message() -> None:


### PR DESCRIPTION
# Summary

- Make work-threaded messages the durable coordination default for this slice.
- Demote agent-addressed inbox delivery to compatibility-only routing.
- Document the migration path for planner, worker, and operator message flows.

# Changes

- Updated `src/atelier/messages.py` so explicit threaded audiences and blocking metadata win over assignee and queue fallbacks while preserving the newer normalized message contract on `main`.
- Updated mail dispatch and planner notification paths to stamp explicit work-thread metadata and keep agent-addressed delivery as bounded compatibility routing.
- Documented the migration policy in `docs/work-threaded-message-migration.md` and refreshed the related skill and planner template guidance.
- Added regression coverage for threaded routing precedence and planner notification metadata on the corrected `main`-based branch.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets
- Addresses #594

# Risks / Rollout

- Existing agent-addressed delivery remains available as a compatibility path, so legacy flows still work while threaded routing stays the explicit durable model.
