### PR TITLE
Harden projected planner startup runtime selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,9 @@ Options:
 - In an active planner session, run
   `python3 skills/planner-startup-check/scripts/refresh_overview.py` to refresh
   the same read-only startup overview on demand.
+  This command now hardens the previously uncovered mode where projected
+  planner scripts were launched by an ambient interpreter that did not match
+  the repo dependency runtime.
 
 ### `atelier open [workspace-branch] [--] [command ...]`
 

--- a/docs/runtime-env-subprocess-inventory.md
+++ b/docs/runtime-env-subprocess-inventory.md
@@ -18,6 +18,11 @@ when launching planner/worker/editor/shell subprocesses.
   run from an agent home that has a local `./worktree` link.
 - Planner startup refresh commands should pass `--agent-id` explicitly instead
   of relying on inherited shell state.
+- The `refresh_overview.py` failure after `at-g5a19` was an uncovered
+  interpreter-selection mode, not another source-path-ordering regression:
+  projected planner scripts could still start under an incompatible ambient
+  `python3` / installed-tool runtime and then import repo source against those
+  installed dependencies.
 - Runtime warnings about removed inherited keys are now immediate guidance for
   explicit launch context, not future deprecation notices.
 

--- a/src/atelier/runtime_env.py
+++ b/src/atelier/runtime_env.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 import os
+import shutil
+import sys
 from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Sequence
 
 _WARNING_SAMPLE_LIMIT = 6
+_PROJECTED_RUNTIME_SELECTED_ENV = "ATELIER_PROJECTED_RUNTIME_SELECTED"
 
 USER_DEFAULT_ENV_KEYS: frozenset[str] = frozenset(
     {
@@ -78,3 +83,114 @@ def format_ambient_env_warning(removed_keys: Iterable[str]) -> str | None:
         "Use explicit launch context (for example --repo-dir or the local "
         "./worktree link) instead of ambient ATELIER_* routing state."
     )
+
+
+def projected_repo_python_command(
+    *,
+    repo_root: Path,
+    base_env: Mapping[str, str] | None = None,
+    current_executable: str | None = None,
+) -> tuple[str, ...] | None:
+    """Resolve a deterministic Python command for projected source scripts.
+
+    Projected skill scripts can safely bootstrap repo source imports via
+    ``sys.path`` edits, but that alone does not guarantee the interpreter's
+    dependency set matches the repo checkout. This resolver prefers the repo's
+    own ``.venv`` Python, then falls back to ``uv run --project <repo> python``
+    when the checkout has a ``pyproject.toml`` and ``uv`` is available.
+
+    Args:
+        repo_root: Repo root containing the projected ``src/atelier`` tree.
+        base_env: Optional environment map used for command lookup.
+        current_executable: Optional active Python executable path.
+
+    Returns:
+        ``None`` when the current interpreter already matches the repo runtime
+        or when no deterministic repo runtime is available; otherwise a command
+        prefix suitable for ``os.execvpe``.
+    """
+    repo_python = _repo_python_candidate(repo_root)
+    current = str(current_executable or sys.executable or "").strip()
+    if repo_python is not None:
+        if _same_executable_path(current, repo_python):
+            return None
+        return (str(repo_python),)
+
+    if not (repo_root / "pyproject.toml").is_file():
+        return None
+
+    env = dict(os.environ if base_env is None else base_env)
+    uv_path = shutil.which("uv", path=env.get("PATH"))
+    if not uv_path:
+        return None
+    return (uv_path, "run", "--project", str(repo_root), "python")
+
+
+def maybe_reexec_projected_repo_runtime(
+    *,
+    repo_root: Path | None,
+    script_path: Path,
+    argv: Sequence[str] | None = None,
+    base_env: Mapping[str, str] | None = None,
+    current_executable: str | None = None,
+) -> None:
+    """Re-exec a projected script into the repo runtime when required.
+
+    This is used by projected planner scripts that may be launched with an
+    ambient interpreter such as a tool-install Python. In that case the script
+    must switch to the repo runtime before importing ``atelier`` modules with
+    compiled/runtime dependencies like ``pydantic_core``.
+
+    Args:
+        repo_root: Resolved repo root discovered by the standalone bootstrap.
+        script_path: Concrete script path that should be re-executed.
+        argv: Optional script arguments excluding the interpreter and script
+            path. Defaults to ``sys.argv[1:]``.
+        base_env: Optional environment map used for the re-exec.
+        current_executable: Optional active Python executable path.
+    """
+    if repo_root is None:
+        return
+
+    env = dict(os.environ if base_env is None else base_env)
+    if env.get(_PROJECTED_RUNTIME_SELECTED_ENV) == "1":
+        return
+
+    command = projected_repo_python_command(
+        repo_root=repo_root,
+        base_env=env,
+        current_executable=current_executable,
+    )
+    if command is None:
+        return
+
+    exec_env = dict(env)
+    exec_env[_PROJECTED_RUNTIME_SELECTED_ENV] = "1"
+    script_args = list(sys.argv[1:] if argv is None else argv)
+    os.execvpe(
+        command[0],
+        [*command, str(script_path), *script_args],
+        exec_env,
+    )
+
+
+def _repo_python_candidate(repo_root: Path) -> Path | None:
+    for relative_path in (
+        Path(".venv/bin/python3"),
+        Path(".venv/bin/python"),
+        Path(".venv/Scripts/python.exe"),
+    ):
+        candidate = repo_root / relative_path
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate.resolve()
+    return None
+
+
+def _same_executable_path(current_executable: str, candidate: Path) -> bool:
+    current = current_executable.strip()
+    if not current:
+        return False
+    try:
+        return Path(current).resolve() == candidate.resolve()
+    except OSError:
+        return False

--- a/src/atelier/skills/epic-list/scripts/list_epics.py
+++ b/src/atelier/skills/epic-list/scripts/list_epics.py
@@ -22,7 +22,7 @@ def _repo_dir_from_argv(argv: list[str]) -> Path | None:
     return None
 
 
-def _bootstrap_source_import() -> None:
+def _bootstrap_source_import() -> Path | None:
     candidate_roots: list[Path] = []
     argv_repo_dir = _repo_dir_from_argv(sys.argv[1:])
     if argv_repo_dir is not None:
@@ -48,13 +48,25 @@ def _bootstrap_source_import() -> None:
         src_dir_entry = str(src_dir)
         sys.path[:] = [entry for entry in sys.path if entry != src_dir_entry]
         sys.path.insert(0, src_dir_entry)
-        return
+        return resolved
+    return None
 
 
-_bootstrap_source_import()
+_BOOTSTRAP_REPO_ROOT = _bootstrap_source_import()
 
-from atelier import planner_overview
-from atelier.beads_context import resolve_runtime_repo_dir_hint, resolve_skill_beads_context
+from atelier.runtime_env import maybe_reexec_projected_repo_runtime  # noqa: E402
+
+if __name__ == "__main__":
+    maybe_reexec_projected_repo_runtime(
+        repo_root=_BOOTSTRAP_REPO_ROOT,
+        script_path=Path(__file__).resolve(),
+    )
+
+from atelier import planner_overview  # noqa: E402
+from atelier.beads_context import (  # noqa: E402
+    resolve_runtime_repo_dir_hint,
+    resolve_skill_beads_context,
+)
 
 # Re-exported for tests that load this script directly.
 _status_bucket = planner_overview._status_bucket  # pyright: ignore[reportPrivateUsage]

--- a/src/atelier/skills/plan-changesets/scripts/create_changeset.py
+++ b/src/atelier/skills/plan-changesets/scripts/create_changeset.py
@@ -25,7 +25,7 @@ def _repo_dir_from_argv(argv: list[str]) -> Path | None:
     return None
 
 
-def _bootstrap_source_import() -> None:
+def _bootstrap_source_import() -> Path | None:
     candidate_roots: list[Path] = []
     argv_repo_dir = _repo_dir_from_argv(sys.argv[1:])
     if argv_repo_dir is not None:
@@ -51,10 +51,19 @@ def _bootstrap_source_import() -> None:
         src_dir_entry = str(src_dir)
         sys.path[:] = [entry for entry in sys.path if entry != src_dir_entry]
         sys.path.insert(0, src_dir_entry)
-        return
+        return resolved
+    return None
 
 
-_bootstrap_source_import()
+_BOOTSTRAP_REPO_ROOT = _bootstrap_source_import()
+
+from atelier.runtime_env import maybe_reexec_projected_repo_runtime  # noqa: E402
+
+if __name__ == "__main__":
+    maybe_reexec_projected_repo_runtime(
+        repo_root=_BOOTSTRAP_REPO_ROOT,
+        script_path=Path(__file__).resolve(),
+    )
 
 from atelier import auto_export, beads  # noqa: E402
 from atelier.beads_context import resolve_runtime_repo_dir_hint  # noqa: E402

--- a/src/atelier/skills/plan-create-epic/scripts/create_epic.py
+++ b/src/atelier/skills/plan-create-epic/scripts/create_epic.py
@@ -24,7 +24,7 @@ def _repo_dir_from_argv(argv: list[str]) -> Path | None:
     return None
 
 
-def _bootstrap_source_import() -> None:
+def _bootstrap_source_import() -> Path | None:
     candidate_roots: list[Path] = []
     argv_repo_dir = _repo_dir_from_argv(sys.argv[1:])
     if argv_repo_dir is not None:
@@ -50,10 +50,19 @@ def _bootstrap_source_import() -> None:
         src_dir_entry = str(src_dir)
         sys.path[:] = [entry for entry in sys.path if entry != src_dir_entry]
         sys.path.insert(0, src_dir_entry)
-        return
+        return resolved
+    return None
 
 
-_bootstrap_source_import()
+_BOOTSTRAP_REPO_ROOT = _bootstrap_source_import()
+
+from atelier.runtime_env import maybe_reexec_projected_repo_runtime  # noqa: E402
+
+if __name__ == "__main__":
+    maybe_reexec_projected_repo_runtime(
+        repo_root=_BOOTSTRAP_REPO_ROOT,
+        script_path=Path(__file__).resolve(),
+    )
 
 from atelier import auto_export, beads  # noqa: E402
 from atelier.beads_context import resolve_runtime_repo_dir_hint  # noqa: E402

--- a/src/atelier/skills/planner-startup-check/SKILL.md
+++ b/src/atelier/skills/planner-startup-check/SKILL.md
@@ -71,6 +71,11 @@ reject unsupported invocation forms.
 
 ## On-demand refresh
 
+- Runtime note: the post-`at-g5a19` failure shape was not another repo-source
+  path-ordering regression. The uncovered mode was launching projected planner
+  scripts with an incompatible ambient `python3` / installed-tool interpreter,
+  then importing repo source against that dependency set. Projected planner
+  scripts now switch into the repo runtime before importing `atelier` modules.
 - During an active planner session, re-run the same read-only overview with:
   `python3 skills/planner-startup-check/scripts/refresh_overview.py --agent-id "<planner-agent-id>" --repo-dir ./worktree`
 - This refresh is read-only and includes:

--- a/src/atelier/skills/planner-startup-check/scripts/refresh_overview.py
+++ b/src/atelier/skills/planner-startup-check/scripts/refresh_overview.py
@@ -24,7 +24,7 @@ def _repo_dir_from_argv(argv: list[str]) -> Path | None:
     return None
 
 
-def _bootstrap_source_import() -> None:
+def _bootstrap_source_import() -> Path | None:
     candidate_roots: list[Path] = []
     argv_repo_dir = _repo_dir_from_argv(sys.argv[1:])
     if argv_repo_dir is not None:
@@ -50,14 +50,26 @@ def _bootstrap_source_import() -> None:
         src_dir_entry = str(src_dir)
         sys.path[:] = [entry for entry in sys.path if entry != src_dir_entry]
         sys.path.insert(0, src_dir_entry)
-        return
+        return resolved
+    return None
 
 
-_bootstrap_source_import()
+_BOOTSTRAP_REPO_ROOT = _bootstrap_source_import()
 
-from atelier import lifecycle, planner_overview
-from atelier.beads_context import resolve_runtime_repo_dir_hint, resolve_skill_beads_context
-from atelier.planner_startup_check import (
+from atelier.runtime_env import maybe_reexec_projected_repo_runtime  # noqa: E402
+
+if __name__ == "__main__":
+    maybe_reexec_projected_repo_runtime(
+        repo_root=_BOOTSTRAP_REPO_ROOT,
+        script_path=Path(__file__).resolve(),
+    )
+
+from atelier import lifecycle, planner_overview  # noqa: E402
+from atelier.beads_context import (  # noqa: E402
+    resolve_runtime_repo_dir_hint,
+    resolve_skill_beads_context,
+)
+from atelier.planner_startup_check import (  # noqa: E402
     StartupBeadsInvocationHelper,
     StartupCommandResult,
     StartupRuntimePreflight,

--- a/src/atelier/skills/tickets/scripts/auto_export_issue.py
+++ b/src/atelier/skills/tickets/scripts/auto_export_issue.py
@@ -23,7 +23,7 @@ def _repo_dir_from_argv(argv: list[str]) -> Path | None:
     return None
 
 
-def _bootstrap_source_import() -> None:
+def _bootstrap_source_import() -> Path | None:
     candidate_roots: list[Path] = []
     argv_repo_dir = _repo_dir_from_argv(sys.argv[1:])
     if argv_repo_dir is not None:
@@ -49,10 +49,19 @@ def _bootstrap_source_import() -> None:
         src_dir_entry = str(src_dir)
         sys.path[:] = [entry for entry in sys.path if entry != src_dir_entry]
         sys.path.insert(0, src_dir_entry)
-        return
+        return resolved
+    return None
 
 
-_bootstrap_source_import()
+_BOOTSTRAP_REPO_ROOT = _bootstrap_source_import()
+
+from atelier.runtime_env import maybe_reexec_projected_repo_runtime  # noqa: E402
+
+if __name__ == "__main__":
+    maybe_reexec_projected_repo_runtime(
+        repo_root=_BOOTSTRAP_REPO_ROOT,
+        script_path=Path(__file__).resolve(),
+    )
 
 from atelier import auto_export  # noqa: E402
 from atelier.beads_context import resolve_runtime_repo_dir_hint  # noqa: E402

--- a/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
+++ b/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+import pytest
 
 
 def _copy_script(
@@ -12,6 +15,21 @@ def _copy_script(
     skill_name: str,
     script_name: str,
 ) -> tuple[Path, Path]:
+    agent_home = tmp_path / "agent-home"
+    projected_script = _copy_script_into_agent_home(
+        agent_home,
+        skill_name=skill_name,
+        script_name=script_name,
+    )
+    return agent_home, projected_script
+
+
+def _copy_script_into_agent_home(
+    agent_home: Path,
+    *,
+    skill_name: str,
+    script_name: str,
+) -> Path:
     source_script = (
         Path(__file__).resolve().parents[3]
         / "src"
@@ -21,12 +39,11 @@ def _copy_script(
         / "scripts"
         / script_name
     )
-    agent_home = tmp_path / "agent-home"
     script_dir = agent_home / "skills" / skill_name / "scripts"
-    script_dir.mkdir(parents=True)
+    script_dir.mkdir(parents=True, exist_ok=True)
     projected_script = script_dir / script_name
     projected_script.write_text(source_script.read_text(encoding="utf-8"), encoding="utf-8")
-    return agent_home, projected_script
+    return projected_script
 
 
 def _write_fake_module(path: Path, content: str) -> None:
@@ -42,7 +59,12 @@ def _fake_repo(
 ) -> Path:
     repo_root = tmp_path / "repo"
     package_root = repo_root / "src" / "atelier"
+    source_root = Path(__file__).resolve().parents[3] / "src" / "atelier"
     _write_fake_module(package_root / "__init__.py", "")
+    _write_fake_module(
+        package_root / "runtime_env.py",
+        (source_root / "runtime_env.py").read_text(encoding="utf-8"),
+    )
     _write_fake_module(
         package_root / f"{sentinel_import}.py",
         "\n".join(
@@ -80,6 +102,43 @@ def _fake_installed_package(tmp_path: Path, *, modules: dict[str, str]) -> Path:
     for module_name, content in modules.items():
         _write_fake_module(package_root / module_name, content)
     return installed_root
+
+
+def _link_repo_python(repo_root: Path) -> None:
+    repo_python = repo_root / ".venv" / "bin" / "python3"
+    repo_python.parent.mkdir(parents=True, exist_ok=True)
+    repo_python.symlink_to(Path(sys.executable).resolve())
+
+
+def _ambient_python_executable() -> str:
+    current = Path(sys.executable).resolve()
+    candidates = (
+        "/opt/homebrew/opt/python@3.14/bin/python3.14",
+        "/opt/homebrew/bin/python3",
+        "/usr/local/bin/python3",
+        "/usr/bin/python3",
+        shutil.which("python3", path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"),
+    )
+    for raw_candidate in candidates:
+        if not raw_candidate:
+            continue
+        candidate = Path(raw_candidate)
+        if not candidate.is_file():
+            continue
+        try:
+            if candidate.resolve() == current:
+                continue
+        except OSError:
+            continue
+        version_probe = subprocess.run(
+            [str(candidate), "-c", "import sys; print(sys.version_info[:2] >= (3, 10))"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if version_probe.returncode == 0 and version_probe.stdout.strip() == "True":
+            return str(candidate)
+    pytest.skip("no distinct Python 3.10+ executable available for projected-runtime test")
 
 
 def test_projected_create_epic_prefers_agent_worktree_source(tmp_path: Path) -> None:
@@ -213,10 +272,13 @@ def test_projected_refresh_overview_reorders_repo_src_ahead_of_installed_package
             "lifecycle.py": "",
             "planner_overview.py": "",
             "beads_context.py": (
+                "from pathlib import Path\n"
+                "\n"
                 "class _Context:\n"
                 "    def __init__(self, repo_dir):\n"
-                "        self.beads_root = repo_dir\n"
-                "        self.repo_root = repo_dir\n"
+                "        resolved = Path(repo_dir)\n"
+                "        self.beads_root = resolved\n"
+                "        self.repo_root = resolved\n"
                 "        self.override_warning = None\n"
                 "\n"
                 "def resolve_runtime_repo_dir_hint(*, repo_dir=None, cwd=None, env=None):\n"
@@ -331,3 +393,170 @@ def test_projected_refresh_overview_reorders_repo_src_ahead_of_installed_package
     assert sentinel_path.read_text(encoding="utf-8") == str(
         repo_root / "src" / "atelier" / "planner_startup_check.py"
     )
+
+
+def test_projected_refresh_overview_reexecs_into_repo_runtime_for_preflight(
+    tmp_path: Path,
+) -> None:
+    agent_home, projected_script = _copy_script(
+        tmp_path,
+        skill_name="planner-startup-check",
+        script_name="refresh_overview.py",
+    )
+    _copy_script_into_agent_home(
+        agent_home,
+        skill_name="plan-create-epic",
+        script_name="create_epic.py",
+    )
+    _copy_script_into_agent_home(
+        agent_home,
+        skill_name="tickets",
+        script_name="auto_export_issue.py",
+    )
+    repo_root = _fake_repo(
+        tmp_path,
+        sentinel_import="bootstrap_marker",
+        extra_modules={
+            "auto_export.py": "\n".join(
+                [
+                    "from pathlib import Path",
+                    "import os",
+                    "import sys",
+                    "",
+                    "Path(os.environ['AUTO_EXPORT_SENTINEL']).write_text(",
+                    "    sys.executable,",
+                    "    encoding='utf-8',",
+                    ")",
+                    "",
+                    "def resolve_auto_export_context(*_args, **_kwargs):",
+                    "    return None",
+                    "",
+                    "def auto_export_issue(*_args, **_kwargs):",
+                    "    return None",
+                ]
+            ),
+            "lifecycle.py": (
+                "def canonical_lifecycle_status(value):\n    return str(value or '').strip()\n"
+            ),
+            "planner_overview.py": (
+                "def render_epics(*_args, **_kwargs):\n    return 'Epics by state:\\n- (none)'\n"
+            ),
+            "beads_context.py": (
+                "from pathlib import Path\n"
+                "\n"
+                "class _Context:\n"
+                "    def __init__(self, repo_dir):\n"
+                "        resolved = Path(repo_dir)\n"
+                "        self.beads_root = resolved\n"
+                "        self.repo_root = resolved\n"
+                "        self.override_warning = None\n"
+                "\n"
+                "def resolve_runtime_repo_dir_hint(*, repo_dir=None, cwd=None, env=None):\n"
+                "    return (repo_dir, None)\n"
+                "\n"
+                "def resolve_skill_beads_context(*, beads_dir=None, repo_dir=None):\n"
+                "    return _Context(repo_dir)\n"
+            ),
+            "planner_startup_check.py": "\n".join(
+                [
+                    "from dataclasses import dataclass",
+                    "",
+                    "@dataclass(frozen=True)",
+                    "class StartupBeadsInvocationHelper:",
+                    "    beads_root: object | None = None",
+                    "    cwd: object | None = None",
+                    "",
+                    "    def list_descendant_changesets(self, *_args, **_kwargs):",
+                    "        return []",
+                    "",
+                    "@dataclass(frozen=True)",
+                    "class StartupCommandResult:",
+                    "    inbox_messages: tuple[object, ...] = ()",
+                    "    queued_messages: tuple[object, ...] = ()",
+                    "    epics: tuple[object, ...] = ()",
+                    "    parity_report: object | None = None",
+                    "",
+                    "@dataclass(frozen=True)",
+                    "class StartupRuntimePreflight:",
+                    "    name: str",
+                    "    status: str",
+                    "    detail: str",
+                    "",
+                    "def build_startup_triage_failure_model(**_kwargs):",
+                    "    return None",
+                    "",
+                    "def build_startup_triage_model(**_kwargs):",
+                    "    return None",
+                    "",
+                    "def execute_startup_command_plan(*_args, **_kwargs):",
+                    "    return StartupCommandResult()",
+                    "",
+                    "def render_startup_triage_markdown(*_args, **_kwargs):",
+                    "    return 'ok'",
+                ]
+            ),
+        },
+    )
+    _link_repo_python(repo_root)
+    installed_root = _fake_installed_package(
+        tmp_path,
+        modules={
+            "auto_export.py": (
+                "from pathlib import Path\n"
+                "import os\n"
+                "\n"
+                "Path(os.environ['AUTO_EXPORT_SENTINEL']).write_text('installed', encoding='utf-8')\n"
+            ),
+            "beads.py": "",
+            "beads_context.py": (
+                "def resolve_runtime_repo_dir_hint(*, repo_dir=None, cwd=None, env=None):\n"
+                "    return (repo_dir, None)\n"
+                "\n"
+                "class _Context:\n"
+                "    def __init__(self, repo_dir):\n"
+                "        self.beads_root = repo_dir\n"
+                "        self.repo_root = repo_dir\n"
+                "        self.override_warning = None\n"
+                "\n"
+                "def resolve_skill_beads_context(*, beads_dir=None, repo_dir=None):\n"
+                "    return _Context(repo_dir)\n"
+            ),
+            "executable_work_validation.py": (
+                "def compact_excerpt(value):\n"
+                "    return str(value)\n"
+                "def validate_executable_work_payload(**_kwargs):\n"
+                "    return []\n"
+            ),
+            "lifecycle.py": (
+                "def canonical_lifecycle_status(value):\n    return str(value or '').strip()\n"
+            ),
+            "planner_overview.py": (
+                "def render_epics(*_args, **_kwargs):\n    return 'installed'\n"
+            ),
+            "planner_startup_check.py": ("class StartupBeadsInvocationHelper:\n    pass\n"),
+        },
+    )
+    ambient_python = _ambient_python_executable()
+    sentinel_path = tmp_path / "auto-export-runtime.txt"
+
+    completed = subprocess.run(
+        [
+            ambient_python,
+            str(projected_script),
+            "--agent-id",
+            "atelier/planner/example",
+            "--repo-dir",
+            str(repo_root),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=agent_home,
+        env={
+            "AUTO_EXPORT_SENTINEL": str(sentinel_path),
+            "PYTHONPATH": os.pathsep.join([str(installed_root), str(repo_root / "src")]),
+        },
+    )
+
+    assert completed.returncode == 0
+    assert sentinel_path.read_text(encoding="utf-8") == str(Path(sys.executable).resolve())

--- a/tests/atelier/test_runtime_env.py
+++ b/tests/atelier/test_runtime_env.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from atelier import runtime_env
@@ -49,3 +51,35 @@ def test_sanitize_subprocess_environment_empty_mapping_does_not_inherit_ambient(
 
     assert env == {}
     assert removed == ()
+
+
+def test_projected_repo_python_command_prefers_repo_venv_python(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    python_path = repo_root / ".venv" / "bin" / "python3"
+    python_path.parent.mkdir(parents=True)
+    python_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    python_path.chmod(python_path.stat().st_mode | 0o111)
+
+    command = runtime_env.projected_repo_python_command(
+        repo_root=repo_root,
+        current_executable="/usr/bin/python3",
+    )
+
+    assert command == (str(python_path.resolve()),)
+
+
+def test_projected_repo_python_command_returns_none_when_current_matches_repo_venv(
+    tmp_path: Path,
+) -> None:
+    repo_root = tmp_path / "repo"
+    python_path = repo_root / ".venv" / "bin" / "python3"
+    python_path.parent.mkdir(parents=True)
+    python_path.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    python_path.chmod(python_path.stat().st_mode | 0o111)
+
+    command = runtime_env.projected_repo_python_command(
+        repo_root=repo_root,
+        current_executable=str(python_path.resolve()),
+    )
+
+    assert command is None


### PR DESCRIPTION
# Summary

- make projected planner scripts switch into the repo runtime before importing Atelier modules

# Changes

- add a projected-script runtime selector in `src/atelier/runtime_env.py` that prefers the repo `.venv` and otherwise falls back to `uv run --project <repo> python`
- apply that runtime guard to projected planner entrypoints used by startup and planner execution (`refresh_overview.py`, `create_epic.py`, `auto_export_issue.py`, `list_epics.py`, `create_changeset.py`)
- document that the remaining `pydantic_core._pydantic_core` break was an uncovered ambient-interpreter mode after the earlier source-path fix, not another path-order regression
- add regression coverage for direct repo-runtime selection and for `refresh_overview.py` preflighting projected child scripts under a mismatched interpreter

# Testing

- `pytest -q tests/atelier/test_runtime_env.py tests/atelier/skills/test_projected_skill_runtime_bootstrap.py`
- `tmpdir=$(mktemp -d); ln -s '<worktree>/.venv/lib/python3.14/site-packages/platformdirs' "$tmpdir/platformdirs"; PYTHONPATH="$tmpdir" python -m pytest -q tests/atelier/skills/test_planner_startup_refresh_script.py`
- `just test`

# Tickets

- Fixes #605

# Risks / Rollout

- low risk; the code only changes projected planner script bootstrap and leaves normal module imports untouched

# Notes

- the failing path was `refresh_overview.py -> _planner_runtime_preflight() -> sys.executable -> auto_export_issue.py/create_epic.py` under an ambient interpreter that did not match the repo dependency runtime
