### PR TITLE
Package the shared projected bootstrap in synced skill trees

### DIFF
--- a/docs/runtime-env-subprocess-inventory.md
+++ b/docs/runtime-env-subprocess-inventory.md
@@ -27,15 +27,23 @@ when launching planner/worker/editor/shell subprocesses.
   bootstrap bugs and installed-tool dependency-health failures are treated as
   separate classes. Helpers fail closed before import-time crashes when the
   selected interpreter cannot import `pydantic_core._pydantic_core`.
-- The recurring cross-project drift after `at-g5a19`, `at-34t6h`, and
-  `at-s6qu4` was that projected helper entrypoints were still using multiple
-  bootstrap contracts. Some scripts re-execed into the repo runtime, while
-  others still imported `atelier` directly or only reordered `sys.path`.
-  Projected skill scripts that import `atelier` now share
+- The recurring cross-project drift after `at-g5a19`, `at-34t6h`, and `at-s6qu4`
+  was that projected helper entrypoints were still using multiple bootstrap
+  contracts. Some scripts re-execed into the repo runtime, while others still
+  imported `atelier` directly or only reordered `sys.path`. Projected skill
+  scripts that import `atelier` now share
   `src/atelier/skills/shared/scripts/projected_bootstrap.py`, so repo-source
-  selection, runtime re-exec, and dependency-health diagnostics stay in
-  lockstep for every helper entrypoint instead of drifting one script at a
-  time.
+  selection, runtime re-exec, and dependency-health diagnostics stay in lockstep
+  for every helper entrypoint instead of drifting one script at a time.
+- `at-e1yzp` fixed the shared bootstrap import contract but missed the synced
+  skill packaging topology: `shared/` was not a user skill, so
+  `sync_project_skills` ignored it even though projected scripts imported
+  `skills/shared/scripts/projected_bootstrap.py` at runtime. The old tests also
+  copied that helper directly into temp agent homes, which bypassed the actual
+  packaged-skill install path and let the gap ship. Synced skill installs now
+  package `shared/` as an internal support tree, and projected-runtime
+  regression tests execute from installed agent-home skills instead of manual
+  fixture copies.
 - Runtime warnings about removed inherited keys are now immediate guidance for
   explicit launch context, not future deprecation notices.
 

--- a/src/atelier/skills.py
+++ b/src/atelier/skills.py
@@ -25,6 +25,7 @@ _SKILLS_LOCK_DIRNAME = ".locks"
 _SKILLS_LOCK_FILENAME = "skills-sync.lock"
 _SKILLS_LOCK_GUARD = threading.Lock()
 _SKILLS_LOCAL_LOCKS: dict[str, threading.RLock] = {}
+_PACKAGED_SUPPORT_TREE_NAMES = frozenset({"shared"})
 
 
 @dataclass(frozen=True)
@@ -133,7 +134,7 @@ def _verify_skills_tree(
         return False
     for name, definition in definitions.items():
         skill_dir = skills_dir / name
-        if not (skill_dir / "SKILL.md").is_file():
+        if "SKILL.md" in definition.files and not (skill_dir / "SKILL.md").is_file():
             return False
         if _hash_dir(skill_dir) != definition.digest:
             return False
@@ -183,6 +184,26 @@ def _skills_root() -> Traversable:
     return resources.files("atelier").joinpath("skills")
 
 
+def _load_definition(name: str, root: Traversable) -> SkillDefinition:
+    files = _collect_files(root, Path())
+    digest = _hash_files(files)
+    return SkillDefinition(name=name, files=files, digest=digest)
+
+
+def _packaged_skill_tree_definitions() -> dict[str, SkillDefinition]:
+    """Return packaged skill trees, including internal support directories."""
+    root = _skills_root()
+    definitions: dict[str, SkillDefinition] = {}
+    for entry in root.iterdir():
+        if not entry.is_dir():
+            continue
+        is_user_skill = entry.joinpath("SKILL.md").is_file()
+        if not is_user_skill and entry.name not in _PACKAGED_SUPPORT_TREE_NAMES:
+            continue
+        definitions[entry.name] = _load_definition(entry.name, entry)
+    return definitions
+
+
 def list_packaged_skills() -> list[str]:
     root = _skills_root()
     if not root.is_dir():
@@ -223,15 +244,12 @@ def load_packaged_skills() -> dict[str, SkillDefinition]:
     root = _skills_root()
     definitions: dict[str, SkillDefinition] = {}
     for name in list_packaged_skills():
-        skill_root = root.joinpath(name)
-        files = _collect_files(skill_root, Path())
-        digest = _hash_files(files)
-        definitions[name] = SkillDefinition(name=name, files=files, digest=digest)
+        definitions[name] = _load_definition(name, root.joinpath(name))
     return definitions
 
 
 def packaged_skill_metadata() -> dict[str, dict[str, str]]:
-    definitions = load_packaged_skills()
+    definitions = _packaged_skill_tree_definitions()
     return {
         name: {"version": __version__, "hash": definition.digest}
         for name, definition in definitions.items()
@@ -252,7 +270,7 @@ def workspace_skill_state(
     workspace_dir: Path,
     stored_metadata: dict[str, object] | None,
 ) -> SkillWorkspaceState:
-    definitions = load_packaged_skills()
+    definitions = _packaged_skill_tree_definitions()
     packaged_meta = packaged_skill_metadata()
     raw_stored = stored_metadata or {}
     stored: dict[str, dict[str, str | None]] = {}
@@ -334,7 +352,7 @@ def workspace_skill_state(
 
 
 def install_workspace_skills(workspace_dir: Path) -> dict[str, dict[str, str]]:
-    definitions = load_packaged_skills()
+    definitions = _packaged_skill_tree_definitions()
     skills_dir = workspace_dir / paths.SKILLS_DIRNAME
     with _skills_write_lock(workspace_dir):
         staging_dir = _stage_skills_tree(workspace_dir, definitions)

--- a/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
+++ b/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
@@ -8,48 +8,29 @@ from pathlib import Path
 
 import pytest
 
+import atelier.skills as packaged_skills
+
+
+def _project_repo_root() -> Path:
+    return Path(__file__).resolve().parents[3]
+
 
 def _skills_source_root() -> Path:
-    return Path(__file__).resolve().parents[3] / "src" / "atelier" / "skills"
+    return _project_repo_root() / "src" / "atelier" / "skills"
 
 
-def _copy_script(
+def _install_projected_script(
     tmp_path: Path,
     *,
     skill_name: str,
     script_name: str,
 ) -> tuple[Path, Path]:
     agent_home = tmp_path / "agent-home"
-    projected_script = _copy_script_into_agent_home(
-        agent_home,
-        skill_name=skill_name,
-        script_name=script_name,
-    )
+    packaged_skills.install_workspace_skills(agent_home)
+    projected_script = agent_home / "skills" / skill_name / "scripts" / script_name
+    assert projected_script.exists()
+    assert (agent_home / "skills" / "shared" / "scripts" / "projected_bootstrap.py").is_file()
     return agent_home, projected_script
-
-
-def _copy_script_into_agent_home(
-    agent_home: Path,
-    *,
-    skill_name: str,
-    script_name: str,
-) -> Path:
-    skills_root = _skills_source_root()
-    source_script = skills_root / skill_name / "scripts" / script_name
-    projected_bootstrap = skills_root / "shared" / "scripts" / "projected_bootstrap.py"
-    projected_bootstrap_target = (
-        agent_home / "skills" / "shared" / "scripts" / "projected_bootstrap.py"
-    )
-    projected_bootstrap_target.parent.mkdir(parents=True, exist_ok=True)
-    projected_bootstrap_target.write_text(
-        projected_bootstrap.read_text(encoding="utf-8"),
-        encoding="utf-8",
-    )
-    script_dir = agent_home / "skills" / skill_name / "scripts"
-    script_dir.mkdir(parents=True, exist_ok=True)
-    projected_script = script_dir / script_name
-    projected_script.write_text(source_script.read_text(encoding="utf-8"), encoding="utf-8")
-    return projected_script
 
 
 def _write_fake_module(path: Path, content: str) -> None:
@@ -182,8 +163,34 @@ def test_all_projected_skill_scripts_importing_atelier_use_shared_bootstrap() ->
     assert missing_bootstrap == []
 
 
+@pytest.mark.parametrize(
+    ("skill_name", "script_name"),
+    (
+        ("planner-startup-check", "refresh_overview.py"),
+        ("plan-create-epic", "create_epic.py"),
+        ("plan-changeset-guardrails", "check_guardrails.py"),
+        ("tickets", "auto_export_issue.py"),
+    ),
+)
+def test_synced_agent_home_includes_shared_bootstrap_dependency_path(
+    tmp_path: Path,
+    *,
+    skill_name: str,
+    script_name: str,
+) -> None:
+    agent_home, projected_script = _install_projected_script(
+        tmp_path,
+        skill_name=skill_name,
+        script_name=script_name,
+    )
+    shared_bootstrap = agent_home / "skills" / "shared" / "scripts" / "projected_bootstrap.py"
+
+    assert projected_script.is_file()
+    assert shared_bootstrap.is_file()
+
+
 def test_projected_create_epic_prefers_agent_worktree_source(tmp_path: Path) -> None:
-    agent_home, projected_script = _copy_script(
+    agent_home, projected_script = _install_projected_script(
         tmp_path,
         skill_name="plan-create-epic",
         script_name="create_epic.py",
@@ -212,7 +219,7 @@ def test_projected_create_epic_prefers_agent_worktree_source(tmp_path: Path) -> 
 def test_projected_create_epic_reorders_repo_src_ahead_of_installed_package(
     tmp_path: Path,
 ) -> None:
-    agent_home, projected_script = _copy_script(
+    agent_home, projected_script = _install_projected_script(
         tmp_path,
         skill_name="plan-create-epic",
         script_name="create_epic.py",
@@ -267,7 +274,7 @@ def test_projected_create_epic_reorders_repo_src_ahead_of_installed_package(
 
 
 def test_projected_auto_export_prefers_explicit_repo_dir_source(tmp_path: Path) -> None:
-    agent_home, projected_script = _copy_script(
+    agent_home, projected_script = _install_projected_script(
         tmp_path,
         skill_name="tickets",
         script_name="auto_export_issue.py",
@@ -301,7 +308,7 @@ def test_projected_auto_export_prefers_explicit_repo_dir_source(tmp_path: Path) 
 def test_projected_check_guardrails_reorders_repo_src_ahead_of_installed_package(
     tmp_path: Path,
 ) -> None:
-    agent_home, projected_script = _copy_script(
+    agent_home, projected_script = _install_projected_script(
         tmp_path,
         skill_name="plan-changeset-guardrails",
         script_name="check_guardrails.py",
@@ -383,7 +390,7 @@ def test_projected_check_guardrails_reorders_repo_src_ahead_of_installed_package
 def test_projected_render_tickets_section_reorders_repo_src_ahead_of_installed_package(
     tmp_path: Path,
 ) -> None:
-    agent_home, projected_script = _copy_script(
+    agent_home, projected_script = _install_projected_script(
         tmp_path,
         skill_name="pr-draft",
         script_name="render_tickets_section.py",
@@ -454,7 +461,7 @@ def test_projected_render_tickets_section_reorders_repo_src_ahead_of_installed_p
 def test_projected_refresh_overview_reorders_repo_src_ahead_of_installed_package(
     tmp_path: Path,
 ) -> None:
-    agent_home, projected_script = _copy_script(
+    agent_home, projected_script = _install_projected_script(
         tmp_path,
         skill_name="planner-startup-check",
         script_name="refresh_overview.py",
@@ -592,20 +599,10 @@ def test_projected_refresh_overview_reorders_repo_src_ahead_of_installed_package
 def test_projected_refresh_overview_fails_closed_when_repo_runtime_is_dependency_unhealthy(
     tmp_path: Path,
 ) -> None:
-    agent_home, projected_script = _copy_script(
+    agent_home, projected_script = _install_projected_script(
         tmp_path,
         skill_name="planner-startup-check",
         script_name="refresh_overview.py",
-    )
-    _copy_script_into_agent_home(
-        agent_home,
-        skill_name="plan-create-epic",
-        script_name="create_epic.py",
-    )
-    _copy_script_into_agent_home(
-        agent_home,
-        skill_name="tickets",
-        script_name="auto_export_issue.py",
     )
     repo_root = _fake_repo(
         tmp_path,
@@ -763,7 +760,7 @@ def test_projected_refresh_overview_fails_closed_when_repo_runtime_is_dependency
 def test_projected_check_issue_ownership_fails_closed_when_repo_runtime_is_dependency_unhealthy(
     tmp_path: Path,
 ) -> None:
-    agent_home, projected_script = _copy_script(
+    agent_home, projected_script = _install_projected_script(
         tmp_path,
         skill_name="beads",
         script_name="check_issue_ownership.py",

--- a/tests/atelier/test_skills.py
+++ b/tests/atelier/test_skills.py
@@ -58,6 +58,10 @@ def test_install_workspace_skills_writes_skill_docs() -> None:
         workspace_dir = Path(tmp)
         metadata = skills.install_workspace_skills(workspace_dir)
         assert metadata
+        assert "shared" in metadata
+        assert (
+            workspace_dir / "skills" / "shared" / "scripts" / "projected_bootstrap.py"
+        ).is_file()
         for name in (
             "publish",
             "github",
@@ -211,6 +215,19 @@ def test_sync_project_skills_updates_when_packaged_skill_missing() -> None:
         result = skills.sync_project_skills(project_dir)
         assert result.action == "updated"
         assert stale_skill.exists()
+
+
+def test_sync_project_skills_updates_when_shared_support_tree_missing() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        project_dir = Path(tmp)
+        skills.install_workspace_skills(project_dir)
+        support_tree = project_dir / "skills" / "shared"
+        shutil.rmtree(support_tree)
+
+        result = skills.sync_project_skills(project_dir)
+
+        assert result.action == "updated"
+        assert (support_tree / "scripts" / "projected_bootstrap.py").is_file()
 
 
 def test_sync_project_skills_applies_upgrade_with_yes() -> None:


### PR DESCRIPTION
# Summary

- Package the internal `shared/` support tree during skill sync so projected helper installs carry `projected_bootstrap.py`.
- Keep user-facing skill discovery unchanged while fixing install, verification, and metadata reconciliation for synced agent-home skill trees.

# Changes

- teach `src/atelier/skills.py` to install explicit support trees like `shared/` alongside normal packaged skills
- replace manual `projected_bootstrap.py` fixture copies with synced-install regression coverage in the projected runtime and skill sync tests
- document why the earlier runtime fix missed the packaging-topology gap

# Testing

- `just lint`
- `just test`

# Tickets

- Fixes #640

# Risks / Rollout

- Low: this changes packaged skill sync behavior and regression coverage only; user-facing skill selection remains unchanged.

# Notes

- This addresses the packaged-skill topology bug separately from prior runtime dependency drift work.
