### PR TITLE
Fix planner guardrail false negatives for valid authoring fields

### DIFF
--- a/src/atelier/planner_contract.py
+++ b/src/atelier/planner_contract.py
@@ -14,7 +14,9 @@ from typing import Final
 from .executable_work_validation import normalize_text
 
 _KEY_PATTERN: Final[re.Pattern[str]] = re.compile(r"[^a-z0-9]+")
-_LINE_FIELD_PATTERN: Final[re.Pattern[str]] = re.compile(r"^\s*([^:]+):\s*(.+?)\s*$")
+_FIELD_HEADER_PATTERN: Final[re.Pattern[str]] = re.compile(
+    r"^\s*(?:[-*+]\s+|\d+[.)]\s+)?([^:]+):\s*(.*?)\s*$"
+)
 _TEXT_FIELDS: Final[tuple[str, ...]] = ("description", "notes", "design")
 _REQUIRED_FIELD_ALIASES: Final[dict[str, tuple[str, ...]]] = {
     "intent": ("intent",),
@@ -34,6 +36,13 @@ _DONE_DEFINITION_ALIASES: Final[tuple[str, ...]] = (
     "success_definition",
 )
 _ACCEPTANCE_FIELDS: Final[tuple[str, ...]] = ("acceptance_criteria", "acceptance")
+_SUPPORTED_FIELD_KEYS: Final[frozenset[str]] = frozenset(
+    {
+        alias
+        for aliases in (*_REQUIRED_FIELD_ALIASES.values(), _DONE_DEFINITION_ALIASES)
+        for alias in aliases
+    }
+)
 _PLACEHOLDER_VALUES: Final[frozenset[str]] = frozenset(
     {
         "/",
@@ -104,14 +113,37 @@ def _collect_fields(issues: Sequence[Mapping[str, object]]) -> dict[str, tuple[s
 
 def _iter_field_lines(text: str) -> tuple[tuple[str, str], ...]:
     parsed: list[tuple[str, str]] = []
-    for line in text.splitlines():
-        match = _LINE_FIELD_PATTERN.match(line)
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        match = _FIELD_HEADER_PATTERN.match(lines[index])
         if match is None:
+            index += 1
             continue
         normalized_key = _normalize_key(match.group(1))
-        if not normalized_key:
+        if normalized_key not in _SUPPORTED_FIELD_KEYS:
+            index += 1
             continue
-        parsed.append((normalized_key, match.group(2).strip()))
+        inline_value = match.group(2).strip()
+        if inline_value:
+            parsed.append((normalized_key, inline_value))
+            index += 1
+            continue
+
+        block_lines: list[str] = []
+        index += 1
+        while index < len(lines):
+            next_line = lines[index]
+            next_match = _FIELD_HEADER_PATTERN.match(next_line)
+            if next_match is not None:
+                next_key = _normalize_key(next_match.group(1))
+                if next_key in _SUPPORTED_FIELD_KEYS:
+                    break
+            stripped_line = next_line.strip()
+            if stripped_line:
+                block_lines.append(stripped_line)
+            index += 1
+        parsed.append((normalized_key, "\n".join(block_lines).strip()))
     return tuple(parsed)
 
 

--- a/src/atelier/skills/plan-changeset-guardrails/scripts/check_guardrails.py
+++ b/src/atelier/skills/plan-changeset-guardrails/scripts/check_guardrails.py
@@ -119,12 +119,14 @@ _CONCERN_DOMAINS: dict[str, re.Pattern[str]] = {
     ),
 }
 _RESPLIT_THRESHOLD_TRIGGER = re.compile(
-    r"\b(?:re[- ]?split trigger|split trigger|loc threshold|file threshold)\b",
+    r"\b(?:re[- ]?split triggers?|split triggers?|re[- ]?split criteria|"
+    r"split criteria|loc threshold|file threshold)\b",
     re.IGNORECASE,
 )
 _RESPLIT_THRESHOLD_NUMERIC = re.compile(r">\s*(?:400|800)\b")
 _RESPLIT_NEW_DOMAIN_TRIGGER = re.compile(
-    r"\b(?:new concern domain|additional concern domain|new domain during review)\b",
+    r"\b(?:new concern domain|additional concern domain|new domain during review|"
+    r"expand(?:s)? into broad [a-z0-9/ -]+ redesign|broad [a-z0-9/ -]+ redesign)\b",
     re.IGNORECASE,
 )
 _DEFERRED_FOLLOW_ON_ACTION = re.compile(

--- a/tests/atelier/skills/test_plan_changeset_guardrails_script.py
+++ b/tests/atelier/skills/test_plan_changeset_guardrails_script.py
@@ -180,6 +180,112 @@ def test_evaluate_guardrails_flags_missing_done_definition() -> None:
     assert any("missing explicit done definition" in item for item in report.violations)
 
 
+def test_evaluate_guardrails_accepts_block_style_edge_cases_in_design() -> None:
+    module = _load_script_module()
+    epic = {
+        "id": "at-epic",
+        "labels": ["at:epic"],
+        "description": (
+            "intent: Keep planner authoring validation deterministic.\n"
+            "rationale: Valid planner fields should not be reported as missing.\n"
+            "non_goals: Do not redesign planning workflows.\n"
+            "constraints: Preserve explicit authoring rules and deterministic checks.\n"
+            "related_context: plan-changeset-guardrails.\n"
+            "done_definition: Done when valid planner beads no longer fail validation."
+        ),
+        "design": (
+            "edge_cases:\n"
+            "- duplicate fields across description and notes\n"
+            "- block-style field values in structured planner docs"
+        ),
+        "notes": (
+            "LOC estimate: 240\n"
+            "Invariant impact map:\n"
+            "- mutation entry points\n"
+            "- recovery paths\n"
+            "- external side-effect adapters\n"
+            "Re-split triggers:\n"
+            "- split if parser repair expands into broader planner-authoring redesign\n"
+            "- split if review reveals a new concern domain beyond checker alignment\n"
+            "Planner action on split:\n"
+            "- capture deferred follow-on work immediately.\n"
+            "Review scope growth guidance:\n"
+            "- defer unrelated authoring-style cleanups."
+        ),
+    }
+
+    report = module._evaluate_guardrails(
+        epic_issue=epic,
+        child_changesets=[],
+        target_changesets=[epic],
+    )
+
+    assert not any(
+        "missing planner authoring contract fields" in item for item in report.violations
+    )
+
+
+def test_evaluate_guardrails_accepts_bulleted_authoring_aliases_in_notes() -> None:
+    module = _load_script_module()
+    child = {
+        "id": "at-epic.1",
+        "labels": [],
+        "notes": (
+            "- intent: Normalize supported planner field variants.\n"
+            "- rationale: Historic planner notes may use bullet-prefixed entries.\n"
+            "- non-goal: Do not weaken the authoring rules.\n"
+            "- constraint: Keep validation deterministic.\n"
+            "- edge-case: Structured notes may carry the only executable context.\n"
+            "- related-beads: at-e1yzp, at-k0ako.\n"
+            "- success-definition: Done when bullet-prefixed aliases validate.\n"
+            "LOC estimate: 180"
+        ),
+    }
+
+    report = module._evaluate_guardrails(
+        epic_issue=None,
+        child_changesets=[],
+        target_changesets=[child],
+    )
+
+    assert report.violations == []
+
+
+def test_evaluate_guardrails_accepts_broad_redesign_resplit_trigger_wording() -> None:
+    module = _load_script_module()
+    epic = {
+        "id": "at-epic",
+        "labels": ["at:epic"],
+        "title": "Fix planner guardrail literalism",
+        "description": _planner_contract_text(),
+        "notes": (
+            "LOC estimate: 240\n"
+            "Invariant impact map:\n"
+            "- mutation entry points\n"
+            "- recovery paths\n"
+            "- external side-effect adapters\n"
+            "Re-split triggers:\n"
+            "- split if parser repair and planner-authoring contract normalization become "
+            "separate review-sized concerns with independent tests.\n"
+            "- split if the work expands into broad planner-skill redesign instead of "
+            "checker/contract alignment.\n"
+            "Planner action on split:\n"
+            "- capture deferred follow-on work immediately.\n"
+            "Review scope growth guidance:\n"
+            "- defer unrelated authoring-style cleanups."
+        ),
+        "acceptance_criteria": "Done when valid guardrail notes no longer raise false negatives.",
+    }
+
+    report = module._evaluate_guardrails(
+        epic_issue=epic,
+        child_changesets=[],
+        target_changesets=[epic],
+    )
+
+    assert not any("missing explicit re-split triggers" in item for item in report.violations)
+
+
 def test_evaluate_guardrails_flags_cross_cutting_guardrail_gaps() -> None:
     module = _load_script_module()
     epic = {


### PR DESCRIPTION
# Summary
- fix planner guardrail false negatives for valid authoring fields and supported re-split notes

# Changes
- teach planner contract parsing to read supported fields from block-style sections and bullet-prefixed structured notes
- accept plural re-split trigger headers and broad redesign wording already used in planner notes
- add regressions for block-style edge cases, note aliases, and real-world re-split wording

# Testing
- `just format`
- `just lint`
- `just test`

# Tickets
- Fixes #634

# Risks / Rollout
- low risk; scoped to planner guardrail parsing and regression coverage

# Notes
- verified the planner guardrail script now reports no violations for the seeded planner example
