### PR TITLE
Normalize placeholder null ids in GC lookups

### DIFF
--- a/src/atelier/gc/common.py
+++ b/src/atelier/gc/common.py
@@ -75,9 +75,27 @@ def normalize_branch(value: object) -> str | None:
     return cleaned
 
 
-def try_show_issue(issue_id: str, *, beads_root: Path, cwd: Path) -> dict[str, object] | None:
+def try_show_issue(
+    issue_id: object,
+    *,
+    beads_root: Path,
+    cwd: Path,
+    context: str | None = None,
+) -> dict[str, object] | None:
+    if not isinstance(issue_id, str):
+        return None
+    cleaned = issue_id.strip()
+    if not cleaned:
+        return None
+    if cleaned.lower() == "null":
+        detail = f" in {context}" if context else ""
+        log_warning(
+            "gc ignored malformed placeholder Beads id "
+            f"{issue_id!r}{detail}; treating metadata as unresolved"
+        )
+        return None
     result = beads.run_bd_command(
-        ["show", issue_id, "--json"],
+        ["show", cleaned, "--json"],
         beads_root=beads_root,
         cwd=cwd,
         allow_failure=True,
@@ -87,7 +105,7 @@ def try_show_issue(issue_id: str, *, beads_root: Path, cwd: Path) -> dict[str, o
         if not detail:
             detail = f"bd show exited with code {result.returncode}"
         log_warning(
-            f"gc issue lookup failed for {issue_id!r}: {detail}; treating mapping as unresolved"
+            f"gc issue lookup failed for {cleaned!r}: {detail}; treating mapping as unresolved"
         )
         return None
     raw = result.stdout.strip() if result.stdout else ""
@@ -96,7 +114,7 @@ def try_show_issue(issue_id: str, *, beads_root: Path, cwd: Path) -> dict[str, o
     try:
         payload = json.loads(raw)
     except json.JSONDecodeError:
-        log_warning(f"gc issue lookup returned invalid JSON for {issue_id!r}; skipping")
+        log_warning(f"gc issue lookup returned invalid JSON for {cleaned!r}; skipping")
         return None
     if isinstance(payload, dict):
         issues: list[dict[str, object]] = [payload]
@@ -107,7 +125,7 @@ def try_show_issue(issue_id: str, *, beads_root: Path, cwd: Path) -> dict[str, o
     try:
         records = beads.parse_issue_records(issues, source="gc.try_show_issue")
     except ValueError:
-        log_warning(f"gc issue lookup returned invalid issue payload for {issue_id!r}; skipping")
+        log_warning(f"gc issue lookup returned invalid issue payload for {cleaned!r}; skipping")
         return None
     if records:
         return records[0].raw

--- a/src/atelier/gc/hooks.py
+++ b/src/atelier/gc/hooks.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .. import beads
-from .common import issue_labels, parse_rfc3339, try_show_issue
+from .common import issue_labels, log_warning, parse_rfc3339, try_show_issue
 from .models import GcAction
 
 
@@ -50,6 +50,21 @@ def collect_hooks(
         cwd=repo_root,
     )
     agents: dict[str, dict[str, object]] = {}
+
+    def _normalize_hook_bead(value: object, *, agent_id: str) -> str | None:
+        if not isinstance(value, str):
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        if cleaned.lower() == "null":
+            log_warning(
+                "gc ignored malformed placeholder hook metadata "
+                f"for agent {agent_id!r}: hook_bead={value!r}"
+            )
+            return None
+        return cleaned
+
     for issue in agent_issues:
         description = issue.get("description")
         fields = beads.parse_description_fields(description if isinstance(description, str) else "")
@@ -65,6 +80,7 @@ def collect_hooks(
             hook_bead = beads.get_agent_hook(issue_id, beads_root=beads_root, cwd=repo_root)
         if not hook_bead:
             hook_bead = fields.get("hook_bead")
+        hook_bead = _normalize_hook_bead(hook_bead, agent_id=agent_id)
         agents[agent_id] = {
             "issue": issue,
             "issue_id": issue_id,
@@ -92,7 +108,12 @@ def collect_hooks(
         issue_id = issue.get("id") if isinstance(issue, dict) else None
         if not isinstance(issue_id, str) or not issue_id:
             continue
-        epic = try_show_issue(hook_bead, beads_root=beads_root, cwd=repo_root)
+        epic = try_show_issue(
+            hook_bead,
+            beads_root=beads_root,
+            cwd=repo_root,
+            context=f"agent hook metadata for {agent_id}",
+        )
         description = f"Release stale hook for {agent_id} (epic {hook_bead})"
         hook_value = hook_bead if isinstance(hook_bead, str) else None
 

--- a/src/atelier/gc/worktrees.py
+++ b/src/atelier/gc/worktrees.py
@@ -16,6 +16,7 @@ from .common import (
     issue_integrated_sha,
     issue_labels,
     log_debug,
+    log_warning,
     normalize_branch,
     run_git_gc_command,
     try_show_issue,
@@ -153,6 +154,16 @@ def _resolve_mapping_issue(
     beads_root: Path,
     repo_root: Path,
 ) -> _MappingIssueLookup:
+    mapping_epic_id = mapping.epic_id.strip()
+    if not mapping_epic_id:
+        return _MappingIssueLookup(issue=None, source="unresolved")
+    if mapping_epic_id.lower() == "null":
+        log_warning(
+            "gc ignored malformed placeholder worktree metadata "
+            f"epic_id={mapping.epic_id!r} at {mapping.worktree_path!r}"
+        )
+        return _MappingIssueLookup(issue=None, source="skip-placeholder")
+
     candidate_scores: dict[str, int] = defaultdict(int)
     mapping_worktree = _normalize_mapping_worktree_key(
         project_dir=project_dir,
@@ -178,20 +189,20 @@ def _resolve_mapping_issue(
                     if mapping_worktree
                     else f"metadata(branch) score={top_score}"
                 )
-                if resolved_epic_id != mapping.epic_id:
+                if resolved_epic_id != mapping_epic_id:
                     log_debug(
                         "resolved mapping epic id "
-                        f"{mapping.epic_id!r} -> {resolved_epic_id!r} via {source}"
+                        f"{mapping_epic_id!r} -> {resolved_epic_id!r} via {source}"
                     )
                 return _MappingIssueLookup(issue=resolved_issue, source=source)
         else:
             log_debug(
                 "ambiguous mapping metadata resolution "
-                f"epic_id={mapping.epic_id!r} score={top_score} "
+                f"epic_id={mapping_epic_id!r} score={top_score} "
                 f"candidates={','.join(sorted(top_candidates))}"
             )
 
-    direct = index.epics_by_id.get(mapping.epic_id)
+    direct = index.epics_by_id.get(mapping_epic_id)
     if direct is not None:
         return _MappingIssueLookup(issue=direct, source="direct-index")
 
@@ -199,7 +210,12 @@ def _resolve_mapping_issue(
         log_debug(f"skip non-bead mapping key {mapping.epic_id!r} at {mapping.worktree_path!r}")
         return _MappingIssueLookup(issue=None, source="skip-non-bead")
 
-    issue = try_show_issue(mapping.epic_id, beads_root=beads_root, cwd=repo_root)
+    issue = try_show_issue(
+        mapping_epic_id,
+        beads_root=beads_root,
+        cwd=repo_root,
+        context=f"worktree mapping {mapping.worktree_path}",
+    )
     if issue is not None:
         return _MappingIssueLookup(issue=issue, source="direct-bd-show")
     return _MappingIssueLookup(issue=None, source="unresolved")

--- a/tests/atelier/gc/test_common.py
+++ b/tests/atelier/gc/test_common.py
@@ -98,6 +98,26 @@ def test_try_show_issue_returns_none_when_bd_show_fails() -> None:
     log_warning.assert_called_once()
 
 
+def test_try_show_issue_skips_placeholder_id_without_lookup() -> None:
+    with (
+        patch("atelier.gc.common.beads.run_bd_command") as run_bd_command,
+        patch("atelier.gc.common.log_warning") as log_warning,
+    ):
+        result = gc_common.try_show_issue(
+            " null ",
+            beads_root=Path("/beads"),
+            cwd=Path("/repo"),
+            context="agent hook metadata for worker-1",
+        )
+
+    assert result is None
+    run_bd_command.assert_not_called()
+    log_warning.assert_called_once_with(
+        "gc ignored malformed placeholder Beads id ' null ' "
+        "in agent hook metadata for worker-1; treating metadata as unresolved"
+    )
+
+
 def test_try_show_issue_returns_issue_payload_on_success() -> None:
     payload = {"id": "at-123", "title": "Issue", "status": "open", "labels": []}
     with patch(
@@ -108,7 +128,17 @@ def test_try_show_issue_returns_issue_payload_on_success() -> None:
             stdout='{"id":"at-123","title":"Issue","status":"open","labels":[]}',
             stderr="",
         ),
-    ):
-        result = gc_common.try_show_issue("at-123", beads_root=Path("/beads"), cwd=Path("/repo"))
+    ) as run_bd_command:
+        result = gc_common.try_show_issue(
+            " at-123 ",
+            beads_root=Path("/beads"),
+            cwd=Path("/repo"),
+        )
 
     assert result == payload
+    run_bd_command.assert_called_once_with(
+        ["show", "at-123", "--json"],
+        beads_root=Path("/beads"),
+        cwd=Path("/repo"),
+        allow_failure=True,
+    )

--- a/tests/atelier/gc/test_hooks.py
+++ b/tests/atelier/gc/test_hooks.py
@@ -135,3 +135,41 @@ def test_collect_hooks_scans_all_agent_pages_before_releasing_stale_hooks() -> N
         f"Release stale hook for agent-{total_agents - 1} (epic epic-{total_agents - 1})"
     )
     run_bd_json.assert_called_once_with(expected_args, beads_root=beads_root, cwd=repo_root)
+
+
+def test_collect_hooks_skips_placeholder_hook_without_issue_lookup() -> None:
+    agent_issue = {
+        "id": "agent-1",
+        "title": "atelier/worker/codex/p4242-t1",
+        "labels": ["at:agent"],
+        "description": "agent_id: agent-1\nhook_bead: null\n",
+    }
+
+    def fake_run_bd_json(
+        args: list[str], *, beads_root: Path, cwd: Path
+    ) -> list[dict[str, object]]:
+        if args[:3] == ["list", "--label", "at:agent"]:
+            return [agent_issue]
+        return []
+
+    with (
+        patch("atelier.beads.run_bd_json", side_effect=fake_run_bd_json),
+        patch("atelier.beads.list_epics", return_value=[]),
+        patch("atelier.beads.get_agent_hook", return_value="null"),
+        patch(
+            "atelier.gc.hooks.try_show_issue",
+            side_effect=AssertionError("placeholder hook should not trigger issue lookup"),
+        ),
+        patch("atelier.gc.hooks.log_warning") as log_warning,
+    ):
+        actions = gc_hooks.collect_hooks(
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+            stale_hours=24.0,
+            include_missing_heartbeat=True,
+        )
+
+    assert actions == []
+    log_warning.assert_called_once_with(
+        "gc ignored malformed placeholder hook metadata for agent 'agent-1': hook_bead='null'"
+    )

--- a/tests/atelier/gc/test_worktrees.py
+++ b/tests/atelier/gc/test_worktrees.py
@@ -464,6 +464,56 @@ def test_collect_resolved_epic_artifacts_skips_ambiguous_branch_only_metadata_ma
         assert actions == []
 
 
+def test_collect_resolved_epic_artifacts_skips_placeholder_mapping_epic_id() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        project_dir = root / "data"
+        repo_root = root / "repo"
+        project_dir.mkdir(parents=True, exist_ok=True)
+        repo_root.mkdir(parents=True, exist_ok=True)
+        mapping_path = worktrees.mapping_path(project_dir, "null")
+        mapping_path.parent.mkdir(parents=True, exist_ok=True)
+        worktrees.write_mapping(
+            mapping_path,
+            worktrees.WorktreeMapping(
+                epic_id="null",
+                worktree_path="worktrees/at-closed",
+                root_branch="feat/closed",
+                changesets={},
+                changeset_worktrees={},
+            ),
+        )
+        matching_epic = {
+            "id": "at-closed",
+            "status": "closed",
+            "description": "workspace.root_branch: feat/closed\nworkspace.parent_branch: main\n",
+            "labels": ["at:epic", "workspace:feat/closed"],
+        }
+
+        with (
+            patch("atelier.beads.list_epics", return_value=[matching_epic]),
+            patch("atelier.beads.list_descendant_changesets", return_value=[]),
+            patch(
+                "atelier.gc.worktrees.try_show_issue",
+                side_effect=AssertionError("placeholder epic_id should not trigger issue lookup"),
+            ),
+            patch("atelier.gc.worktrees.log_warning") as log_warning,
+        ):
+            actions = gc_worktrees.collect_resolved_epic_artifacts(
+                project_dir=project_dir,
+                beads_root=Path("/beads"),
+                repo_root=repo_root,
+                git_path="git",
+                assume_yes=False,
+            )
+
+        assert actions == []
+        log_warning.assert_called_once_with(
+            "gc ignored malformed placeholder worktree metadata "
+            "epic_id='null' at 'worktrees/at-closed'"
+        )
+
+
 def test_collect_orphan_worktrees_resolves_prefix_migrated_mapping_by_metadata() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)


### PR DESCRIPTION
# Summary

- Stop GC from treating literal `"null"` placeholders as real Beads ids during issue lookup.

# Changes

- Normalize GC issue ids in the shared lookup helper before any `bd show` call.
- Treat placeholder `hook_bead` and worktree `epic_id` metadata as malformed, log them clearly, and keep cleanup fail-closed.
- Add regression coverage for placeholder hook metadata, placeholder worktree ids, and trimmed issue lookup inputs.

# Testing

- `just format`
- `uv run pytest tests/atelier/gc tests/atelier/commands/test_gc.py`
- `pytest`
- `tests/shell/run.sh`

# Tickets

- None

# Risks / Rollout

- Low risk; this is scoped to GC normalization and diagnostics.

# Notes

- Placeholder metadata is treated as absent and is not auto-repaired in this slice.
