### PR TITLE
Publish the supported Beads client contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,12 @@ Command-specific details live in module docstrings under `src/atelier/commands`.
 ## Requirements
 
 - Git (for worktrees and branch operations)
-- `bd` `>= 0.51.0` on your PATH (Atelier's local planning store)
+- `bd` `>= 0.56.1` on your PATH (Atelier's local planning store)
+
+The reusable Beads client published under `atelier.lib.beads` supports a bounded
+v1 `bd` surface. See
+[docs/beads-client-contract.md](docs/beads-client-contract.md) for the supported
+command inventory, version/capability policy, and downstream adoption rules.
 
 ## Repo-Local Commit Hooks
 
@@ -591,10 +596,9 @@ Options:
 - `--new-session`: Always start a fresh planner session (skip resume lookup).
 - In an active planner session, run
   `python3 skills/planner-startup-check/scripts/refresh_overview.py` to refresh
-  the same read-only startup overview on demand.
-  This command now hardens the previously uncovered mode where projected
-  planner scripts were launched by an ambient interpreter that did not match
-  the repo dependency runtime.
+  the same read-only startup overview on demand. This command now hardens the
+  previously uncovered mode where projected planner scripts were launched by an
+  ambient interpreter that did not match the repo dependency runtime.
 
 ### `atelier open [workspace-branch] [--] [command ...]`
 

--- a/docs/beads-client-contract.md
+++ b/docs/beads-client-contract.md
@@ -1,0 +1,103 @@
+# Beads Client v1 Contract
+
+This document publishes the supported v1 contract for `atelier.lib.beads`. It
+defines the only `bd` surface the reusable client supports today, the version
+and capability bounds that gate that support, and how downstream layers are
+expected to adopt the client.
+
+## Version and Capability Policy
+
+- Minimum supported `bd` version: `0.56.1`
+- Default maximum version ceiling: none
+- Capability ceilings are allowed in `atelier.lib.beads.CompatibilityPolicy`
+  when upstream changes require an explicit fail-closed window.
+
+Environments are validated through
+`CompatibilityPolicy.assert_environment_supports(...)`.
+
+- Versions below `0.56.1` raise `UnsupportedVersionError`.
+- Missing required capabilities raise `CapabilityMismatchError`.
+- Unsupported operations raise `UnsupportedOperationError`.
+
+`inspect_environment()` is the only text-normalized escape hatch. It uses
+`bd --version` plus `bd <command> --help` probes to detect the installed version
+and supported capabilities. All other supported operations require JSON-backed
+decoding and return typed models rather than raw stdout.
+
+## Supported Command Inventory
+
+The v1 client contract is intentionally narrow. The supported operations are:
+
+| Client method | Operation id | `bd` surface | Output mode | Required
+capabilities | | --- | --- | --- | --- | --- | | `inspect_environment()` |
+`inspect-environment` | `bd --version` plus `--help` probes | `text-normalized`
+| none | | `show()` | `show` | `bd show <issue-id> --json` | `json-required` |
+`version-reporting`, `issue-json` | | `list()` | `list` | `bd list --json ...` |
+`json-required` | `version-reporting`, `issue-json` | | `ready()` | `ready` |
+`bd ready --json ...` | `json-required` | `version-reporting`, `issue-json`,
+`ready-discovery` | | `create()` | `create` | `bd create --json ...` |
+`json-required` | `version-reporting`, `issue-mutation` | | `update()` |
+`update` | `bd update <issue-id> --json ...` | `json-required` |
+`version-reporting`, `issue-mutation` | | `close()` | `close` |
+`bd close <issue-id> --json ...` | `json-required` | `version-reporting`,
+`issue-mutation` | | `add_dependency()` | `dep-add` |
+`bd dep add <issue-id> <dependency-id> --json` | `json-required` |
+`version-reporting`, `issue-json`, `dependency-mutation` | |
+`remove_dependency()` | `dep-remove` |
+`bd dep remove <issue-id> <dependency-id> --json` | `json-required` |
+`version-reporting`, `issue-json`, `dependency-mutation` |
+
+The supported capability names are:
+
+- `version-reporting`
+- `issue-json`
+- `issue-mutation`
+- `dependency-mutation`
+- `ready-discovery`
+
+Nearby `bd` commands are intentionally outside the v1 contract unless they are
+added to the typed client surface and compatibility policy. Examples of
+unsupported nearby surface area include `blocked`, `doctor`, `dolt`, `edit`,
+`prime`, `stats`, and prefix-management flows.
+
+## Downstream Adoption Rules
+
+`atelier.lib.beads.client.Beads` is the canonical downstream dependency.
+Downstream code should treat the protocol plus the shared request/response
+models and typed errors as the integration boundary.
+
+### `at-s1vc`: alternative implementation contract
+
+The in-memory implementation planned in `at-s1vc` should implement the same
+`Beads` protocol rather than exposing a parallel API.
+
+- Reuse the request/response models from `atelier.lib.beads.models`.
+- Preserve the typed error semantics from `atelier.lib.beads.errors`.
+- Support the same v1 operation inventory; do not add extra public methods that
+  bypass the shared contract.
+- Provide `inspect_environment()` results that can be validated against the same
+  `CompatibilityPolicy`, even though the transport is not subprocess backed.
+
+### `at-njpt4`: higher-level Atelier store contract
+
+The Atelier-owned store abstraction planned in `at-njpt4` should build on the
+reusable Beads client instead of reconstructing `bd` subprocess glue.
+
+- Depend on the `Beads` protocol, not directly on `SubprocessBeadsClient`.
+- Consume typed `IssueRecord` and request models instead of parsing `bd` stdout
+  or rebuilding argv.
+- Keep raw command construction, transport, and compatibility probing inside
+  `atelier.lib.beads`.
+- Use `SyncBeadsClient` only at synchronous call boundaries; keep the core
+  integration async-first where possible.
+
+## Proof Artifacts
+
+The published v1 contract is backed by a structured fixture and tests:
+
+- `tests/atelier/lib/fixtures/beads_client_contract_v1.json`
+- `tests/atelier/lib/test_beads_contract.py`
+
+Those tests fail when the documented inventory or version policy drifts from
+`DEFAULT_COMPATIBILITY_POLICY`, and they also verify that this document and the
+top-level README keep the published contract visible to downstream consumers.

--- a/tests/atelier/lib/fixtures/beads_client_contract_v1.json
+++ b/tests/atelier/lib/fixtures/beads_client_contract_v1.json
@@ -1,0 +1,112 @@
+{
+  "minimum_version": "0.56.1",
+  "maximum_version_exclusive": null,
+  "capabilities": [
+    "version-reporting",
+    "issue-json",
+    "issue-mutation",
+    "dependency-mutation",
+    "ready-discovery"
+  ],
+  "operations": [
+    {
+      "operation": "inspect-environment",
+      "method": "inspect_environment",
+      "output_mode": "text-normalized",
+      "required_capabilities": []
+    },
+    {
+      "operation": "show",
+      "method": "show",
+      "output_mode": "json-required",
+      "required_capabilities": [
+        "version-reporting",
+        "issue-json"
+      ]
+    },
+    {
+      "operation": "list",
+      "method": "list",
+      "output_mode": "json-required",
+      "required_capabilities": [
+        "version-reporting",
+        "issue-json"
+      ]
+    },
+    {
+      "operation": "ready",
+      "method": "ready",
+      "output_mode": "json-required",
+      "required_capabilities": [
+        "version-reporting",
+        "issue-json",
+        "ready-discovery"
+      ]
+    },
+    {
+      "operation": "create",
+      "method": "create",
+      "output_mode": "json-required",
+      "required_capabilities": [
+        "version-reporting",
+        "issue-mutation"
+      ]
+    },
+    {
+      "operation": "update",
+      "method": "update",
+      "output_mode": "json-required",
+      "required_capabilities": [
+        "version-reporting",
+        "issue-mutation"
+      ]
+    },
+    {
+      "operation": "close",
+      "method": "close",
+      "output_mode": "json-required",
+      "required_capabilities": [
+        "version-reporting",
+        "issue-mutation"
+      ]
+    },
+    {
+      "operation": "dep-add",
+      "method": "add_dependency",
+      "output_mode": "json-required",
+      "required_capabilities": [
+        "version-reporting",
+        "issue-json",
+        "dependency-mutation"
+      ]
+    },
+    {
+      "operation": "dep-remove",
+      "method": "remove_dependency",
+      "output_mode": "json-required",
+      "required_capabilities": [
+        "version-reporting",
+        "issue-json",
+        "dependency-mutation"
+      ]
+    }
+  ],
+  "unsupported_surface": [
+    "blocked",
+    "doctor",
+    "dolt",
+    "edit",
+    "prime",
+    "stats"
+  ],
+  "downstream_contract": {
+    "at-s1vc": {
+      "role": "Alternative implementation",
+      "rule": "Implement the Beads protocol and reuse the shared models and typed errors."
+    },
+    "at-njpt4": {
+      "role": "Higher-level Atelier store abstraction",
+      "rule": "Build on the Beads protocol and typed models instead of reconstructing bd subprocess glue."
+    }
+  }
+}

--- a/tests/atelier/lib/test_beads_contract.py
+++ b/tests/atelier/lib/test_beads_contract.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TypedDict
+
+from atelier.lib.beads import DEFAULT_COMPATIBILITY_POLICY, SupportedOperation
+
+FIXTURES_DIR = Path(__file__).resolve().parent / "fixtures"
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONTRACT_FIXTURE_PATH = FIXTURES_DIR / "beads_client_contract_v1.json"
+CONTRACT_DOC_PATH = REPO_ROOT / "docs" / "beads-client-contract.md"
+README_PATH = REPO_ROOT / "README.md"
+
+_OPERATION_METHODS = {
+    SupportedOperation.INSPECT_ENVIRONMENT: "inspect_environment",
+    SupportedOperation.SHOW: "show",
+    SupportedOperation.LIST: "list",
+    SupportedOperation.READY: "ready",
+    SupportedOperation.CREATE: "create",
+    SupportedOperation.UPDATE: "update",
+    SupportedOperation.CLOSE: "close",
+    SupportedOperation.DEPENDENCY_ADD: "add_dependency",
+    SupportedOperation.DEPENDENCY_REMOVE: "remove_dependency",
+}
+
+
+class OperationFixture(TypedDict):
+    operation: str
+    method: str
+    output_mode: str
+    required_capabilities: list[str]
+
+
+class DownstreamContractFixture(TypedDict):
+    role: str
+    rule: str
+
+
+class ContractFixture(TypedDict):
+    minimum_version: str
+    maximum_version_exclusive: str | None
+    capabilities: list[str]
+    operations: list[OperationFixture]
+    unsupported_surface: list[str]
+    downstream_contract: dict[str, DownstreamContractFixture]
+
+
+def _load_contract_fixture() -> ContractFixture:
+    return json.loads(CONTRACT_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+
+def test_beads_contract_fixture_matches_default_policy() -> None:
+    payload = _load_contract_fixture()
+
+    assert payload["minimum_version"] == str(DEFAULT_COMPATIBILITY_POLICY.minimum_version)
+    assert payload["maximum_version_exclusive"] is None
+    assert payload["capabilities"] == [
+        rule.capability.value for rule in DEFAULT_COMPATIBILITY_POLICY.capability_rules
+    ]
+    assert payload["operations"] == [
+        {
+            "operation": contract.operation.value,
+            "method": _OPERATION_METHODS[contract.operation],
+            "output_mode": contract.output_mode.value,
+            "required_capabilities": [
+                capability.value for capability in contract.required_capabilities
+            ],
+        }
+        for contract in DEFAULT_COMPATIBILITY_POLICY.operations
+    ]
+
+
+def test_contract_doc_publishes_supported_inventory_and_downstream_rules() -> None:
+    payload = _load_contract_fixture()
+    content = CONTRACT_DOC_PATH.read_text(encoding="utf-8")
+
+    assert "Beads Client v1 Contract" in content
+    assert payload["minimum_version"] in content
+    for operation in payload["operations"]:
+        assert operation["operation"] in content
+        assert operation["method"] in content
+    for unsupported_command in payload["unsupported_surface"]:
+        assert unsupported_command in content
+    for downstream_id in payload["downstream_contract"]:
+        assert downstream_id in content
+
+
+def test_readme_points_to_the_published_beads_contract() -> None:
+    content = README_PATH.read_text(encoding="utf-8")
+
+    assert "`bd` `>= 0.56.1`" in content
+    assert "docs/beads-client-contract.md" in content


### PR DESCRIPTION
# Summary

- Publish the supported v1 Beads client contract so downstream layers have a stable boundary for supported `bd` operations.

# Changes

- Add `docs/beads-client-contract.md` with the supported operation inventory, version/capability policy, unsupported nearby `bd` surface, and downstream adoption rules.
- Add `tests/atelier/lib/fixtures/beads_client_contract_v1.json` and `tests/atelier/lib/test_beads_contract.py` to lock the published contract to `DEFAULT_COMPATIBILITY_POLICY`.
- Update `README.md` to point readers at the Beads client contract and align the documented minimum `bd` version with the implemented policy.

# Testing

- `bash scripts/supported-python.sh run --extra dev pytest ./tests/atelier/lib/test_beads.py ./tests/atelier/lib/test_beads_contract.py`
- `bash scripts/supported-python.sh run --extra dev ruff check ./README.md ./docs/beads-client-contract.md ./tests/atelier/lib/test_beads_contract.py`
- `just format`
- `just lint`
- `just test`

# Tickets

- Fixes #581

# Risks / Rollout

- Low risk because this slice is documentation and test coverage only.
- Future contract drift should be caught by the new fixture-backed Beads contract test.

# Notes

- This PR targets `main` because the previous stacked changeset is already merged.
