### PR TITLE
Keep work-threaded messages on their original work item

### DIFF
--- a/docs/work-threaded-message-migration.md
+++ b/docs/work-threaded-message-migration.md
@@ -6,11 +6,15 @@ a later worker or planner session can recover the same context.
 
 Assignees and queues are optional compatibility metadata. They may help the
 current runtime notice a message quickly, but they are not a durable
-coordination path and must not replace the work thread.
+coordination path and must not replace the work thread. New `mail-send`
+dispatches must name the owning epic or changeset explicitly with
+`thread: <epic-or-changeset>`.
 
 ## Default policy
 
 - Put durable coordination on a work thread with `thread: <epic-or-changeset>`.
+- Treat `mail-send` without `thread` as invalid. Fail closed instead of
+  creating an agent-addressed coordination message.
 - Set explicit routing metadata when the message is work-scoped:
   - `thread_target: epic|changeset`
   - `audiences: [worker|planner|operator]`
@@ -35,8 +39,9 @@ coordination path and must not replace the work thread.
   the affected epic or changeset whenever the decision is about active work.
 - Queue metadata may still surface the message in planner/operator startup, but
   the thread owns the durable context.
-- Non-work-wide exceptions, such as "no eligible epics", may remain queue-only
-  because there is no specific work thread to attach.
+- Non-work-wide exceptions, such as "no eligible epics", are outside
+  `mail-send`'s durable work-threaded contract because there is no specific
+  work thread to attach.
 
 ## Operator flows
 
@@ -46,12 +51,15 @@ coordination path and must not replace the work thread.
 
 ## Compatibility-only cases
 
-Compatibility-only delivery remains acceptable only when one of these is true:
+Compatibility metadata may still appear when one of these is true:
 
-- The message is a transient compatibility nudge layered on top of a threaded
-  work message.
-- The flow has no specific epic or changeset thread to attach.
+- A threaded work message also carries assignee or queue hints for the current
+  runtime.
+- A historical message predates the tightened work-threaded contract.
 - The runtime is claiming a queued message and recording `claimed_by` metadata.
+
+If there is no epic or changeset thread yet, create or select the owning work
+item before using `mail-send` for durable coordination.
 
 If a work-threaded message contains explicit audience or blocking metadata,
 legacy assignee or queue routing must not override it.

--- a/src/atelier/skills/mail-send/SKILL.md
+++ b/src/atelier/skills/mail-send/SKILL.md
@@ -7,8 +7,10 @@ description: >-
 
 # Mail send
 
-Work-threaded messages are the durable coordination path. Use `to` only to
-describe the intended audience and, when helpful, to nudge the current runtime.
+Work-threaded messages are the durable coordination path. `mail-send` supports
+only work-threaded coordination and fails closed when `--thread` is omitted.
+Use `to` only to describe the intended audience and, when helpful, to nudge
+the current runtime.
 
 ## Inputs
 
@@ -17,16 +19,15 @@ describe the intended audience and, when helpful, to nudge the current runtime.
 - to: Recipient agent id used to derive audience metadata and optional assignee
   hints.
 - from: Sender agent id.
-- thread: Optional work thread id (epic or changeset bead id). Required for
-  durable work-scoped coordination.
+- thread: Required work thread id (epic or changeset bead id).
 - reply_to: Optional message id being replied to.
 - beads_dir: Optional Beads store path.
 
 ## Steps
 
 1. Use the dispatch script:
-   - `python skills/mail-send/scripts/send_message.py --subject "<subject>" --body "<body>" --to "<to>" --from "<from>" [--thread "<thread>"] [--reply-to "<reply_to>"] [--beads-dir "<beads_dir>"]`
-1. For durable work coordination, always provide `--thread <epic-or-changeset>`:
+   - `python skills/mail-send/scripts/send_message.py --subject "<subject>" --body "<body>" --to "<to>" --from "<from>" --thread "<thread>" [--reply-to "<reply_to>"] [--beads-dir "<beads_dir>"]`
+1. `mail-send` requires `--thread <epic-or-changeset>`:
    - the script adds `thread_target`, `audiences`, and default `kind` metadata
    - worker-targeted threaded messages also add `blocking_roles: [worker]`
 1. Do not create planner-to-worker message beads directly with `bd create`.
@@ -37,14 +38,16 @@ describe the intended audience and, when helpful, to nudge the current runtime.
      worker is currently active
    - assignee metadata may still help an active runtime notice the message, but
      it is not the durable coordination path
-1. Use unthreaded messages only when no specific work item exists to carry the
-   durable context.
+1. If no epic or changeset exists yet, do not use `mail-send` as a durable
+   coordination path. Select or create the owning work item first.
 
 ## Verification
 
 - Threaded path: message bead exists on the original epic/changeset thread and
-  carries explicit work-thread metadata when `--thread` is provided.
+  carries explicit work-thread metadata.
 - Inactive worker path: the same threaded message is still created on the
   original work item, so a later worker can discover it there.
+- Missing-thread path: the script exits with an error instead of creating an
+  agent-addressed coordination message.
 - Follow `docs/work-threaded-message-migration.md` for planner/worker/operator
   migration guidance.

--- a/src/atelier/skills/mail-send/scripts/send_message.py
+++ b/src/atelier/skills/mail-send/scripts/send_message.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Send a threaded work message and persist it on the original work item."""
+"""Send a work-threaded message and persist it on the original work item."""
 
 from __future__ import annotations
 
@@ -69,6 +69,11 @@ def dispatch_message(
     beads_root: Path,
     cwd: Path,
 ) -> DispatchOutcome:
+    if not thread:
+        raise RuntimeError(
+            "mail-send requires --thread <epic-or-changeset>; "
+            "agent-addressed delivery is not supported"
+        )
     metadata: dict[str, object] = {
         "from": from_agent,
         "kind": _message_kind(subject=subject, reply_to=reply_to),
@@ -77,16 +82,13 @@ def dispatch_message(
     if audience in {"worker", "planner", "operator"}:
         metadata["audience"] = [audience]
         metadata["audiences"] = [audience]
-    if thread:
-        metadata["thread"] = thread
-        thread_target = messages.infer_thread_target(thread)
-        if thread_target is not None:
-            metadata["thread_kind"] = thread_target
-            metadata["thread_target"] = thread_target
-        metadata["delivery"] = "work-threaded"
-        metadata.update(_thread_metadata(thread=thread, recipient=to, subject=subject))
-    else:
-        metadata["delivery"] = "agent-addressed"
+    metadata["thread"] = thread
+    thread_target = messages.infer_thread_target(thread)
+    if thread_target is not None:
+        metadata["thread_kind"] = thread_target
+        metadata["thread_target"] = thread_target
+    metadata["delivery"] = "work-threaded"
+    metadata.update(_thread_metadata(thread=thread, recipient=to, subject=subject))
     if subject.startswith("NEEDS-DECISION:"):
         metadata["blocking"] = True
     if reply_to:
@@ -121,7 +123,11 @@ def main() -> None:
     parser.add_argument("--body", required=True, help="Message body")
     parser.add_argument("--to", required=True, help="Recipient agent id")
     parser.add_argument("--from", dest="from_agent", required=True, help="Sender agent id")
-    parser.add_argument("--thread", default="", help="Optional thread id")
+    parser.add_argument(
+        "--thread",
+        required=True,
+        help="Work thread id (epic or changeset bead id)",
+    )
     parser.add_argument("--reply-to", default="", help="Optional reply message id")
     parser.add_argument(
         "--beads-dir",

--- a/src/atelier/templates/AGENTS.planner.md.tmpl
+++ b/src/atelier/templates/AGENTS.planner.md.tmpl
@@ -24,6 +24,8 @@ The CLI does not enforce planning correctness. You do, via skills.
   assignee delivery is compatibility metadata only. If no worker is active, the
   message must still stay on that original work thread for the next worker to
   consume.
+- Do not use `mail-send` without an epic/changeset thread; select the owning
+  work item first so coordination stays durable.
 
 ## No Approval Step (Except Promotion)
 

--- a/tests/atelier/skills/test_mail_send_script.py
+++ b/tests/atelier/skills/test_mail_send_script.py
@@ -5,6 +5,8 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from atelier import messages
 
 
@@ -153,15 +155,15 @@ def test_inactive_worker_threaded_message_is_discoverable_by_later_worker() -> N
     assert messages.work_thread_routing(issue).thread_id == "at-es93n.1"
 
 
-def test_dispatch_message_non_planner_sender_does_not_reroute() -> None:
+def test_dispatch_message_without_thread_fails_closed() -> None:
     module = _load_script_module()
     with (
-        patch.object(module.agent_home, "is_session_agent_active", return_value=False),
         patch.object(
             module.beads, "create_message_bead", return_value={"id": "at-msg-2"}
         ) as create,
+        pytest.raises(RuntimeError, match="mail-send requires --thread"),
     ):
-        result = module.dispatch_message(
+        module.dispatch_message(
             subject="Heads up",
             body="FYI",
             to="atelier/worker/codex/p404-t4",
@@ -172,12 +174,7 @@ def test_dispatch_message_non_planner_sender_does_not_reroute() -> None:
             cwd=Path("/repo"),
         )
 
-    assert result.decision == "delivered"
-    assert result.issue_id == "at-msg-2"
-    create.assert_called_once()
-    assert create.call_args.kwargs["metadata"]["delivery"] == "agent-addressed"
-    assert create.call_args.kwargs["metadata"]["audience"] == ["worker"]
-    assert create.call_args.kwargs["metadata"]["kind"] == "instruction"
+    create.assert_not_called()
 
 
 def test_dispatch_message_threaded_needs_decision_to_planner_sets_explicit_routing() -> None:


### PR DESCRIPTION
# Summary

- Keep planner-to-worker threaded messages attached to the original epic or changeset even when the targeted worker is inactive.

# Changes

- Remove the inactive-worker reroute epic path from `mail-send` so threaded dispatch always writes the original message bead.
- Update shipped messaging guidance to describe work-threaded delivery as the durable coordination path.
- Replace reroute regressions with tests that prove inactive dispatch remains discoverable on the original thread.

# Testing

- `just test`
- `just lint`
- `./.venv/bin/pytest tests/atelier/skills/test_mail_send_script.py tests/atelier/test_messages.py tests/atelier/worker/test_finalization_service.py`

## Tickets
- None

# Risks / Rollout

- Low risk; the change removes fallback work synthesis and keeps existing threaded worker-blocking metadata intact.

# Notes

- Unthreaded compatibility messages are unchanged; this only tightens the durable path for work-threaded coordination.
