### PR TITLE
Prevent finalize/reconcile changeset metadata races

### DIFF
--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -6145,19 +6145,50 @@ def update_changeset_review(
     *,
     beads_root: Path,
     cwd: Path,
-) -> None:
-    """Update review metadata fields for a changeset bead."""
-    _update_description_fields_optimistic(
-        changeset_id,
-        fields={
+    preserve_missing: bool = False,
+) -> dict[str, object]:
+    """Update review metadata fields for a changeset bead.
+
+    Args:
+        changeset_id: Changeset bead identifier.
+        metadata: Review metadata values to persist.
+        beads_root: Path to the Beads store.
+        cwd: Repository working directory for `bd`.
+        preserve_missing: When true, keep existing description-field values for
+            review metadata keys omitted from ``metadata`` instead of writing
+            ``null``. This is required for partial review-state refreshes that
+            only intend to mutate a subset of the review fields.
+
+    Returns:
+        The refreshed issue payload after the update.
+    """
+    with _issue_write_lock(changeset_id, beads_root=beads_root):
+        fields = {
             "pr_url": metadata.pr_url,
             "pr_number": metadata.pr_number,
             "pr_state": metadata.pr_state,
             "review_owner": metadata.review_owner,
-        },
-        beads_root=beads_root,
-        cwd=cwd,
-    )
+        }
+        if preserve_missing:
+            issues = run_bd_json(["show", changeset_id], beads_root=beads_root, cwd=cwd)
+            if not issues:
+                die(f"changeset not found: {changeset_id}")
+            issue = issues[0]
+            existing = changesets.parse_review_metadata(_issue_description(issue))
+            if metadata.pr_url is None:
+                fields["pr_url"] = existing.pr_url
+            if metadata.pr_number is None:
+                fields["pr_number"] = existing.pr_number
+            if metadata.pr_state is None:
+                fields["pr_state"] = existing.pr_state
+            if metadata.review_owner is None:
+                fields["review_owner"] = existing.review_owner
+        return _update_description_fields_optimistic(
+            changeset_id,
+            fields=fields,
+            beads_root=beads_root,
+            cwd=cwd,
+        )
 
 
 def update_changeset_review_feedback_cursor(

--- a/src/atelier/worker/finalization/pr_gate.py
+++ b/src/atelier/worker/finalization/pr_gate.py
@@ -739,6 +739,7 @@ def set_changeset_review_pending_state(
             changesets.ReviewMetadata(pr_state=fallback_pr_state),
             beads_root=beads_root,
             cwd=repo_root,
+            preserve_missing=True,
         )
 
 

--- a/src/atelier/worker/work_finalization_state.py
+++ b/src/atelier/worker/work_finalization_state.py
@@ -938,6 +938,7 @@ def update_changeset_review_from_pr(
         metadata,
         beads_root=beads_root,
         cwd=repo_root,
+        preserve_missing=True,
     )
 
 

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -5952,6 +5952,41 @@ def test_update_changeset_review_feedback_cursor_updates_description() -> None:
     assert "review.last_feedback_seen_at: 2026-02-20T12:00:00Z" in captured["description"]
 
 
+def test_update_changeset_review_preserves_missing_fields_when_requested() -> None:
+    state = {
+        "description": (
+            "pr_url: https://example.test/pr/42\n"
+            "pr_number: 42\n"
+            "pr_state: draft-pr\n"
+            "review_owner: reviewer-a\n"
+        )
+    }
+
+    def fake_json(args: list[str], *, beads_root: Path, cwd: Path) -> list[dict[str, object]]:
+        return [{"id": "atelier-99", "description": state["description"]}]
+
+    def fake_update(issue_id: str, description: str, *, beads_root: Path, cwd: Path) -> None:
+        del issue_id, beads_root, cwd
+        state["description"] = description
+
+    with (
+        patch("atelier.beads.run_bd_json", side_effect=fake_json),
+        patch("atelier.beads._update_issue_description", side_effect=fake_update),
+    ):
+        beads.update_changeset_review(
+            "atelier-99",
+            beads.changesets.ReviewMetadata(pr_state="in-review"),
+            beads_root=Path("/beads"),
+            cwd=Path("/repo"),
+            preserve_missing=True,
+        )
+
+    assert "pr_url: https://example.test/pr/42" in state["description"]
+    assert "pr_number: 42" in state["description"]
+    assert "pr_state: in-review" in state["description"]
+    assert "review_owner: reviewer-a" in state["description"]
+
+
 def test_update_issue_description_fields_retries_after_interleaved_overwrite() -> None:
     state = {"description": "hook_bead: epic-1\npr_state: draft-pr\n"}
     writes = 0

--- a/tests/atelier/worker/test_pr_gate.py
+++ b/tests/atelier/worker/test_pr_gate.py
@@ -174,6 +174,43 @@ def test_handle_pushed_without_pr_returns_review_pending_when_strategy_blocks(
     assert result.finalize_result.reason == "changeset_review_pending"
 
 
+def test_set_changeset_review_pending_state_fallback_preserves_existing_review_fields(
+    monkeypatch,
+) -> None:
+    marked: list[str] = []
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        pr_gate.beads,
+        "update_changeset_review",
+        lambda changeset_id, metadata, **kwargs: captured.update(
+            {
+                "changeset_id": changeset_id,
+                "metadata": metadata,
+                **kwargs,
+            }
+        ),
+    )
+
+    pr_gate.set_changeset_review_pending_state(
+        changeset_id="at-123.1",
+        pr_payload=None,
+        pushed=True,
+        fallback_pr_state="pr-open",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+        mark_changeset_in_progress=lambda changeset_id, **_kwargs: marked.append(changeset_id),
+        update_changeset_review_from_pr=lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("PR payload path should not run")
+        ),
+    )
+
+    assert marked == ["at-123.1"]
+    assert captured["changeset_id"] == "at-123.1"
+    assert captured["metadata"].pr_state == "pr-open"
+    assert captured["preserve_missing"] is True
+
+
 def test_handle_pushed_without_pr_reports_failure_when_pr_create_fails(
     monkeypatch,
 ) -> None:

--- a/tests/atelier/worker/test_work_finalization_state.py
+++ b/tests/atelier/worker/test_work_finalization_state.py
@@ -44,6 +44,46 @@ def test_changeset_base_branch_prefers_workspace_parent_for_first_reviewable(mon
     assert base == "main"
 
 
+def test_update_changeset_review_from_pr_preserves_existing_review_owner(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        work_finalization_state.prs,
+        "has_review_requests",
+        lambda _payload: False,
+    )
+    monkeypatch.setattr(
+        work_finalization_state.prs,
+        "lifecycle_state",
+        lambda _payload, *, pushed, review_requested: "pr-open",
+    )
+    monkeypatch.setattr(
+        work_finalization_state.beads,
+        "update_changeset_review",
+        lambda changeset_id, metadata, **kwargs: captured.update(
+            {
+                "changeset_id": changeset_id,
+                "metadata": metadata,
+                **kwargs,
+            }
+        ),
+    )
+
+    work_finalization_state.update_changeset_review_from_pr(
+        "at-epic.1",
+        pr_payload={"url": "https://example.test/pr/42", "number": 42},
+        pushed=True,
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    assert captured["changeset_id"] == "at-epic.1"
+    assert captured["metadata"].pr_url == "https://example.test/pr/42"
+    assert captured["metadata"].pr_number == "42"
+    assert captured["metadata"].pr_state == "pr-open"
+    assert captured["preserve_missing"] is True
+
+
 def test_changeset_parent_branch_normalizes_collapsed_root_to_default(monkeypatch) -> None:
     issue = {
         "description": ("changeset.root_branch: feat/root\nchangeset.parent_branch: feat/root\n"),


### PR DESCRIPTION
# Summary

- Preserve existing changeset review metadata during finalize/reconcile partial updates so workers keep running instead of exiting on description-field conflicts.

# Changes

- add a preserving update mode for changeset review metadata so partial review writes keep existing `pr_url`, `pr_number`, and `review_owner` values
- use that preserving mode from the finalize review-pending fallback and the PR-refresh path
- add regression coverage for the Beads helper and the worker finalize call sites that previously issued partial review updates

# Testing

- `just format`
- `just lint`
- `just test`

# Tickets

- Fixes #636

# Risks / Rollout

- scope is limited to partial review-metadata updates; explicit callers that need to clear fields still use the default overwrite behavior

# Notes

- This addresses the finalize/reconcile race where repeated review-state persistence could clobber sibling description fields and trip the optimistic conflict guard.
