### PR TITLE
Add sync wrappers and transport test doubles to the Beads client

### DIFF
--- a/src/atelier/lib/beads/__init__.py
+++ b/src/atelier/lib/beads/__init__.py
@@ -20,6 +20,7 @@ from .errors import (
 )
 from .models import (
     BeadsCapability,
+    BeadsCommandHelp,
     BeadsCommandRequest,
     BeadsCommandResult,
     BeadsEnvironment,
@@ -36,7 +37,14 @@ from .models import (
     SupportedOperation,
     UpdateIssueRequest,
 )
-from .process import SubprocessBeadsClient, SubprocessBeadsTransport
+from .process import (
+    SubprocessBeadsClient,
+    SubprocessBeadsTransport,
+    decode_help_output,
+    decode_version_output,
+)
+from .sync import SyncBeadsClient
+from .testing import RecordingBeadsTransport, ScriptedBeadsTransport
 
 __all__ = [
     "DEFAULT_COMPATIBILITY_POLICY",
@@ -46,6 +54,7 @@ __all__ = [
     "Beads",
     "BeadsCapability",
     "BeadsCommandError",
+    "BeadsCommandHelp",
     "BeadsCommandRequest",
     "BeadsCommandResult",
     "BeadsCompatibilityError",
@@ -65,12 +74,17 @@ __all__ = [
     "OperationContract",
     "OperationOutputMode",
     "ReadyIssuesRequest",
+    "RecordingBeadsTransport",
+    "ScriptedBeadsTransport",
     "SemanticVersion",
     "ShowIssueRequest",
     "SubprocessBeadsClient",
     "SubprocessBeadsTransport",
     "SupportedOperation",
+    "SyncBeadsClient",
     "UnsupportedOperationError",
     "UnsupportedVersionError",
     "UpdateIssueRequest",
+    "decode_help_output",
+    "decode_version_output",
 ]

--- a/src/atelier/lib/beads/compatibility.py
+++ b/src/atelier/lib/beads/compatibility.py
@@ -130,6 +130,10 @@ DEFAULT_COMPATIBILITY_POLICY = CompatibilityPolicy(
     ),
     operations=(
         OperationContract(
+            operation=SupportedOperation.INSPECT_ENVIRONMENT,
+            output_mode=OperationOutputMode.TEXT_NORMALIZED,
+        ),
+        OperationContract(
             operation=SupportedOperation.SHOW,
             output_mode=OperationOutputMode.JSON_REQUIRED,
             required_capabilities=_READ_CAPS,

--- a/src/atelier/lib/beads/models.py
+++ b/src/atelier/lib/beads/models.py
@@ -300,6 +300,19 @@ class BeadsCommandResult(BeadsModel):
     timed_out: bool = False
 
 
+class BeadsCommandHelp(BeadsModel):
+    """Normalized help metadata for a text-only ``bd`` command."""
+
+    argv: tuple[NonBlankStr, ...]
+    flags: tuple[NonBlankStr, ...] = ()
+    supports_json_output: bool = False
+
+    @field_validator("flags")
+    @classmethod
+    def _dedupe_flags(cls, value: tuple[str, ...]) -> tuple[str, ...]:
+        return _dedupe_strings(value)
+
+
 class BeadsEnvironment(BeadsModel):
     """Installed ``bd`` version and capabilities."""
 

--- a/src/atelier/lib/beads/process.py
+++ b/src/atelier/lib/beads/process.py
@@ -23,6 +23,7 @@ from .errors import (
 )
 from .models import (
     BeadsCapability,
+    BeadsCommandHelp,
     BeadsCommandRequest,
     BeadsCommandResult,
     BeadsEnvironment,
@@ -39,6 +40,7 @@ from .models import (
 )
 
 _SEMVER_SEARCH: Pattern[str] = compile(r"\bv?(\d+)\.(\d+)\.(\d+)\b")
+_FLAG_SEARCH: Pattern[str] = compile(r"--[a-z0-9][a-z0-9-]*")
 _JSON_FLAG = "--json"
 _CAPABILITY_PROBES = (
     (BeadsCapability.ISSUE_JSON, (("show", "--help"), ("list", "--help"))),
@@ -337,8 +339,7 @@ class SubprocessBeadsClient(Beads):
             result = await self._execute_raw(command)
             if result.returncode != 0:
                 return None
-            help_text = "\n".join(part for part in (result.stdout, result.stderr) if part)
-            if _JSON_FLAG not in help_text:
+            if not decode_help_output(result).supports_json_output:
                 return None
         return capability
 
@@ -378,6 +379,22 @@ class SubprocessBeadsClient(Beads):
 
 
 def _parse_version(result: BeadsCommandResult) -> SemanticVersion:
+    return decode_version_output(result)
+
+
+def decode_version_output(result: BeadsCommandResult) -> SemanticVersion:
+    """Decode ``bd --version`` output into a semantic version.
+
+    Args:
+        result: Raw command result from the Beads transport.
+
+    Returns:
+        Parsed semantic version for the installed ``bd`` executable.
+
+    Raises:
+        BeadsParseError: If no semantic version can be decoded.
+    """
+
     output = "\n".join(part for part in (result.stdout, result.stderr) if part).strip()
     match = _SEMVER_SEARCH.search(output)
     if match is not None:
@@ -394,6 +411,25 @@ def _parse_version(result: BeadsCommandResult) -> SemanticVersion:
             result,
             operation=SupportedOperation.INSPECT_ENVIRONMENT,
         ) from exc
+
+
+def decode_help_output(result: BeadsCommandResult) -> BeadsCommandHelp:
+    """Decode ``bd ... --help`` output into normalized command metadata.
+
+    Args:
+        result: Raw command result from the Beads transport.
+
+    Returns:
+        Typed help metadata including normalized long flags.
+    """
+
+    output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+    flags = tuple(_FLAG_SEARCH.findall(output))
+    return BeadsCommandHelp(
+        argv=result.argv,
+        flags=flags,
+        supports_json_output=_JSON_FLAG in flags,
+    )
 
 
 def _parse_single_issue(

--- a/src/atelier/lib/beads/sync.py
+++ b/src/atelier/lib/beads/sync.py
@@ -1,0 +1,65 @@
+"""Synchronous wrappers over the async-first Beads client."""
+
+from __future__ import annotations
+
+import asyncio
+
+from .client import Beads
+from .compatibility import CompatibilityPolicy
+from .models import (
+    BeadsEnvironment,
+    CloseIssueRequest,
+    CreateIssueRequest,
+    DependencyMutationRequest,
+    IssueRecord,
+    ListIssuesRequest,
+    ReadyIssuesRequest,
+    ShowIssueRequest,
+    UpdateIssueRequest,
+)
+
+
+class SyncBeadsClient:
+    """Run the async Beads client behind a synchronous facade.
+
+    Args:
+        async_client: Async-first Beads client to execute.
+
+    Raises:
+        RuntimeError: Raised by ``asyncio.run`` when called from an active
+            event loop.
+    """
+
+    def __init__(self, async_client: Beads) -> None:
+        self._async_client = async_client
+
+    @property
+    def compatibility_policy(self) -> CompatibilityPolicy:
+        return self._async_client.compatibility_policy
+
+    def inspect_environment(self) -> BeadsEnvironment:
+        return asyncio.run(self._async_client.inspect_environment())
+
+    def show(self, request: ShowIssueRequest) -> IssueRecord:
+        return asyncio.run(self._async_client.show(request))
+
+    def list(self, request: ListIssuesRequest) -> tuple[IssueRecord, ...]:
+        return asyncio.run(self._async_client.list(request))
+
+    def ready(self, request: ReadyIssuesRequest) -> tuple[IssueRecord, ...]:
+        return asyncio.run(self._async_client.ready(request))
+
+    def create(self, request: CreateIssueRequest) -> IssueRecord:
+        return asyncio.run(self._async_client.create(request))
+
+    def update(self, request: UpdateIssueRequest) -> IssueRecord:
+        return asyncio.run(self._async_client.update(request))
+
+    def close(self, request: CloseIssueRequest) -> IssueRecord:
+        return asyncio.run(self._async_client.close(request))
+
+    def add_dependency(self, request: DependencyMutationRequest) -> IssueRecord:
+        return asyncio.run(self._async_client.add_dependency(request))
+
+    def remove_dependency(self, request: DependencyMutationRequest) -> IssueRecord:
+        return asyncio.run(self._async_client.remove_dependency(request))

--- a/src/atelier/lib/beads/testing.py
+++ b/src/atelier/lib/beads/testing.py
@@ -1,0 +1,71 @@
+"""Reusable Beads transport doubles for low-level tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from .client import BeadsTransport
+from .models import BeadsCommandRequest, BeadsCommandResult
+
+_TransportOutcome = BeadsCommandResult | Exception
+
+
+def _coerce_outcomes(
+    outcome: _TransportOutcome | tuple[_TransportOutcome, ...] | list[_TransportOutcome],
+) -> list[_TransportOutcome]:
+    if isinstance(outcome, tuple):
+        return list(outcome)
+    if isinstance(outcome, list):
+        return list(outcome)
+    return [outcome]
+
+
+class RecordingBeadsTransport(BeadsTransport):
+    """Record requests and return one canned result for each execution.
+
+    Args:
+        result: Result to replay. When omitted, returns a zero-exit empty
+            payload with the requested argv.
+    """
+
+    def __init__(self, result: BeadsCommandResult | None = None) -> None:
+        self._result = result
+        self.requests: list[BeadsCommandRequest] = []
+
+    async def execute(self, request: BeadsCommandRequest) -> BeadsCommandResult:
+        self.requests.append(request)
+        if self._result is None:
+            return BeadsCommandResult(argv=request.argv, returncode=0)
+        return self._result.model_copy(update={"argv": request.argv})
+
+
+class ScriptedBeadsTransport(BeadsTransport):
+    """Replay scripted transport outcomes keyed by argv and record requests.
+
+    Args:
+        responses: Mapping of argv tuples to one or more scripted outcomes.
+
+    Raises:
+        AssertionError: Raised when a request is not present in the script.
+    """
+
+    def __init__(
+        self,
+        responses: Mapping[
+            tuple[str, ...],
+            _TransportOutcome | tuple[_TransportOutcome, ...] | list[_TransportOutcome],
+        ],
+    ) -> None:
+        self._responses = {argv: _coerce_outcomes(outcome) for argv, outcome in responses.items()}
+        self.requests: list[BeadsCommandRequest] = []
+
+    async def execute(self, request: BeadsCommandRequest) -> BeadsCommandResult:
+        self.requests.append(request)
+        outcomes = self._responses.get(request.argv)
+        if not outcomes:
+            joined = " ".join(request.argv)
+            raise AssertionError(f"unexpected Beads transport request: {joined}")
+        outcome = outcomes.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome

--- a/tests/atelier/lib/test_beads.py
+++ b/tests/atelier/lib/test_beads.py
@@ -11,6 +11,7 @@ from atelier.lib.beads import (
     Beads,
     BeadsCapability,
     BeadsCommandError,
+    BeadsCommandHelp,
     BeadsCommandRequest,
     BeadsCommandResult,
     BeadsEnvironment,
@@ -28,13 +29,18 @@ from atelier.lib.beads import (
     OperationContract,
     OperationOutputMode,
     ReadyIssuesRequest,
+    RecordingBeadsTransport,
+    ScriptedBeadsTransport,
     SemanticVersion,
     ShowIssueRequest,
     SubprocessBeadsClient,
     SubprocessBeadsTransport,
     SupportedOperation,
+    SyncBeadsClient,
     UnsupportedVersionError,
     UpdateIssueRequest,
+    decode_help_output,
+    decode_version_output,
 )
 
 
@@ -170,16 +176,6 @@ def test_protocols_are_runtime_checkable() -> None:
     assert isinstance(_FakeTransport(), BeadsTransport)
     assert isinstance(_FakeClient(), Beads)
     assert isinstance(_FakeClient(), AsyncBeadsClient)
-
-
-class _StubTransport:
-    def __init__(self, responses: dict[tuple[str, ...], BeadsCommandResult]) -> None:
-        self._responses = responses
-        self.requests: list[BeadsCommandRequest] = []
-
-    async def execute(self, request: BeadsCommandRequest) -> BeadsCommandResult:
-        self.requests.append(request)
-        return self._responses[request.argv]
 
 
 class _FakeProcess:
@@ -339,14 +335,22 @@ def test_subprocess_client_decodes_core_json_commands() -> None:
                     ("bd", "dep", "remove", "at-2", "at-1", "--json"),
                     stdout='{"issue_id":"at-2","depends_on_id":"at-1","status":"removed"}',
                 ),
-                _result(
-                    ("bd", "show", "at-2", "--json"),
-                    stdout='[{"id":"at-2","issue_type":"task","dependencies":["at-1"]}]',
-                ),
             ]
         ),
     )
-    transport = _StubTransport(responses)
+    responses[("bd", "show", "at-2", "--json")] = [
+        BeadsCommandResult(
+            argv=("bd", "show", "at-2", "--json"),
+            returncode=0,
+            stdout='[{"id":"at-2","issue_type":"task","dependencies":["at-1"]}]',
+        ),
+        BeadsCommandResult(
+            argv=("bd", "show", "at-2", "--json"),
+            returncode=0,
+            stdout='[{"id":"at-2","issue_type":"task"}]',
+        ),
+    ]
+    transport = ScriptedBeadsTransport(responses)
     client = SubprocessBeadsClient(transport=transport, env={"BEADS_DIR": "/repo/.beads"})
 
     shown = _run(client.show(ShowIssueRequest(issue_id="at-1")))
@@ -425,7 +429,7 @@ def test_subprocess_client_parse_and_capability_failures(
 ) -> None:
     responses = _probe_responses()
     responses.update([_result(argv, stdout=stdout, returncode=returncode, stderr=stderr)])
-    client = SubprocessBeadsClient(transport=_StubTransport(responses))
+    client = SubprocessBeadsClient(transport=ScriptedBeadsTransport(responses))
 
     with pytest.raises(error_type, match=match):
         if isinstance(client_request, ShowIssueRequest):
@@ -442,10 +446,90 @@ def test_inspect_environment_fails_closed_when_json_flag_is_missing() -> None:
         stdout=_HELP_OUTPUT_NO_JSON,
         stderr="",
     )
-    transport = _StubTransport(responses)
+    transport = ScriptedBeadsTransport(responses)
     client = SubprocessBeadsClient(transport=transport)
 
     with pytest.raises(CapabilityMismatchError, match="show: issue-json"):
         _run(client.inspect_environment())
 
     assert ("bd", "show", "at-1", "--json") not in [request.argv for request in transport.requests]
+
+
+def test_decode_version_output_returns_semantic_version() -> None:
+    result = BeadsCommandResult(
+        argv=("bd", "--version"),
+        returncode=0,
+        stdout="bd version 0.56.7 (dev)",
+    )
+
+    assert decode_version_output(result) == SemanticVersion(major=0, minor=56, patch=7)
+
+
+def test_decode_help_output_normalizes_flags() -> None:
+    result = BeadsCommandResult(
+        argv=("bd", "show", "--help"),
+        returncode=0,
+        stdout="Flags:\n  -h, --help\n      --json  output\n      --json  output",
+    )
+
+    assert decode_help_output(result) == BeadsCommandHelp(
+        argv=("bd", "show", "--help"),
+        flags=("--help", "--json"),
+        supports_json_output=True,
+    )
+
+
+def test_recording_transport_records_requests() -> None:
+    transport = RecordingBeadsTransport()
+    request = BeadsCommandRequest(
+        operation=SupportedOperation.SHOW,
+        argv=("bd", "show", "at-1", "--json"),
+    )
+
+    result = _run(transport.execute(request))
+
+    assert result.argv == request.argv
+    assert transport.requests == [request]
+
+
+def test_scripted_transport_replays_sequential_outcomes() -> None:
+    responses = _probe_responses()
+    responses[("bd", "show", "at-1", "--json")] = [
+        BeadsCommandResult(
+            argv=("bd", "show", "at-1", "--json"),
+            returncode=0,
+            stdout='[{"id":"at-1","issue_type":"task"}]',
+        ),
+        BeadsCommandResult(
+            argv=("bd", "show", "at-1", "--json"),
+            returncode=0,
+            stdout='[{"id":"at-1","status":"closed","issue_type":"task"}]',
+        ),
+    ]
+    transport = ScriptedBeadsTransport(responses)
+    client = SubprocessBeadsClient(transport=transport)
+
+    first = _run(client.show(ShowIssueRequest(issue_id="at-1")))
+    second = _run(client.show(ShowIssueRequest(issue_id="at-1")))
+
+    assert (first.status, second.status) == (None, "closed")
+    assert [request.argv for request in transport.requests].count(
+        ("bd", "show", "at-1", "--json")
+    ) == 2
+
+
+def test_sync_beads_client_wraps_async_client() -> None:
+    responses = _probe_responses()
+    responses[("bd", "show", "at-1", "--json")] = BeadsCommandResult(
+        argv=("bd", "show", "at-1", "--json"),
+        returncode=0,
+        stdout='[{"id":"at-1","issue_type":"task"}]',
+    )
+    async_client = SubprocessBeadsClient(transport=ScriptedBeadsTransport(responses))
+    sync_client = SyncBeadsClient(async_client)
+
+    environment = sync_client.inspect_environment()
+    issue = sync_client.show(ShowIssueRequest(issue_id="at-1"))
+
+    assert environment.version == SemanticVersion(major=0, minor=56, patch=1)
+    assert issue.id == "at-1"


### PR DESCRIPTION
# Summary
- add a synchronous facade for the async-first Beads client
- expose typed decoders for the text-only bd environment probes
- add reusable low-level transport doubles and cover them in tests

# Changes
- add `SyncBeadsClient` and export it from the reusable Beads library surface
- normalize `bd --version` and `bd ... --help` output into typed models used by environment inspection
- add `RecordingBeadsTransport` and `ScriptedBeadsTransport` for low-level decoder and transport tests
- expand the Beads library tests for sync parity, decoder behavior, and scripted transport behavior

# Testing
- `just format`
- `just lint`
- `just test`

# Tickets
- Fixes #580

# Risks / Rollout
- low-risk library-surface addition; downstream callers can adopt the sync facade and test doubles incrementally

# Notes
- rebased onto `main` after the parent changeset PR merged so this PR contains only the current slice
