### PR TITLE
Fix projected skill mixed-runtime dependency drift

### DIFF
--- a/src/atelier/agents.py
+++ b/src/atelier/agents.py
@@ -277,6 +277,7 @@ def agent_environment(
         Sanitized launch environment with required identity variables injected.
     """
     env, removed = runtime_env.sanitize_subprocess_environment(base_env=base_env)
+    env, removed_pythonpath = runtime_env.sanitize_pythonpath_environment(base_env=env)
     warning_keys = _warning_removed_routing_keys(
         removed=removed,
         base_env=base_env,
@@ -285,6 +286,9 @@ def agent_environment(
     warning = runtime_env.format_ambient_env_warning(warning_keys)
     if warning and warn is not None:
         warn(warning)
+    pythonpath_warning = runtime_env.format_ambient_pythonpath_warning(removed_pythonpath)
+    if pythonpath_warning and warn is not None:
+        warn(pythonpath_warning)
     if agent_id:
         env["ATELIER_AGENT_ID"] = agent_id
         env["BD_ACTOR"] = agent_id

--- a/src/atelier/runtime_env.py
+++ b/src/atelier/runtime_env.py
@@ -6,18 +6,26 @@ import importlib
 import os
 import shutil
 import sys
+import sysconfig
 from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
 
 _WARNING_SAMPLE_LIMIT = 6
 _PROJECTED_RUNTIME_SELECTED_ENV = "ATELIER_PROJECTED_RUNTIME_SELECTED"
 _PROJECTED_RUNTIME_DEPENDENCY = "pydantic_core._pydantic_core"
+_PROJECTED_RUNTIME_PROVENANCE_MODULES: tuple[str, ...] = (
+    "pydantic",
+    "pydantic_core",
+    _PROJECTED_RUNTIME_DEPENDENCY,
+)
 _INSTALLED_TOOL_RUNTIME_MARKERS: tuple[str, ...] = (
     "/.local/share/uv/tools/atelier/",
     "/Library/Application Support/uv/tools/atelier/",
     "/site-packages/atelier/",
 )
+_PYTHONPATH_ENV = "PYTHONPATH"
 
 USER_DEFAULT_ENV_KEYS: frozenset[str] = frozenset(
     {
@@ -33,6 +41,13 @@ USER_DEFAULT_ENV_KEYS: frozenset[str] = frozenset(
         "ATELIER_STARTUP_DEFERRED_EPIC_SCAN_LIMIT",
     }
 )
+
+
+@dataclass(frozen=True)
+class _ProjectedRuntimeProvenanceIssue:
+    module_name: str
+    module_path: str
+    expected_roots: tuple[str, ...]
 
 
 def sanitize_subprocess_environment(
@@ -89,6 +104,54 @@ def format_ambient_env_warning(removed_keys: Iterable[str]) -> str | None:
         f"({sample}{suffix}). "
         "Use explicit launch context (for example --repo-dir or the local "
         "./worktree link) instead of ambient ATELIER_* routing state."
+    )
+
+
+def sanitize_pythonpath_environment(
+    *,
+    base_env: Mapping[str, str] | None = None,
+) -> tuple[dict[str, str], tuple[str, ...]]:
+    """Return an environment without inherited ``PYTHONPATH`` entries.
+
+    Atelier-managed agent and projected-skill runtimes do not inherit ambient
+    ``PYTHONPATH`` because it can mix a selected interpreter with third-party
+    packages from another distribution tree.
+
+    Args:
+        base_env: Optional source environment map. When omitted, current process
+            environment is used.
+
+    Returns:
+        Tuple of ``(sanitized_env, removed_entries)`` where ``removed_entries``
+        are the inherited ``PYTHONPATH`` entries that were dropped.
+    """
+    env = dict(os.environ if base_env is None else base_env)
+    removed_entries = _pythonpath_entries(env.get(_PYTHONPATH_ENV))
+    env.pop(_PYTHONPATH_ENV, None)
+    return env, removed_entries
+
+
+def format_ambient_pythonpath_warning(removed_entries: Iterable[str]) -> str | None:
+    """Build a warning for dropped inherited ``PYTHONPATH`` entries.
+
+    Args:
+        removed_entries: Iterable of dropped ``PYTHONPATH`` entries.
+
+    Returns:
+        User-facing warning text when entries were removed; otherwise ``None``.
+    """
+    unique = sorted({entry for entry in removed_entries if entry})
+    if not unique:
+        return None
+    sample = ", ".join(unique[:_WARNING_SAMPLE_LIMIT])
+    suffix = ""
+    if len(unique) > _WARNING_SAMPLE_LIMIT:
+        suffix = f", +{len(unique) - _WARNING_SAMPLE_LIMIT} more"
+    return (
+        "Warning: ignored inherited PYTHONPATH entries "
+        f"({sample}{suffix}). "
+        "Atelier-managed runtimes rebuild Python imports from the selected "
+        "repo runtime instead of mixing in ambient site-packages."
     )
 
 
@@ -209,10 +272,67 @@ def ensure_projected_runtime_dependency(
             interpreter.
     """
     try:
-        importlib.import_module(dependency)
-        return
+        imported_modules = tuple(
+            (module_name, importlib.import_module(module_name))
+            for module_name in _projected_runtime_dependency_modules(dependency)
+        )
     except Exception as exc:
         dependency_error = exc
+    else:
+        provenance_issues = _projected_runtime_provenance_issues(imported_modules)
+        if not provenance_issues:
+            return
+        provenance_issue = provenance_issues[0]
+        command = (
+            projected_repo_python_command(
+                repo_root=repo_root,
+                base_env=base_env,
+                current_executable=current_executable or sys.executable,
+            )
+            if repo_root is not None
+            else None
+        )
+        runtime_label = _projected_runtime_label(
+            current_executable=str(current_executable or sys.executable or "").strip(),
+            script_path=script_path,
+        )
+        repo_display = str(repo_root) if repo_root is not None else "(unresolved)"
+        print(
+            "error: planner helper runtime provenance is mixed before importing atelier modules.",
+            file=sys.stderr,
+        )
+        print(
+            "boundary: repo-source bootstrap is separate; this is a dependency "
+            "provenance contradiction, not another src-path-ordering regression.",
+            file=sys.stderr,
+        )
+        print(f"script: {script_path}", file=sys.stderr)
+        print(
+            f"interpreter: {str(current_executable or sys.executable or '').strip() or '(unknown)'}",
+            file=sys.stderr,
+        )
+        print(f"runtime: {runtime_label}", file=sys.stderr)
+        print(f"repo_root: {repo_display}", file=sys.stderr)
+        print(f"module: {provenance_issue.module_name}", file=sys.stderr)
+        print(f"module_path: {provenance_issue.module_path}", file=sys.stderr)
+        print(
+            "expected_roots: " + ", ".join(provenance_issue.expected_roots or ("(unresolved)",)),
+            file=sys.stderr,
+        )
+        ambient_pythonpath = str(os.environ.get(_PYTHONPATH_ENV, "")).strip()
+        if ambient_pythonpath:
+            print(f"ambient_pythonpath: {ambient_pythonpath}", file=sys.stderr)
+        print(
+            "action: "
+            + _projected_runtime_recovery_guidance(
+                repo_root=repo_root,
+                script_path=script_path,
+                runtime_label=runtime_label,
+                command=command,
+            ),
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 
     env = dict(os.environ if base_env is None else base_env)
     current = str(current_executable or sys.executable or "").strip()
@@ -318,3 +438,99 @@ def _projected_runtime_recovery_guidance(
         "repair the selected Python runtime so it can import compiled "
         "dependencies, then rerun the helper."
     )
+
+
+def _pythonpath_entries(raw_pythonpath: str | None) -> tuple[str, ...]:
+    raw = str(raw_pythonpath or "").strip()
+    if not raw:
+        return ()
+    return tuple(entry for entry in raw.split(os.pathsep) if entry)
+
+
+def reset_current_process_pythonpath(
+    entries: Iterable[str],
+    *,
+    preserve_paths: Iterable[str] = (),
+) -> None:
+    """Remove inherited ``PYTHONPATH`` entries from the active process state.
+
+    Args:
+        entries: ``PYTHONPATH`` entries to drop from ``sys.path``.
+        preserve_paths: Explicit paths that must remain in ``sys.path`` even if
+            they also appeared in ``entries``.
+    """
+    os.environ.pop(_PYTHONPATH_ENV, None)
+    removed = {entry for entry in entries if entry}
+    if not removed:
+        return
+    preserved = {entry for entry in preserve_paths if entry}
+    sys.path[:] = [entry for entry in sys.path if entry not in removed or entry in preserved]
+
+
+def _projected_runtime_dependency_modules(dependency: str) -> tuple[str, ...]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for module_name in (*_PROJECTED_RUNTIME_PROVENANCE_MODULES, dependency):
+        normalized = str(module_name).strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        names.append(normalized)
+    return tuple(names)
+
+
+def _projected_runtime_provenance_issues(
+    imported_modules: Sequence[tuple[str, object]],
+) -> tuple[_ProjectedRuntimeProvenanceIssue, ...]:
+    allowed_roots = _current_runtime_dependency_roots()
+    expected_roots = tuple(str(root) for root in allowed_roots)
+    issues: list[_ProjectedRuntimeProvenanceIssue] = []
+    for module_name, module in imported_modules:
+        module_path = _module_origin_path(module)
+        if module_path is None:
+            continue
+        if _path_within_roots(module_path, allowed_roots):
+            continue
+        issues.append(
+            _ProjectedRuntimeProvenanceIssue(
+                module_name=module_name,
+                module_path=str(module_path),
+                expected_roots=expected_roots,
+            )
+        )
+    return tuple(issues)
+
+
+def _current_runtime_dependency_roots() -> tuple[Path, ...]:
+    roots: list[Path] = []
+    for key in ("purelib", "platlib"):
+        raw_path = str(sysconfig.get_path(key) or "").strip()
+        if not raw_path:
+            continue
+        resolved = Path(raw_path).resolve()
+        if resolved not in roots:
+            roots.append(resolved)
+    return tuple(roots)
+
+
+def _module_origin_path(module: object) -> Path | None:
+    raw_path = getattr(module, "__file__", None)
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        spec = getattr(module, "__spec__", None)
+        raw_path = getattr(spec, "origin", None)
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    try:
+        return Path(raw_path).resolve()
+    except OSError:
+        return Path(raw_path)
+
+
+def _path_within_roots(path: Path, roots: Sequence[Path]) -> bool:
+    for root in roots:
+        try:
+            path.relative_to(root)
+        except ValueError:
+            continue
+        return True
+    return False

--- a/src/atelier/skills/shared/scripts/projected_bootstrap.py
+++ b/src/atelier/skills/shared/scripts/projected_bootstrap.py
@@ -109,6 +109,14 @@ def bootstrap_projected_atelier_script(
     from atelier.runtime_env import (
         ensure_projected_runtime_dependency,
         maybe_reexec_projected_repo_runtime,
+        reset_current_process_pythonpath,
+        sanitize_pythonpath_environment,
+    )
+
+    resolved_env, removed_pythonpath = sanitize_pythonpath_environment(base_env=resolved_env)
+    reset_current_process_pythonpath(
+        removed_pythonpath,
+        preserve_paths=(str(repo_root / "src") if repo_root is not None else "",),
     )
 
     if require_runtime_health:

--- a/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
+++ b/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
@@ -91,6 +91,21 @@ def _fake_installed_package(tmp_path: Path, *, modules: dict[str, str]) -> Path:
     return installed_root
 
 
+def _fake_mixed_runtime_site_packages(
+    tmp_path: Path,
+    *,
+    atelier_modules: dict[str, str],
+) -> Path:
+    installed_root = _fake_installed_package(tmp_path, modules=atelier_modules)
+    _write_fake_module(installed_root / "pydantic" / "__init__.py", "__version__ = 'installed'\n")
+    _write_fake_module(
+        installed_root / "pydantic_core" / "__init__.py",
+        "from . import _pydantic_core\n",
+    )
+    _write_fake_module(installed_root / "pydantic_core" / "_pydantic_core.py", "")
+    return installed_root
+
+
 def _link_repo_python(repo_root: Path) -> None:
     repo_python = repo_root / ".venv" / "bin" / "python3"
     repo_python.parent.mkdir(parents=True, exist_ok=True)
@@ -142,6 +157,22 @@ def _ambient_python_executable() -> str:
         if version_probe.returncode == 0 and version_probe.stdout.strip() == "True":
             return str(candidate)
     pytest.skip("no distinct Python 3.10+ executable available for projected-runtime test")
+
+
+def _pydantic_provenance_sentinel_module(env_var: str) -> str:
+    return "\n".join(
+        [
+            "from pathlib import Path",
+            "import os",
+            "import pydantic",
+            "",
+            f"Path(os.environ['{env_var}']).write_text(",
+            "    pydantic.__file__ or '',",
+            "    encoding='utf-8',",
+            ")",
+            "",
+        ]
+    )
 
 
 def test_all_projected_skill_scripts_importing_atelier_use_shared_bootstrap() -> None:
@@ -273,6 +304,55 @@ def test_projected_create_epic_reorders_repo_src_ahead_of_installed_package(
     )
 
 
+def test_projected_create_epic_ignores_inherited_pythonpath_when_repo_runtime_matches(
+    tmp_path: Path,
+) -> None:
+    agent_home, projected_script = _install_projected_script(
+        tmp_path,
+        skill_name="plan-create-epic",
+        script_name="create_epic.py",
+    )
+    repo_root = _fake_repo(
+        tmp_path,
+        sentinel_import="bootstrap_marker",
+        extra_modules={
+            "auto_export.py": _pydantic_provenance_sentinel_module("PYDANTIC_SENTINEL"),
+        },
+    )
+    _link_repo_python(repo_root)
+    installed_root = _fake_mixed_runtime_site_packages(
+        tmp_path,
+        atelier_modules={
+            "auto_export.py": "raise RuntimeError('installed auto_export should not load')\n",
+        },
+    )
+    sentinel_path = tmp_path / "create-epic-pydantic-sentinel.txt"
+
+    completed = subprocess.run(
+        [
+            str(repo_root / ".venv" / "bin" / "python3"),
+            str(projected_script),
+            "--repo-dir",
+            str(repo_root),
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=agent_home,
+        env={
+            "PYDANTIC_SENTINEL": str(sentinel_path),
+            "PYTHONPATH": os.pathsep.join([str(installed_root), str(repo_root / "src")]),
+        },
+    )
+
+    assert completed.returncode == 0
+    assert sentinel_path.exists()
+    assert sentinel_path.read_text(encoding="utf-8") != str(
+        installed_root / "pydantic" / "__init__.py"
+    )
+
+
 def test_projected_auto_export_prefers_explicit_repo_dir_source(tmp_path: Path) -> None:
     agent_home, projected_script = _install_projected_script(
         tmp_path,
@@ -384,6 +464,77 @@ def test_projected_check_guardrails_reorders_repo_src_ahead_of_installed_package
     assert completed.returncode == 0
     assert sentinel_path.read_text(encoding="utf-8") == str(
         repo_root / "src" / "atelier" / "beads_context.py"
+    )
+
+
+def test_projected_check_guardrails_ignores_inherited_pythonpath_when_repo_runtime_matches(
+    tmp_path: Path,
+) -> None:
+    agent_home, projected_script = _install_projected_script(
+        tmp_path,
+        skill_name="plan-changeset-guardrails",
+        script_name="check_guardrails.py",
+    )
+    repo_root = _fake_repo(
+        tmp_path,
+        sentinel_import="bootstrap_marker",
+        extra_modules={
+            "bd_invocation.py": (
+                "def with_bd_mode(*args, beads_dir=None, env=None):\n    return ['bd', *args]\n"
+            ),
+            "beads_context.py": (
+                _pydantic_provenance_sentinel_module("PYDANTIC_SENTINEL")
+                + "\n"
+                + "def resolve_runtime_repo_dir_hint(*, repo_dir=None, cwd=None, env=None):\n"
+                + "    return (repo_dir, None)\n"
+            ),
+            "planner_contract.py": (
+                "def validate_authoring_contract(*_args, **_kwargs):\n    return []\n"
+            ),
+        },
+    )
+    _link_repo_python(repo_root)
+    installed_root = _fake_mixed_runtime_site_packages(
+        tmp_path,
+        atelier_modules={
+            "beads.py": "raise RuntimeError('installed beads should not load')\n",
+            "bd_invocation.py": (
+                "def with_bd_mode(*args, beads_dir=None, env=None):\n"
+                "    return ['installed', *args]\n"
+            ),
+            "beads_context.py": (
+                "def resolve_runtime_repo_dir_hint(*, repo_dir=None, cwd=None, env=None):\n"
+                "    return (repo_dir, None)\n"
+            ),
+            "planner_contract.py": (
+                "def validate_authoring_contract(*_args, **_kwargs):\n    return []\n"
+            ),
+        },
+    )
+    sentinel_path = tmp_path / "check-guardrails-pydantic-sentinel.txt"
+
+    completed = subprocess.run(
+        [
+            str(repo_root / ".venv" / "bin" / "python3"),
+            str(projected_script),
+            "--repo-dir",
+            str(repo_root),
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=agent_home,
+        env={
+            "PYDANTIC_SENTINEL": str(sentinel_path),
+            "PYTHONPATH": os.pathsep.join([str(installed_root), str(repo_root / "src")]),
+        },
+    )
+
+    assert completed.returncode == 0
+    assert sentinel_path.exists()
+    assert sentinel_path.read_text(encoding="utf-8") != str(
+        installed_root / "pydantic" / "__init__.py"
     )
 
 

--- a/tests/atelier/test_agents.py
+++ b/tests/atelier/test_agents.py
@@ -281,14 +281,14 @@ class TestAgentSpec:
         assert env["BEADS_AGENT_NAME"] == "planner/test-session"
         assert env["PYTHONPATH"].split(os.pathsep)[0] == expected_root
 
-    def test_agent_environment_preserves_existing_pythonpath_entries(self) -> None:
+    def test_agent_environment_replaces_inherited_pythonpath_entries(self) -> None:
         expected_root = str(Path(agents.__file__).resolve().parent.parent)
         existing = ["/tmp/one", expected_root, "/tmp/two", "/tmp/one"]
         env = agents.agent_environment(
             "planner/test-session",
             base_env={"PYTHONPATH": os.pathsep.join(existing)},
         )
-        assert env["PYTHONPATH"].split(os.pathsep) == [expected_root, "/tmp/one", "/tmp/two"]
+        assert env["PYTHONPATH"].split(os.pathsep) == [expected_root]
 
     def test_agent_environment_drops_inherited_runtime_routing_keys(self) -> None:
         env = agents.agent_environment(
@@ -314,6 +314,21 @@ class TestAgentSpec:
         assert len(warnings) == 1
         assert "ATELIER_PROJECT" in warnings[0]
         assert "--repo-dir" in warnings[0]
+
+    def test_agent_environment_warns_when_inherited_pythonpath_is_sanitized(self) -> None:
+        warnings: list[str] = []
+        env = agents.agent_environment(
+            "planner/test-session",
+            base_env={"PYTHONPATH": "/tmp/foreign/site-packages"},
+            warn=warnings.append,
+        )
+
+        assert len(warnings) == 1
+        assert "PYTHONPATH" in warnings[0]
+        assert "/tmp/foreign/site-packages" in warnings[0]
+        assert env["PYTHONPATH"].split(os.pathsep)[0] == str(
+            Path(agents.__file__).resolve().parent.parent
+        )
 
     def test_agent_environment_does_not_warn_for_self_scoped_agent_id(self) -> None:
         warnings: list[str] = []

--- a/tests/atelier/test_runtime_env.py
+++ b/tests/atelier/test_runtime_env.py
@@ -40,6 +40,28 @@ def test_format_ambient_env_warning_includes_removed_keys_and_migration_guidance
     assert "./worktree" in warning
 
 
+def test_sanitize_pythonpath_environment_drops_inherited_entries() -> None:
+    env, removed = runtime_env.sanitize_pythonpath_environment(
+        base_env={
+            "PYTHONPATH": "/tmp/one:/tmp/two",
+            "PATH": "/usr/bin",
+        }
+    )
+
+    assert "PYTHONPATH" not in env
+    assert env["PATH"] == "/usr/bin"
+    assert removed == ("/tmp/one", "/tmp/two")
+
+
+def test_format_ambient_pythonpath_warning_includes_removed_entries() -> None:
+    warning = runtime_env.format_ambient_pythonpath_warning(("/tmp/one", "/tmp/two"))
+
+    assert warning is not None
+    assert "/tmp/one" in warning
+    assert "/tmp/two" in warning
+    assert "selected repo runtime" in warning
+
+
 def test_sanitize_subprocess_environment_empty_mapping_does_not_inherit_ambient(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -101,7 +123,61 @@ def test_ensure_projected_runtime_dependency_returns_when_import_succeeds(
         script_path=Path("/repo/skills/example.py"),
     )
 
-    assert imported == ["pydantic_core._pydantic_core"]
+    assert imported == [
+        "pydantic",
+        "pydantic_core",
+        "pydantic_core._pydantic_core",
+    ]
+
+
+def test_ensure_projected_runtime_dependency_fails_closed_for_provenance_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    class _FakeModule:
+        def __init__(self, module_file: str) -> None:
+            self.__file__ = module_file
+
+    module_map = {
+        "pydantic": _FakeModule("/tmp/foreign/pydantic/__init__.py"),
+        "pydantic_core": _FakeModule(
+            "/repo/.venv/lib/python3.11/site-packages/pydantic_core/__init__.py"
+        ),
+        "pydantic_core._pydantic_core": _FakeModule(
+            "/repo/.venv/lib/python3.11/site-packages/pydantic_core/_pydantic_core.so"
+        ),
+    }
+
+    monkeypatch.setattr(
+        runtime_env.importlib,
+        "import_module",
+        lambda name: module_map[name],
+    )
+    monkeypatch.setattr(
+        runtime_env.sysconfig,
+        "get_path",
+        lambda key: {
+            "purelib": "/repo/.venv/lib/python3.11/site-packages",
+            "platlib": "/repo/.venv/lib/python3.11/site-packages",
+        }[key],
+    )
+    monkeypatch.setattr(runtime_env, "projected_repo_python_command", lambda **_kwargs: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        runtime_env.ensure_projected_runtime_dependency(
+            repo_root=Path("/repo"),
+            script_path=Path("/repo/skills/example.py"),
+            current_executable="/repo/.venv/bin/python3",
+        )
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "runtime provenance is mixed" in captured.err
+    assert "module: pydantic" in captured.err
+    assert "module_path:" in captured.err
+    assert "foreign/pydantic/__init__.py" in captured.err
+    assert "expected_roots: /repo/.venv/lib/python3.11/site-packages" in captured.err
+    assert "dependency provenance contradiction" in captured.err
 
 
 def test_ensure_projected_runtime_dependency_fails_closed_for_installed_tool_runtime(


### PR DESCRIPTION
# Summary

- Prevent projected Atelier skills from inheriting ambient `PYTHONPATH` and mixing a repo-selected interpreter with third-party packages from another environment.

# Changes

- Strip inherited `PYTHONPATH` from Atelier-managed agent launches and projected skill bootstrap before runtime health checks.
- Fail closed when projected helpers resolve `pydantic` or `pydantic_core` outside the selected interpreter's own site-packages.
- Add regression coverage for contaminated agent environments and projected `plan-create-epic` plus `plan-changeset-guardrails` entrypoints.

# Testing

- `just format`
- `just lint`
- `just test`

# Tickets

- None

# Risks / Rollout

- Projected skills now intentionally ignore ambient `PYTHONPATH`; any workflow that depended on injecting external Python paths into Atelier-managed runtimes will fail closed and must use the selected repo runtime instead.

# Notes

- This changeset turns the intermittent mixed-runtime repro into explicit runtime isolation plus provenance diagnostics before planners or workers hit a later import failure.
