### PR TITLE
Ensure published PR bodies auto-close exported GitHub issues

### DIFF
--- a/src/atelier/worker/publish.py
+++ b/src/atelier/worker/publish.py
@@ -80,6 +80,20 @@ def _ticket_has_state_tracking(ticket: ExternalTicketRef) -> bool:
     )
 
 
+def _is_primary_exported_github_ticket(ticket: ExternalTicketRef) -> bool:
+    """Return whether ticket metadata represents the exported GitHub work item.
+
+    A primary exported GitHub issue is created for the changeset itself, so the
+    PR body must keep a closing clause even when cached state metadata has gone
+    stale. That keeps merge-driven GitHub issue closure deterministic.
+    """
+    return (
+        ticket.provider == "github"
+        and ticket.relation == "primary"
+        and ticket.direction == "exported"
+    )
+
+
 def _ticket_allows_closing_clause(
     ticket: ExternalTicketRef,
     *,
@@ -93,6 +107,9 @@ def _ticket_allows_closing_clause(
         return False
     if ticket.state == "unknown":
         return False
+
+    if _is_primary_exported_github_ticket(ticket):
+        return True
 
     if not _ticket_has_state_tracking(ticket):
         # Backwards-compatibility for legacy metadata without state tracking.
@@ -116,6 +133,10 @@ def _ticket_forbids_closing_clause(
         return True
     if ticket.state == "unknown":
         return True
+
+    if _is_primary_exported_github_ticket(ticket):
+        return False
+
     if not _ticket_has_state_tracking(ticket):
         return False
 

--- a/tests/atelier/skills/test_pr_draft_scripts.py
+++ b/tests/atelier/skills/test_pr_draft_scripts.py
@@ -102,6 +102,25 @@ def test_render_tickets_section_avoids_closing_clause_for_closed_ticket() -> Non
     assert "- Fixes #371" not in section
 
 
+def test_render_tickets_section_keeps_closing_clause_for_exported_primary_github_issue() -> None:
+    module = _load_script_module()
+    issue = {
+        "description": (
+            "scope: test\n"
+            "external_tickets: "
+            '[{"provider":"github","id":"607","relation":"primary","direction":"exported",'
+            '"sync_mode":"export","state":"open",'
+            '"state_updated_at":"2026-03-01T15:22:33Z","last_synced_at":"2026-03-01T15:22:33Z"}]\n'
+        )
+    }
+
+    section = module.render_ticket_section(issue)
+
+    assert "## Tickets" in section
+    assert "- Fixes #607" in section
+    assert "- Addresses #607" not in section
+
+
 def test_load_issue_defaults_to_direct_mode(monkeypatch, tmp_path: Path) -> None:
     module = _load_script_module()
     captured: dict[str, list[str]] = {}

--- a/tests/atelier/worker/test_publish.py
+++ b/tests/atelier/worker/test_publish.py
@@ -193,6 +193,49 @@ def test_render_pr_ticket_lines_allows_fixes_for_fresh_state_metadata() -> None:
     assert lines == ["- Fixes #387"]
 
 
+def test_render_pr_ticket_lines_keeps_fixes_for_stale_primary_exported_github_ticket() -> None:
+    issue = {
+        "description": (
+            "external_tickets: "
+            '[{"provider":"github","id":"607","relation":"primary","direction":"exported",'
+            '"sync_mode":"export","state":"open",'
+            '"state_updated_at":"2026-03-01T15:22:33Z","last_synced_at":"2026-03-01T15:22:33Z"}]'
+        )
+    }
+
+    lines = publish.render_pr_ticket_lines(
+        issue, now=dt.datetime(2026, 3, 1, 16, 55, tzinfo=dt.UTC)
+    )
+
+    assert lines == ["- Fixes #607"]
+
+
+def test_render_pr_ticket_lines_only_auto_closes_primary_exported_github_ticket() -> None:
+    issue = {
+        "description": (
+            "external_tickets: "
+            '[{"provider":"github","id":"607","relation":"primary","direction":"exported",'
+            '"sync_mode":"export","state":"open",'
+            '"state_updated_at":"2026-03-01T15:22:33Z","last_synced_at":"2026-03-01T15:22:33Z"},'
+            '{"provider":"github","id":"608","relation":"secondary","direction":"exported",'
+            '"sync_mode":"export","state":"open",'
+            '"state_updated_at":"2026-03-01T15:22:33Z","last_synced_at":"2026-03-01T15:22:33Z"},'
+            '{"provider":"linear","id":"ABC-19","relation":"context","direction":"exported",'
+            '"sync_mode":"export","state":"open"}]'
+        )
+    }
+
+    lines = publish.render_pr_ticket_lines(
+        issue, now=dt.datetime(2026, 3, 1, 16, 55, tzinfo=dt.UTC)
+    )
+
+    assert lines == [
+        "- Fixes #607",
+        "- Addresses #608",
+        "- Addresses ABC-19",
+    ]
+
+
 def test_render_pr_ticket_lines_does_not_upgrade_closed_ticket_from_explicit_clause() -> None:
     issue = {
         "description": (


### PR DESCRIPTION
## Summary
Ensure published PR bodies auto-close exported GitHub issues.

## Changes
- keep primary exported GitHub issues on a closing-clause path even when cached state metadata is stale
- add regression coverage for worker publish and pr-draft ticket rendering

## Testing
- `just lint`
- `just test`

## Tickets
- Fixes #607

## Risks / Rollout
- limits the closing-clause override to primary exported GitHub issues so secondary and context tickets keep non-closing references
