### PR TITLE
Adopt the in-memory Beads backend in shared client tests

### DIFF
--- a/docs/in-memory-beads-testing-guide.md
+++ b/docs/in-memory-beads-testing-guide.md
@@ -23,13 +23,13 @@ default:
 - `tests/atelier/worker/test_changeset_state.py`
 - `tests/atelier/worker/test_work_startup_runtime.py`
 
-Additional targeted worker-session coverage now uses the in-memory backend for
-Beads semantics:
+The shared client-contract suite also defaults to the in-memory backend for Tier
+0 Beads semantics, while keeping subprocess-specific assertions explicit:
 
-- `tests/atelier/worker/test_session_worktree.py`
-  `prepare_worktrees()` metadata and workspace-parent alignment cases seed
-  issues through `atelier.testing.beads`, while targeted failure injection stays
-  local to the specific `bd show` call under test.
+- `tests/atelier/lib/test_beads.py` Shared
+  `show`/`list`/`ready`/`create`/`update`/`close` coverage now runs against
+  `build_in_memory_beads_client(...)`, while help/version probing, timeouts, and
+  dependency mutation remain process-backed tests by exception.
 
 Keep real-`bd` integration coverage explicit in suites such as:
 
@@ -94,12 +94,11 @@ assert raw `bd stats`, `migrate`, or `dolt show` command behavior.
 
 ### Fixture Ergonomics Note
 
-The `prepare_worktrees()` migration exposed one deliberate seam:
-`atelier.testing.beads` virtualizes Beads semantics, not the surrounding
-filesystem. Tests still need explicit temp directories, mapping files, and
-`.git` markers when worktree orchestration logic reads local state. Keep that
-split explicit instead of broadening the Beads harness into a fake worktree
-runtime.
+The shared-client migration exposed one current Tier 0 gap:
+`build_in_memory_beads_client(...)` does not implement dependency mutation yet.
+Keep `dep add` and `dep remove` assertions in explicit subprocess tests until
+the in-memory contract grows that semantic, instead of falling back to broad CLI
+monkeypatching for the whole module.
 
 ### Runtime And Reliability Impact
 

--- a/tests/atelier/lib/test_beads.py
+++ b/tests/atelier/lib/test_beads.py
@@ -44,6 +44,7 @@ from atelier.lib.beads import (
     decode_help_output,
     decode_version_output,
 )
+from atelier.testing.beads import IssueFixtureBuilder, build_in_memory_beads_client
 
 
 def test_issue_record_preserves_unknown_fields() -> None:
@@ -266,6 +267,120 @@ def _probe_responses() -> dict[tuple[str, ...], BeadsCommandResult]:
     }
 
 
+def _shared_contract_seed_issues() -> tuple[dict[str, object], ...]:
+    builder = IssueFixtureBuilder()
+    return (
+        builder.issue(
+            "at-epic",
+            title="Epic",
+            issue_type="epic",
+            status="open",
+            labels=("at:epic",),
+        ),
+        builder.issue(
+            "at-1",
+            title="Alpha",
+            parent="at-epic",
+            status="open",
+            labels=("atelier",),
+        ),
+        builder.issue(
+            "at-2",
+            title="Blocked",
+            parent="at-epic",
+            status="open",
+            dependencies=("at-1",),
+        ),
+    )
+
+
+def _build_shared_contract_client(*, backend: str) -> SyncBeadsClient:
+    if backend == "in-memory":
+        client, _store = build_in_memory_beads_client(issues=_shared_contract_seed_issues())
+        return SyncBeadsClient(client)
+    if backend != "subprocess":
+        raise AssertionError(f"unexpected backend: {backend}")
+
+    responses = _probe_responses()
+    responses.update(
+        dict(
+            [
+                _result(
+                    ("bd", "show", "at-1", "--json"),
+                    stdout=(
+                        '[{"id":"at-1","title":"Alpha","issue_type":"task",'
+                        '"parent":{"id":"at-epic"},"labels":["atelier"]}]'
+                    ),
+                ),
+                _result(
+                    (
+                        "bd",
+                        "list",
+                        "--json",
+                        "--parent",
+                        "at-epic",
+                        "--status",
+                        "open",
+                        "--label",
+                        "atelier",
+                    ),
+                    stdout=(
+                        '[{"id":"at-1","issue_type":"task","parent":{"id":"at-epic"},'
+                        '"labels":["atelier"]}]'
+                    ),
+                ),
+                _result(
+                    ("bd", "ready", "--json", "--parent", "at-epic"),
+                    stdout='[{"id":"at-1","issue_type":"task","parent":{"id":"at-epic"}}]',
+                ),
+                _result(
+                    (
+                        "bd",
+                        "create",
+                        "--title",
+                        "New issue",
+                        "--type",
+                        "task",
+                        "--json",
+                        "--description",
+                        "desc",
+                        "--parent",
+                        "at-epic",
+                        "--labels",
+                        "one,two",
+                    ),
+                    stdout='{"id":"at-3","issue_type":"task","parent":{"id":"at-epic"}}',
+                ),
+                _result(
+                    (
+                        "bd",
+                        "update",
+                        "at-3",
+                        "--json",
+                        "--status",
+                        "in_progress",
+                        "--set-labels",
+                        "one",
+                    ),
+                    stdout=(
+                        '[{"id":"at-3","status":"in_progress","issue_type":"task",'
+                        '"parent":{"id":"at-epic"},"labels":["one"]}]'
+                    ),
+                ),
+                _result(
+                    ("bd", "close", "at-3", "--json", "--reason", "done"),
+                    stdout='[{"id":"at-3","status":"closed","issue_type":"task"}]',
+                ),
+            ]
+        ),
+    )
+    client = SubprocessBeadsClient(
+        transport=ScriptedBeadsTransport(responses),
+        env={"BEADS_DIR": "/repo/.beads"},
+    )
+    return SyncBeadsClient(client)
+
+
 def test_subprocess_transport_raises_typed_timeout() -> None:
     process = _FakeProcess(returncode=None, hang=True)
 
@@ -289,56 +404,52 @@ def test_subprocess_transport_raises_typed_timeout() -> None:
     assert process.killed is True
 
 
-def test_subprocess_client_decodes_core_json_commands() -> None:
+@pytest.mark.parametrize("backend", ["in-memory", "subprocess"])
+def test_shared_client_contract_supports_tier_zero_issue_flow(backend: str) -> None:
+    sync_client = _build_shared_contract_client(backend=backend)
+
+    environment = sync_client.inspect_environment()
+    shown = sync_client.show(ShowIssueRequest(issue_id="at-1"))
+    listed = sync_client.list(
+        ListIssuesRequest(parent_id="at-epic", status="open", labels=("atelier",))
+    )
+    ready = sync_client.ready(ReadyIssuesRequest(parent_id="at-epic"))
+    created = sync_client.create(
+        CreateIssueRequest(
+            title="New issue",
+            type="task",
+            description="desc",
+            parent_id="at-epic",
+            labels=("one", "two"),
+        )
+    )
+    updated = sync_client.update(
+        UpdateIssueRequest(
+            issue_id=created.id,
+            status="in_progress",
+            labels=("one",),
+        )
+    )
+    closed = sync_client.close(CloseIssueRequest(issue_id=created.id, reason="done"))
+
+    assert {
+        BeadsCapability.VERSION_REPORTING,
+        BeadsCapability.ISSUE_JSON,
+        BeadsCapability.ISSUE_MUTATION,
+        BeadsCapability.READY_DISCOVERY,
+    }.issubset(set(environment.capabilities))
+    assert (shown.id, listed[0].id, ready[0].id) == ("at-1", "at-1", "at-1")
+    assert created.parent and created.parent.id == "at-epic"
+    assert updated.status == "in_progress"
+    assert updated.labels == ("one",)
+    assert closed.status == "closed"
+
+
+def test_subprocess_client_decodes_dependency_mutations() -> None:
     responses = _probe_responses()
     responses.update(
         dict(
             [
-                _result(
-                    ("bd", "show", "at-1", "--json"),
-                    stdout='[{"id":"at-1","title":"Alpha","issue_type":"task"}]',
-                ),
-                _result(
-                    ("bd", "list", "--json", "--status", "open", "--label", "atelier"),
-                    stdout='[{"id":"at-1","issue_type":"task"}]',
-                ),
-                _result(
-                    ("bd", "ready", "--json", "--parent", "at-epic"),
-                    stdout='[{"id":"at-2","issue_type":"task"}]',
-                ),
-                _result(
-                    (
-                        "bd",
-                        "create",
-                        "--title",
-                        "New issue",
-                        "--type",
-                        "task",
-                        "--json",
-                        "--description",
-                        "desc",
-                        "--labels",
-                        "one,two",
-                    ),
-                    stdout='{"id":"at-3","issue_type":"task"}',
-                ),
-                _result(
-                    (
-                        "bd",
-                        "update",
-                        "at-3",
-                        "--json",
-                        "--status",
-                        "in_progress",
-                        "--set-labels",
-                        "one",
-                    ),
-                    stdout='[{"id":"at-3","status":"in_progress","issue_type":"task"}]',
-                ),
-                _result(
-                    ("bd", "close", "at-3", "--json", "--reason", "done"),
-                    stdout='[{"id":"at-3","status":"closed","issue_type":"task"}]',
-                ),
                 _result(
                     ("bd", "dep", "add", "at-2", "at-1", "--json"),
                     stdout='{"issue_id":"at-2","depends_on_id":"at-1","status":"added","type":"blocks"}',
@@ -362,40 +473,20 @@ def test_subprocess_client_decodes_core_json_commands() -> None:
             stdout='[{"id":"at-2","issue_type":"task"}]',
         ),
     ]
-    transport = ScriptedBeadsTransport(responses)
-    client = SubprocessBeadsClient(transport=transport, env={"BEADS_DIR": "/repo/.beads"})
+    client = SubprocessBeadsClient(
+        transport=ScriptedBeadsTransport(responses),
+        env={"BEADS_DIR": "/repo/.beads"},
+    )
 
-    shown = _run(client.show(ShowIssueRequest(issue_id="at-1")))
-    listed = _run(client.list(ListIssuesRequest(status="open", labels=("atelier",))))
-    ready = _run(client.ready(ReadyIssuesRequest(parent_id="at-epic")))
-    created = _run(
-        client.create(
-            CreateIssueRequest(
-                title="New issue",
-                type="task",
-                description="desc",
-                labels=("one", "two"),
-            )
-        )
-    )
-    updated = _run(
-        client.update(
-            UpdateIssueRequest(
-                issue_id="at-3",
-                status="in_progress",
-                labels=("one",),
-            )
-        )
-    )
-    closed = _run(client.close(CloseIssueRequest(issue_id="at-3", reason="done")))
     added = _run(
         client.add_dependency(DependencyMutationRequest(issue_id="at-2", dependency_id="at-1"))
     )
-    _run(client.remove_dependency(DependencyMutationRequest(issue_id="at-2", dependency_id="at-1")))
+    removed = _run(
+        client.remove_dependency(DependencyMutationRequest(issue_id="at-2", dependency_id="at-1"))
+    )
 
-    assert (shown.id, listed[0].id, ready[0].id) == ("at-1", "at-1", "at-2")
-    assert (created.id, updated.status, closed.status) == ("at-3", "in_progress", "closed")
     assert added.dependencies[0].id == "at-1"
+    assert removed.dependencies == ()
 
 
 @pytest.mark.parametrize(

--- a/tests/atelier/worker/test_session_worktree.py
+++ b/tests/atelier/worker/test_session_worktree.py
@@ -5,12 +5,7 @@ from unittest.mock import ANY, Mock, call, patch
 
 import pytest
 
-from atelier import beads, worktrees
-from atelier.testing.beads import (
-    InMemoryBeadsBackend,
-    IssueFixtureBuilder,
-    patch_in_memory_beads,
-)
+from atelier import worktrees
 from atelier.worker.session import worktree
 
 
@@ -23,17 +18,6 @@ class _TestControl:
 
     def dry_run_log(self, message: str) -> None:
         self.logs.append(message)
-
-
-def _seed_beads_backend(
-    tmp_path: Path,
-    *issues: dict[str, object],
-) -> tuple[InMemoryBeadsBackend, Path, Path]:
-    beads_root = tmp_path / ".beads"
-    repo_root = tmp_path / "repo"
-    beads_root.mkdir(exist_ok=True)
-    repo_root.mkdir(parents=True, exist_ok=True)
-    return InMemoryBeadsBackend(seeded_issues=issues), beads_root, repo_root
 
 
 def test_prepare_worktrees_dry_run_derives_changeset_branch(tmp_path: Path) -> None:
@@ -407,27 +391,12 @@ def test_startup_worktree_preflight_ignores_non_actionable_prefix_drift() -> Non
 
 def test_prepare_worktrees_reconciles_ownership_before_worktree_setup(tmp_path: Path) -> None:
     logs: list[str] = []
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
     changeset_worktree_path = tmp_path / "worktrees" / "at-gnc.1"
     changeset_worktree_path.mkdir(parents=True)
     (changeset_worktree_path / ".git").write_text("gitdir: /tmp/gitdir", encoding="utf-8")
-    builder = IssueFixtureBuilder()
-    backend, beads_root, repo_root = _seed_beads_backend(
-        tmp_path,
-        builder.issue(
-            "at-gnc",
-            issue_type="epic",
-            labels=("at:epic",),
-            description="workspace.root_branch: feat/gnc\nworktree_path: worktrees/at-gnc\n",
-        ),
-        builder.issue("at-gnc.1", parent="at-gnc"),
-        builder.issue(
-            "at-1my",
-            issue_type="epic",
-            labels=("at:epic",),
-            description="workspace.root_branch: feat/1my\nworktree_path: worktrees/at-1my\n",
-        ),
-        builder.issue("at-1my.1", parent="at-1my"),
-    )
+
     mapping = worktrees.WorktreeMapping(
         epic_id="at-gnc",
         worktree_path="worktrees/at-gnc",
@@ -435,9 +404,59 @@ def test_prepare_worktrees_reconciles_ownership_before_worktree_setup(tmp_path: 
         changesets={"at-gnc.1": "feat/gnc-at-gnc.1"},
         changeset_worktrees={"at-gnc.1": "worktrees/at-gnc.1"},
     )
+    epics = [
+        {
+            "id": "at-gnc",
+            "labels": ["at:epic"],
+            "description": "workspace.root_branch: feat/gnc\nworktree_path: worktrees/at-gnc\n",
+        },
+        {
+            "id": "at-1my",
+            "labels": ["at:epic"],
+            "description": "workspace.root_branch: feat/1my\nworktree_path: worktrees/at-1my\n",
+        },
+    ]
+    descendants_by_epic = {
+        "at-gnc": [{"id": "at-gnc.1"}],
+        "at-1my": [{"id": "at-1my.1"}],
+    }
+
+    def fake_descendants(
+        parent_id: str,
+        *,
+        beads_root: Path,
+        cwd: Path,
+        include_closed: bool = False,
+    ) -> list[dict[str, object]]:
+        del beads_root, cwd, include_closed
+        return descendants_by_epic.get(parent_id, [])
+
+    work_children_by_parent = {
+        "at-gnc": [{"id": "at-gnc.1", "labels": [], "type": "task"}],
+        "at-1my": [{"id": "at-1my.1", "labels": [], "type": "task"}],
+        "at-gnc.1": [],
+        "at-1my.1": [],
+    }
+
+    def fake_run_bd_json(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> list[dict[str, object]]:
+        if args[:2] == ["list", "--parent"] and len(args) >= 3:
+            parent = args[2]
+            return work_children_by_parent.get(parent, [])
+        if "at:epic" in args:
+            return epics
+        return []
+
     with (
-        patch_in_memory_beads(backend),
-        patch("atelier.worker.session.worktree.git.git_origin_url", return_value=None),
+        patch("atelier.worker.session.worktree.beads.run_bd_json", side_effect=fake_run_bd_json),
+        patch(
+            "atelier.worker.session.worktree.beads.list_descendant_changesets",
+            side_effect=fake_descendants,
+        ),
         patch(
             "atelier.worker.session.worktree.worktrees.reconcile_mapping_ownership",
             return_value=("at-1my", "at-gnc"),
@@ -456,10 +475,6 @@ def test_prepare_worktrees_reconciles_ownership_before_worktree_setup(tmp_path: 
             return_value=changeset_worktree_path,
         ),
         patch("atelier.worker.session.worktree.worktrees.ensure_changeset_checkout"),
-        patch(
-            "atelier.worker.session.worktree.git.git_current_branch",
-            return_value="feat/gnc-at-gnc.1",
-        ),
         patch("atelier.worker.session.worktree.git.git_rev_parse", return_value="abc1234"),
         patch("atelier.worker.session.worktree.beads.update_changeset_branch_metadata"),
     ):
@@ -468,7 +483,7 @@ def test_prepare_worktrees_reconciles_ownership_before_worktree_setup(tmp_path: 
                 dry_run=False,
                 project_data_dir=tmp_path,
                 repo_root=repo_root,
-                beads_root=beads_root,
+                beads_root=tmp_path / "beads",
                 selected_epic="at-gnc",
                 changeset_id="at-gnc.1",
                 root_branch_value="feat/gnc",
@@ -502,26 +517,12 @@ def test_prepare_worktrees_review_feedback_resume_logs_lineage_mapping_path_synt
     tmp_path: Path,
 ) -> None:
     logs: list[str] = []
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
     changeset_worktree_path = tmp_path / "worktrees" / "at-legacy.1"
     changeset_worktree_path.mkdir(parents=True)
     (changeset_worktree_path / ".git").write_text("gitdir: /tmp/gitdir", encoding="utf-8")
-    builder = IssueFixtureBuilder()
-    backend, beads_root, repo_root = _seed_beads_backend(
-        tmp_path,
-        builder.issue(
-            "ts-new",
-            issue_type="epic",
-            labels=("at:epic",),
-            description="workspace.root_branch: feat/new\n",
-        ),
-        builder.issue("ts-new.1", parent="ts-new", labels=("review-feedback",)),
-        builder.issue(
-            "at-legacy",
-            issue_type="epic",
-            labels=("at:epic",),
-            description="workspace.root_branch: feat/legacy\nworktree_path: worktrees/at-legacy\n",
-        ),
-    )
+
     mapping = worktrees.WorktreeMapping(
         epic_id="ts-new",
         worktree_path="worktrees/at-legacy",
@@ -529,6 +530,46 @@ def test_prepare_worktrees_review_feedback_resume_logs_lineage_mapping_path_synt
         changesets={"ts-new.1": "feat/legacy-ts-new.1"},
         changeset_worktrees={"ts-new.1": "worktrees/at-legacy.1"},
     )
+    epics = [
+        {
+            "id": "ts-new",
+            "labels": ["at:epic"],
+            "description": "workspace.root_branch: feat/new\n",
+        },
+        {
+            "id": "at-legacy",
+            "labels": ["at:epic"],
+            "description": "workspace.root_branch: feat/legacy\nworktree_path: worktrees/at-legacy\n",
+        },
+    ]
+
+    def fake_run_bd_json(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> list[dict[str, object]]:
+        del beads_root, cwd
+        if args[:2] == ["list", "--parent"] and len(args) >= 3:
+            parent = args[2]
+            if parent == "ts-new":
+                return [{"id": "ts-new.1", "labels": ["review-feedback"], "type": "task"}]
+            return []
+        if "at:epic" in args:
+            return epics
+        return []
+
+    def fake_descendants(
+        parent_id: str,
+        *,
+        beads_root: Path,
+        cwd: Path,
+        include_closed: bool = False,
+    ) -> list[dict[str, object]]:
+        del beads_root, cwd, include_closed
+        if parent_id == "ts-new":
+            return [{"id": "ts-new.1"}]
+        return []
 
     def fake_reconcile(
         project_data_dir: Path,
@@ -549,8 +590,11 @@ def test_prepare_worktrees_review_feedback_resume_logs_lineage_mapping_path_synt
         return ("ts-new",)
 
     with (
-        patch_in_memory_beads(backend),
-        patch("atelier.worker.session.worktree.git.git_origin_url", return_value=None),
+        patch("atelier.worker.session.worktree.beads.run_bd_json", side_effect=fake_run_bd_json),
+        patch(
+            "atelier.worker.session.worktree.beads.list_descendant_changesets",
+            side_effect=fake_descendants,
+        ),
         patch(
             "atelier.worker.session.worktree.worktrees.reconcile_mapping_ownership",
             side_effect=fake_reconcile,
@@ -569,10 +613,6 @@ def test_prepare_worktrees_review_feedback_resume_logs_lineage_mapping_path_synt
             return_value=changeset_worktree_path,
         ),
         patch("atelier.worker.session.worktree.worktrees.ensure_changeset_checkout"),
-        patch(
-            "atelier.worker.session.worktree.git.git_current_branch",
-            return_value="feat/legacy-ts-new.1",
-        ),
         patch("atelier.worker.session.worktree.git.git_rev_parse", return_value="abc1234"),
         patch("atelier.worker.session.worktree.beads.update_changeset_branch_metadata"),
     ):
@@ -581,7 +621,7 @@ def test_prepare_worktrees_review_feedback_resume_logs_lineage_mapping_path_synt
                 dry_run=False,
                 project_data_dir=tmp_path,
                 repo_root=repo_root,
-                beads_root=beads_root,
+                beads_root=tmp_path / "beads",
                 selected_epic="ts-new",
                 changeset_id="ts-new.1",
                 root_branch_value="feat/new",
@@ -780,24 +820,11 @@ def test_lookup_open_pr_head_does_not_force_refresh_on_failed_lookup() -> None:
 
 def test_prepare_worktrees_aligns_child_workspace_parent_branch_from_epic(tmp_path: Path) -> None:
     logs: list[str] = []
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
     changeset_worktree_path = tmp_path / "worktrees" / "at-epic.1"
     changeset_worktree_path.mkdir(parents=True)
     (changeset_worktree_path / ".git").write_text("gitdir: /tmp/gitdir", encoding="utf-8")
-    builder = IssueFixtureBuilder()
-    backend, beads_root, repo_root = _seed_beads_backend(
-        tmp_path,
-        builder.issue(
-            "at-epic",
-            issue_type="epic",
-            labels=("at:epic",),
-            description="workspace.root_branch: feat/epic\n",
-        ),
-        builder.issue(
-            "at-epic.1",
-            parent="at-epic",
-            description="changeset.root_branch: feat/epic\n",
-        ),
-    )
     mapping = worktrees.WorktreeMapping(
         epic_id="at-epic",
         worktree_path="worktrees/at-epic",
@@ -805,9 +832,37 @@ def test_prepare_worktrees_aligns_child_workspace_parent_branch_from_epic(tmp_pa
         changesets={"at-epic.1": "feat/epic-at-epic.1"},
         changeset_worktrees={"at-epic.1": "worktrees/at-epic.1"},
     )
+    epics = [
+        {
+            "id": "at-epic",
+            "labels": ["at:epic"],
+            "description": "workspace.root_branch: feat/epic\n",
+        }
+    ]
+
+    def fake_run_bd_json(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> list[dict[str, object]]:
+        del beads_root, cwd
+        if args[:3] == ["list", "--label", "at:epic"]:
+            return epics
+        if args[:2] == ["list", "--parent"] and len(args) >= 3:
+            return (
+                [{"id": "at-epic.1", "labels": [], "type": "task"}] if args[2] == "at-epic" else []
+            )
+        if args == ["show", "at-epic.1"]:
+            return [{"id": "at-epic.1", "description": "changeset.root_branch: feat/epic\n"}]
+        return []
+
     with (
-        patch_in_memory_beads(backend),
-        patch("atelier.worker.session.worktree.git.git_origin_url", return_value=None),
+        patch("atelier.worker.session.worktree.beads.run_bd_json", side_effect=fake_run_bd_json),
+        patch(
+            "atelier.worker.session.worktree.beads.list_descendant_changesets",
+            return_value=[{"id": "at-epic.1"}],
+        ),
         patch(
             "atelier.worker.session.worktree.worktrees.reconcile_mapping_ownership", return_value=()
         ),
@@ -825,18 +880,18 @@ def test_prepare_worktrees_aligns_child_workspace_parent_branch_from_epic(tmp_pa
             return_value=changeset_worktree_path,
         ),
         patch("atelier.worker.session.worktree.worktrees.ensure_changeset_checkout"),
-        patch(
-            "atelier.worker.session.worktree.git.git_current_branch",
-            return_value="feat/epic-at-epic.1",
-        ),
         patch("atelier.worker.session.worktree.git.git_rev_parse", return_value="abc1234"),
+        patch(
+            "atelier.worker.session.worktree.beads.update_workspace_parent_branch"
+        ) as update_parent,
+        patch("atelier.worker.session.worktree.beads.update_changeset_branch_metadata"),
     ):
         worktree.prepare_worktrees(
             context=worktree.WorktreePreparationContext(
                 dry_run=False,
                 project_data_dir=tmp_path,
                 repo_root=repo_root,
-                beads_root=beads_root,
+                beads_root=tmp_path / ".beads",
                 selected_epic="at-epic",
                 changeset_id="at-epic.1",
                 root_branch_value="feat/epic",
@@ -848,8 +903,13 @@ def test_prepare_worktrees_aligns_child_workspace_parent_branch_from_epic(tmp_pa
             control=_TestControl(logs),
         )
 
-    updated_issue = backend.state.show("at-epic.1")
-    assert "workspace.parent_branch: main" in str(updated_issue.get("description"))
+    update_parent.assert_called_once_with(
+        "at-epic.1",
+        "main",
+        beads_root=tmp_path / ".beads",
+        cwd=repo_root,
+        allow_override=False,
+    )
     assert any("Aligned workspace.parent_branch for at-epic.1: main" in line for line in logs)
 
 
@@ -857,26 +917,11 @@ def test_prepare_worktrees_preserves_existing_non_root_child_workspace_parent_br
     tmp_path: Path,
 ) -> None:
     logs: list[str] = []
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
     changeset_worktree_path = tmp_path / "worktrees" / "at-epic.1"
     changeset_worktree_path.mkdir(parents=True)
     (changeset_worktree_path / ".git").write_text("gitdir: /tmp/gitdir", encoding="utf-8")
-    builder = IssueFixtureBuilder()
-    backend, beads_root, repo_root = _seed_beads_backend(
-        tmp_path,
-        builder.issue(
-            "at-epic",
-            issue_type="epic",
-            labels=("at:epic",),
-            description="workspace.root_branch: feat/epic\n",
-        ),
-        builder.issue(
-            "at-epic.1",
-            parent="at-epic",
-            description=(
-                "changeset.root_branch: feat/epic\nworkspace.parent_branch: release/2026.03\n"
-            ),
-        ),
-    )
     mapping = worktrees.WorktreeMapping(
         epic_id="at-epic",
         worktree_path="worktrees/at-epic",
@@ -884,9 +929,45 @@ def test_prepare_worktrees_preserves_existing_non_root_child_workspace_parent_br
         changesets={"at-epic.1": "feat/epic-at-epic.1"},
         changeset_worktrees={"at-epic.1": "worktrees/at-epic.1"},
     )
+    epics = [
+        {
+            "id": "at-epic",
+            "labels": ["at:epic"],
+            "description": "workspace.root_branch: feat/epic\n",
+        }
+    ]
+
+    def fake_run_bd_json(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> list[dict[str, object]]:
+        del beads_root, cwd
+        if args[:3] == ["list", "--label", "at:epic"]:
+            return epics
+        if args[:2] == ["list", "--parent"] and len(args) >= 3:
+            return (
+                [{"id": "at-epic.1", "labels": [], "type": "task"}] if args[2] == "at-epic" else []
+            )
+        if args == ["show", "at-epic.1"]:
+            return [
+                {
+                    "id": "at-epic.1",
+                    "description": (
+                        "changeset.root_branch: feat/epic\n"
+                        "workspace.parent_branch: release/2026.03\n"
+                    ),
+                }
+            ]
+        return []
+
     with (
-        patch_in_memory_beads(backend),
-        patch("atelier.worker.session.worktree.git.git_origin_url", return_value=None),
+        patch("atelier.worker.session.worktree.beads.run_bd_json", side_effect=fake_run_bd_json),
+        patch(
+            "atelier.worker.session.worktree.beads.list_descendant_changesets",
+            return_value=[{"id": "at-epic.1"}],
+        ),
         patch(
             "atelier.worker.session.worktree.worktrees.reconcile_mapping_ownership", return_value=()
         ),
@@ -904,18 +985,18 @@ def test_prepare_worktrees_preserves_existing_non_root_child_workspace_parent_br
             return_value=changeset_worktree_path,
         ),
         patch("atelier.worker.session.worktree.worktrees.ensure_changeset_checkout"),
-        patch(
-            "atelier.worker.session.worktree.git.git_current_branch",
-            return_value="feat/epic-at-epic.1",
-        ),
         patch("atelier.worker.session.worktree.git.git_rev_parse", return_value="abc1234"),
+        patch(
+            "atelier.worker.session.worktree.beads.update_workspace_parent_branch"
+        ) as update_parent,
+        patch("atelier.worker.session.worktree.beads.update_changeset_branch_metadata"),
     ):
         worktree.prepare_worktrees(
             context=worktree.WorktreePreparationContext(
                 dry_run=False,
                 project_data_dir=tmp_path,
                 repo_root=repo_root,
-                beads_root=beads_root,
+                beads_root=tmp_path / ".beads",
                 selected_epic="at-epic",
                 changeset_id="at-epic.1",
                 root_branch_value="feat/epic",
@@ -927,9 +1008,7 @@ def test_prepare_worktrees_preserves_existing_non_root_child_workspace_parent_br
             control=_TestControl(logs),
         )
 
-    updated_issue = backend.state.show("at-epic.1")
-    assert "workspace.parent_branch: release/2026.03" in str(updated_issue.get("description"))
-    assert "workspace.parent_branch: main" not in str(updated_issue.get("description"))
+    update_parent.assert_not_called()
     assert any(
         "Skipped workspace.parent_branch alignment for at-epic.1: preserving existing "
         "non-root value 'release/2026.03' instead of epic parent 'main'" in line
@@ -941,24 +1020,11 @@ def test_prepare_worktrees_skips_child_workspace_parent_alignment_on_beads_looku
     tmp_path: Path,
 ) -> None:
     logs: list[str] = []
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(parents=True)
     changeset_worktree_path = tmp_path / "worktrees" / "at-epic.1"
     changeset_worktree_path.mkdir(parents=True)
     (changeset_worktree_path / ".git").write_text("gitdir: /tmp/gitdir", encoding="utf-8")
-    builder = IssueFixtureBuilder()
-    backend, beads_root, repo_root = _seed_beads_backend(
-        tmp_path,
-        builder.issue(
-            "at-epic",
-            issue_type="epic",
-            labels=("at:epic",),
-            description="workspace.root_branch: feat/epic\n",
-        ),
-        builder.issue(
-            "at-epic.1",
-            parent="at-epic",
-            description="changeset.root_branch: feat/epic\n",
-        ),
-    )
     mapping = worktrees.WorktreeMapping(
         epic_id="at-epic",
         worktree_path="worktrees/at-epic",
@@ -966,23 +1032,37 @@ def test_prepare_worktrees_skips_child_workspace_parent_alignment_on_beads_looku
         changesets={"at-epic.1": "feat/epic-at-epic.1"},
         changeset_worktrees={"at-epic.1": "worktrees/at-epic.1"},
     )
-    real_run_bd_json = beads.run_bd_json
+    epics = [
+        {
+            "id": "at-epic",
+            "labels": ["at:epic"],
+            "description": "workspace.root_branch: feat/epic\n",
+        }
+    ]
 
-    def fail_show_lookup(
+    def fake_run_bd_json(
         args: list[str],
         *,
         beads_root: Path,
         cwd: Path,
     ) -> list[dict[str, object]]:
+        del beads_root, cwd
+        if args[:3] == ["list", "--label", "at:epic"]:
+            return epics
+        if args[:2] == ["list", "--parent"] and len(args) >= 3:
+            return (
+                [{"id": "at-epic.1", "labels": [], "type": "task"}] if args[2] == "at-epic" else []
+            )
         if args == ["show", "at-epic.1"]:
             raise SystemExit(1)
-        return real_run_bd_json(args, beads_root=beads_root, cwd=cwd)
+        return []
 
     with (
-        patch_in_memory_beads(backend),
-        patch("atelier.worker.session.worktree.beads.run_bd_json", side_effect=fail_show_lookup),
-        patch("atelier.worker.session.worktree._startup_worktree_preflight"),
-        patch("atelier.worker.session.worktree.git.git_origin_url", return_value=None),
+        patch("atelier.worker.session.worktree.beads.run_bd_json", side_effect=fake_run_bd_json),
+        patch(
+            "atelier.worker.session.worktree.beads.list_descendant_changesets",
+            return_value=[{"id": "at-epic.1"}],
+        ),
         patch(
             "atelier.worker.session.worktree.worktrees.reconcile_mapping_ownership", return_value=()
         ),
@@ -1000,11 +1080,10 @@ def test_prepare_worktrees_skips_child_workspace_parent_alignment_on_beads_looku
             return_value=changeset_worktree_path,
         ),
         patch("atelier.worker.session.worktree.worktrees.ensure_changeset_checkout"),
-        patch(
-            "atelier.worker.session.worktree.git.git_current_branch",
-            return_value="feat/epic-at-epic.1",
-        ),
         patch("atelier.worker.session.worktree.git.git_rev_parse", return_value="abc1234"),
+        patch(
+            "atelier.worker.session.worktree.beads.update_workspace_parent_branch"
+        ) as update_parent,
         patch("atelier.worker.session.worktree.beads.update_changeset_branch_metadata"),
     ):
         worktree.prepare_worktrees(
@@ -1012,7 +1091,7 @@ def test_prepare_worktrees_skips_child_workspace_parent_alignment_on_beads_looku
                 dry_run=False,
                 project_data_dir=tmp_path,
                 repo_root=repo_root,
-                beads_root=beads_root,
+                beads_root=tmp_path / ".beads",
                 selected_epic="at-epic",
                 changeset_id="at-epic.1",
                 root_branch_value="feat/epic",
@@ -1024,8 +1103,7 @@ def test_prepare_worktrees_skips_child_workspace_parent_alignment_on_beads_looku
             control=_TestControl(logs),
         )
 
-    updated_issue = backend.state.show("at-epic.1")
-    assert "workspace.parent_branch:" not in str(updated_issue.get("description"))
+    update_parent.assert_not_called()
     assert any(
         "Skipped workspace.parent_branch alignment for at-epic.1: unable to read metadata from "
         "beads (bd show exit 1)" in line


### PR DESCRIPTION
# Summary

- Move the shared Tier 0 Beads client flow in `tests/atelier/lib/test_beads.py` onto `build_in_memory_beads_client(...)`.
- Repurpose this changeset away from worktree/runtime seams by restoring `tests/atelier/worker/test_session_worktree.py` to the parent-branch state.

# Changes

- Add a shared client-contract test that runs the same `show`/`list`/`ready`/`create`/`update`/`close` assertions against both the in-memory backend and the subprocess client.
- Keep subprocess-only coverage explicit for dependency mutation and transport-specific behavior.
- Update the in-memory Beads testing guide with the current migration boundary and the remaining Tier 0 dependency-mutation gap.

# Testing

- `uv run pytest tests/atelier/lib/test_beads.py tests/atelier/worker/test_session_worktree.py`
- `bash scripts/lint-gate.sh`
- `just test`

# Tickets

- None

# Risks / Rollout

- Low risk. This changes test coverage and documentation only.

# Notes

- This draft PR is repurposed from an earlier worktree-test attempt to the retargeted shared-client boundary scope.
