### PR TITLE
Fix authored re-split trigger handling in guardrail checks

### DIFF
--- a/src/atelier/skills/plan-changeset-guardrails/scripts/check_guardrails.py
+++ b/src/atelier/skills/plan-changeset-guardrails/scripts/check_guardrails.py
@@ -72,11 +72,14 @@ _CONCERN_DOMAINS: dict[str, re.Pattern[str]] = {
     ),
 }
 _RESPLIT_THRESHOLD_TRIGGER = re.compile(
-    r"\b(?:re[- ]?split triggers?|split triggers?|re[- ]?split criteria|"
+    r"\b(?:re[-_ ]?split triggers?|split triggers?|re[-_ ]?split criteria|"
     r"split criteria|loc threshold|file threshold)\b",
     re.IGNORECASE,
 )
-_RESPLIT_THRESHOLD_NUMERIC = re.compile(r">\s*(?:400|800)\b")
+_RESPLIT_THRESHOLD_NUMERIC = re.compile(
+    r"(?:>\s*|~\s*)(?:400|800)\b(?:\s*loc\b)?",
+    re.IGNORECASE,
+)
 _RESPLIT_NEW_DOMAIN_TRIGGER = re.compile(
     r"\b(?:new concern domain|additional concern domain|new domain during review|"
     r"expand(?:s)? into broad [a-z0-9/ -]+ redesign|broad [a-z0-9/ -]+ redesign)\b",

--- a/tests/atelier/skills/test_plan_changeset_guardrails_script.py
+++ b/tests/atelier/skills/test_plan_changeset_guardrails_script.py
@@ -286,6 +286,43 @@ def test_evaluate_guardrails_accepts_broad_redesign_resplit_trigger_wording() ->
     assert not any("missing explicit re-split triggers" in item for item in report.violations)
 
 
+def test_evaluate_guardrails_accepts_underscored_resplit_header_with_tilde_threshold() -> None:
+    module = _load_script_module()
+    epic = {
+        "id": "at-epic",
+        "labels": ["at:epic"],
+        "title": "Align guardrail checker with authored planner notes",
+        "description": _planner_contract_text(),
+        "notes": (
+            "LOC estimate: 320\n"
+            "Invariant impact map:\n"
+            "- mutation entry points\n"
+            "- recovery paths\n"
+            "- external side-effect adapters\n"
+            "re_split_triggers:\n"
+            "- threshold crossing: split if any active changeset trends above ~400 LOC\n"
+            "- threshold crossing: split if review expands a changeset beyond its "
+            "declared planner concern domain\n"
+            "- new concern domain discovered during review: split if provider-boundary "
+            "work or a new store semantic appears\n"
+            "planner_action_on_resplit: create deferred follow-on changesets or stack "
+            "extensions immediately and keep the active slice scoped.\n"
+            "review_scope_growth_guidance: if review feedback uncovers a new planner "
+            "concern domain, capture it as deferred follow-on work instead of widening "
+            "the active changeset."
+        ),
+        "acceptance_criteria": "Done when authored re_split trigger notes no longer fail.",
+    }
+
+    report = module._evaluate_guardrails(
+        epic_issue=epic,
+        child_changesets=[],
+        target_changesets=[epic],
+    )
+
+    assert not any("missing explicit re-split triggers" in item for item in report.violations)
+
+
 def test_evaluate_guardrails_flags_cross_cutting_guardrail_gaps() -> None:
     module = _load_script_module()
     epic = {


### PR DESCRIPTION
# Summary

- Accept authored `re_split_triggers` notes in the guardrail checker so valid planner notes stop tripping false-positive re-split violations.

# Changes

- Allow underscore-separated re-split trigger headers in `plan-changeset-guardrails`.
- Treat `~400 LOC` threshold wording as a valid re-split threshold signal.
- Add regression coverage for the authored planner note shape that previously failed validation.

# Testing

- `uv run pytest tests/atelier/skills/test_plan_changeset_guardrails_script.py -q`
- `just format`
- `just lint`
- `just test`

# Tickets

- Fixes #656

# Risks / Rollout

- Low risk; the change is limited to planner-note matching logic and regression tests.

# Notes

- Keeps the existing planner authoring contract intact and only broadens checker recognition to note shapes already authored in practice.
