### PR TITLE
Prove planner store migration parity

### DIFF
--- a/docs/planner-store-migration-contract.md
+++ b/docs/planner-store-migration-contract.md
@@ -1,0 +1,100 @@
+# Planner Store Migration Contract
+
+Planner startup, discovery, message, and authoring flows now depend on
+`atelier.store` as the planner-side issue-store boundary.
+
+This document narrows that statement to the planner runtime. It explains which
+planner entry points are proven against `AtelierStore`, which compatibility
+seams are still adapter-local, and which follow-on gaps remain deferred for
+later epics.
+
+## Proven Planner Boundary
+
+Planner code can treat the following paths as store-backed today:
+
+- startup and discovery reads in `planner_startup_check` and `planner_overview`
+- planner authoring in `plan-create-epic` and `plan-changesets`
+- planner message reads and mutations in `mail-inbox`, `mail-send`,
+  `mail-queue-claim`, and `mail-mark-read`
+- planner promotion lifecycle mutations in `plan-promote-epic`
+
+Those flows should depend on `AtelierStore` plus the typed request/query models
+it publishes:
+
+- `EpicQuery`, `ChangesetQuery`, and `MessageQuery` for planner reads
+- `CreateEpicRequest` and `CreateChangesetRequest` for planner authoring
+- `CreateMessageRequest`, `ClaimMessageRequest`, and `MarkMessageReadRequest`
+  for planner message handling
+- `LifecycleTransitionRequest` for promotion from `deferred` to `open`
+
+Planner modules should not compose raw `bd` argv for those business flows. Raw
+Beads usage is still appropriate for transport diagnostics, startup recovery,
+and compatibility-only projections that are intentionally outside the published
+store surface.
+
+## Planner Compatibility Seams
+
+Two planner-visible compatibility seams remain intentional for now:
+
+- startup and mailbox flows may call the adapter-local
+  `_list_startup_messages()` projection when it is available so planner startup
+  can still surface legacy assignee-routed messages during migration. That
+  projection is startup-only compatibility state, not part of `atelier.store`.
+- `mail-send` still writes an assignee recipient hint after creating the durable
+  work-threaded message. That assignee value is a compatibility hint for current
+  runtime discovery. The durable planner contract is still the thread id, thread
+  kind, audience, blocking flag, and reply linkage persisted through
+  `CreateMessageRequest`.
+
+Planner logic should rely on the store-level message contract first and treat
+compatibility hints as best-effort adapter state only.
+
+## Newly Exposed Planner Gap
+
+`plan-promote-epic` now uses `atelier.store` for the lifecycle mutation and for
+child changeset discovery, but its preview still expands raw issue detail
+through the Beads client.
+
+That preview gap is explicit rather than accidental: the current store models do
+not yet publish the full planner authoring-contract text needed for the
+promotion preview, including the rendered description, notes, acceptance
+criteria, dependencies, and related-context references exactly as planners
+review them before promotion.
+
+Until a richer planner preview model lands in `atelier.store`, keep the preview
+read path adapter-local and do not treat it as a reason to bypass the store for
+other planner mutations.
+
+## Deferred Work
+
+This planner migration slice leaves the following work deferred:
+
+- worker lifecycle and finalization migrations onto `atelier.store`
+- publish and integration orchestration migrations onto `atelier.store`
+- a richer planner preview read model in `atelier.store` so `plan-promote-epic`
+  can drop its raw issue reads
+- shared dual-backend proof for dependency add/remove once the in-memory Beads
+  backend supports those mutations at planner parity
+
+No new planner business flow should introduce a fresh Beads-shaped contract. If
+a planner path needs more state than `atelier.store` currently exposes, add that
+store semantic first and extend the shared parity proof before moving the
+planner logic onto it.
+
+## Proof Surface
+
+Representative planner parity is covered by deterministic tests that exercise
+planner-facing entry points over both supported Beads backends:
+
+- startup and discovery snapshots through `planner_startup_check` and
+  `planner_overview`
+- planner authoring through `plan-create-epic` and `plan-changesets`
+- planner message flows through `mail-send`, `mail-inbox`, `mail-queue-claim`,
+  and `mail-mark-read`
+
+Use this document together with the broader [Atelier Store Contract] when
+planning future planner, worker, or publish migrations.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[atelier store contract]: ./atelier-store-contract.md

--- a/src/atelier/skills/mail-inbox/SKILL.md
+++ b/src/atelier/skills/mail-inbox/SKILL.md
@@ -24,8 +24,14 @@ description: >-
      thread
    - startup/finalize flows may surface threaded blocking messages even without
      a matching assignee
+1. See [Planner Store Migration Contract] for the current planner-side message
+   boundary and deferred gaps.
 
 ## Verification
 
 - Returned list includes only store-backed threaded messages for the agent
   runtime role.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[planner store migration contract]: ../../../../docs/planner-store-migration-contract.md

--- a/src/atelier/skills/mail-mark-read/SKILL.md
+++ b/src/atelier/skills/mail-mark-read/SKILL.md
@@ -16,7 +16,13 @@ description: >-
 1. Run the mark-read script:
    - `python3 skills/mail-mark-read/scripts/mark_read.py <message_id> [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"]`
 1. The script verifies the unread transition through `atelier.store`.
+1. See [Planner Store Migration Contract] for the current planner-side message
+   boundary and deferred gaps.
 
 ## Verification
 
 - Message is no longer returned by unread-only store queries.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[planner store migration contract]: ../../../../docs/planner-store-migration-contract.md

--- a/src/atelier/skills/mail-queue-claim/SKILL.md
+++ b/src/atelier/skills/mail-queue-claim/SKILL.md
@@ -21,8 +21,14 @@ description: >-
    - `python3 skills/mail-queue-claim/scripts/claim_message.py <message_id> [--queue "<queue>"] [--claimed-by "<agent_id>"] [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"]`
 1. The script validates queue identity, enforces claim ownership, and persists
    claim metadata through `atelier.store`.
+1. See [Planner Store Migration Contract] for the current planner-side message
+   boundary and deferred gaps.
 
 ## Verification
 
 - The claimed message includes `claimed_by` and `claimed_at`, and later unread
   queue reads show it as claimed.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[planner store migration contract]: ../../../../docs/planner-store-migration-contract.md

--- a/src/atelier/skills/mail-send/SKILL.md
+++ b/src/atelier/skills/mail-send/SKILL.md
@@ -29,6 +29,7 @@ current runtime.
 1. `mail-send` requires `--thread <epic-or-changeset>`:
    - the script writes the durable store contract fields for `thread`,
      `thread_kind`, `audience`, and default `kind`
+   - the durable write goes through `atelier.store.CreateMessageRequest`
    - worker-targeted threaded messages still block the worker runtime
 1. Do not create planner-to-worker message beads directly with `bd create`.
 1. Treat work-threaded delivery as the durable model:
@@ -36,9 +37,12 @@ current runtime.
      `thread_kind`, `audience`, `kind`, `delivery`)
    - the message stays attached to that original epic or changeset even when no
      worker is currently active
-   - recipient-specific assignee routing is not the durable coordination path
+   - recipient-specific assignee routing is not the durable coordination path;
+     the post-create assignee hint is compatibility-only metadata
 1. If no epic or changeset exists yet, do not use `mail-send` as a durable
    coordination path. Select or create the owning work item first.
+1. See [Planner Store Migration Contract] for the exact store-backed planner
+   boundary and deferred gaps.
 
 ## Verification
 
@@ -50,3 +54,7 @@ current runtime.
   agent-addressed coordination message.
 - Follow `docs/work-threaded-message-migration.md` for planner/worker/operator
   migration guidance.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[planner store migration contract]: ../../../../docs/planner-store-migration-contract.md

--- a/src/atelier/skills/plan-changesets/SKILL.md
+++ b/src/atelier/skills/plan-changesets/SKILL.md
@@ -62,6 +62,9 @@ create/edit deferred work.
 
 1. For each changeset, create a bead with the script:
    - `python skills/plan-changesets/scripts/create_changeset.py --epic-id <epic_id> --title "<title>" --acceptance "<acceptance>" [--status deferred|open] [--description "<scope/guardrails>"] [--notes "<notes>"] [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"] [--no-export]`
+   - The script is a thin planner wrapper over
+     `atelier.store.CreateChangesetRequest`; planner code should not build raw
+     `bd create` argv for changeset authoring.
 1. If decomposition would produce exactly one child changeset, stop and either:
    - keep the epic as the executable changeset, or
    - record explicit decomposition rationale in epic/changeset notes before
@@ -80,6 +83,8 @@ create/edit deferred work.
 1. Record guardrails in the changeset description or notes.
 1. The script creates the bead, applies auto-export when enabled by project
    config, and prints non-fatal retry instructions if export fails.
+1. See [Planner Store Migration Contract] for the exact planner-side store
+   boundary and the remaining deferred preview gap.
 
 ## Example (Cross-cutting lifecycle bug)
 
@@ -109,3 +114,7 @@ Scenario: `Prevent premature close of active-PR changesets`.
   acceptance criteria or `done_definition`.
 - When auto-export is enabled and not opted out, each changeset gets its own
   exported external ticket link.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[planner store migration contract]: ../../../../docs/planner-store-migration-contract.md

--- a/src/atelier/skills/plan-create-epic/SKILL.md
+++ b/src/atelier/skills/plan-create-epic/SKILL.md
@@ -27,6 +27,9 @@ Do not request approval to create or edit deferred beads.
    - `python skills/plan-create-epic/scripts/create_epic.py --title "<title>" --scope "<scope>" --acceptance "<acceptance>" [--changeset-strategy "<changeset_strategy>"] [--design "<design>"] [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"] [--no-export]`
    - This is the canonical top-level executable-work creation path; it sets both
      `issue_type=epic` and the required `at:epic` discovery label.
+   - The script is a thin planner wrapper over
+     `atelier.store.CreateEpicRequest`; planner code should not compose raw
+     `bd create` argv for this flow.
 1. Refine the epic into the executable-path authoring contract immediately:
    - Record explicit `intent`, `rationale`, `non_goals`, `constraints`,
      `edge_cases`, and `related_context` fields in description/notes/design.
@@ -41,6 +44,8 @@ Do not request approval to create or edit deferred beads.
    `open` is the approval gate.
 1. Use `--notes` or `--append-notes` for addendums instead of rewriting the
    description.
+1. See [Planner Store Migration Contract] for the exact planner-side store
+   boundary and the remaining deferred preview gap.
 
 ## Verification
 
@@ -54,3 +59,7 @@ Do not request approval to create or edit deferred beads.
   with `direction=exported` and `sync_mode=export`.
 - If startup diagnostics report identity drift, remediation is deterministic:
   `bd update <epic-id> --type epic --add-label at:epic`.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[planner store migration contract]: ../../../../docs/planner-store-migration-contract.md

--- a/src/atelier/skills/plan-promote-epic/SKILL.md
+++ b/src/atelier/skills/plan-promote-epic/SKILL.md
@@ -77,6 +77,8 @@ description: >-
      `python skills/plan-promote-epic/scripts/promote_epic.py --epic-id "<epic_id>" [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"]`
    - apply promotion after explicit user confirmation:
      `python skills/plan-promote-epic/scripts/promote_epic.py --epic-id "<epic_id>" --yes [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"]`
+   - lifecycle promotion runs through `atelier.store`, but the preview still
+     expands raw issue detail until a richer planner preview model lands
 1. On approval, set epic status to `open`.
 1. Promote each fully-defined child changeset from `deferred` to `open`
    regardless of current dependency blockers (dependency graph still gates
@@ -97,6 +99,8 @@ description: >-
 - If the epic has no child changesets, the epic is the executable leaf work unit
   (changeset by graph inference) and status `open`.
 - Any one-child decomposition has explicit rationale in notes/description.
+- See [Planner Store Migration Contract] for the current planner-side boundary
+  and the remaining preview gap.
 
 ## Example clarification prompt
 
@@ -108,3 +112,7 @@ Before promotion I still need the following clarified in the bead:
 
 Only ask for promotion after those answers are written into the previewed epic
 or child changesets.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[planner store migration contract]: ../../../../docs/planner-store-migration-contract.md

--- a/src/atelier/skills/planner-startup-check/SKILL.md
+++ b/src/atelier/skills/planner-startup-check/SKILL.md
@@ -38,6 +38,12 @@ during startup triage. Do not wait for approval to capture deferred work.
      identity, apply deterministic remediation:
      `bd update <id> --type epic --add-label at:epic`
    - `cs:*` lifecycle labels are not execution gates.
+1. Treat the planner-side startup boundary as store-backed:
+   - `planner_startup_check` and `planner_overview` read through `atelier.store`
+   - startup may still use adapter-local startup compatibility projections for
+     legacy assignee-routed messages
+   - see [Planner Store Migration Contract] for the published boundary and
+     deferred gaps
 
 ## Canonical startup command plan
 
@@ -133,3 +139,7 @@ reject unsupported invocation forms.
   `docs/beads-store-parity.md`.
 - For direct Beads diagnostics, use only supported raw forms:
   `BEADS_DIR="<beads-root>" bd ...` or `bd --db "<beads-root>/beads.db" ...`.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[planner store migration contract]: ../../../../docs/planner-store-migration-contract.md

--- a/tests/atelier/test_planner_store_migration_contract.py
+++ b/tests/atelier/test_planner_store_migration_contract.py
@@ -1,0 +1,446 @@
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+from atelier import messages, planner_overview, planner_startup_check
+from atelier.lib.beads import (
+    BeadsCommandRequest,
+    BeadsCommandResult,
+    ShowIssueRequest,
+    SubprocessBeadsClient,
+)
+from atelier.store import build_atelier_store
+from atelier.testing.beads import (
+    InMemoryBeadsBackend,
+    IssueFixtureBuilder,
+    build_in_memory_beads_client,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC_PATH = REPO_ROOT / "docs" / "planner-store-migration-contract.md"
+SKILLS_DIR = REPO_ROOT / "src" / "atelier" / "skills"
+BUILDER = IssueFixtureBuilder()
+_BACKENDS = ("in-memory", "subprocess")
+
+
+class _InMemorySubprocessTransport:
+    """Drive ``SubprocessBeadsClient`` from the in-memory command backend."""
+
+    def __init__(self, backend: InMemoryBeadsBackend) -> None:
+        self._backend = backend
+
+    async def execute(self, request: BeadsCommandRequest) -> BeadsCommandResult:
+        completed = self._backend.run(request.argv, cwd=request.cwd, env=request.env)
+        return BeadsCommandResult(
+            argv=request.argv,
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+
+def _seed_issues() -> tuple[dict[str, object], ...]:
+    return (
+        BUILDER.issue(
+            "at-epic",
+            title="Planner migration epic",
+            issue_type="epic",
+            status="open",
+            labels=("at:epic", "atelier"),
+            description="workspace.root_branch: root/planner\n",
+        ),
+        BUILDER.issue(
+            "at-epic.1",
+            title="Planner execution slice",
+            parent="at-epic",
+            status="open",
+            labels=("atelier",),
+            description=(
+                "changeset.root_branch: root/planner\n"
+                "changeset.parent_branch: main\n"
+                "changeset.work_branch: root/planner-at-epic.1\n"
+            ),
+        ),
+        BUILDER.issue(
+            "at-epic.2",
+            title="Deferred planner follow-up",
+            parent="at-epic",
+            status="deferred",
+            labels=("atelier",),
+        ),
+        BUILDER.issue(
+            "msg-inbox",
+            title="NEEDS-DECISION: choose planner path",
+            issue_type="message",
+            labels=("at:message", "at:unread"),
+            description=messages.render_message(
+                {
+                    "from": "atelier/worker/codex/p100",
+                    "thread": "at-epic.1",
+                    "thread_kind": "changeset",
+                    "audience": ["planner"],
+                    "kind": "needs-decision",
+                    "blocking": True,
+                },
+                "Choose the planner migration path.",
+            ),
+        ),
+        BUILDER.issue(
+            "msg-queue",
+            title="Queued planner follow-up",
+            issue_type="message",
+            labels=("at:message", "at:unread"),
+            description=messages.render_message(
+                {
+                    "from": "atelier/worker/codex/p100",
+                    "thread": "at-epic.1",
+                    "thread_kind": "changeset",
+                    "audience": ["planner"],
+                    "queue": "planner",
+                    "kind": "instruction",
+                },
+                "Queue this planner follow-up.",
+            ),
+        ),
+    )
+
+
+def _backend_client(backend: str):
+    issues = _seed_issues()
+    if backend == "in-memory":
+        client, _ = build_in_memory_beads_client(issues=issues)
+        return client
+    if backend == "subprocess":
+        command_backend = InMemoryBeadsBackend(seeded_issues=issues)
+        return SubprocessBeadsClient(transport=_InMemorySubprocessTransport(command_backend))
+    raise AssertionError(f"unexpected backend: {backend}")
+
+
+def _store_for_backend(backend: str):
+    client = _backend_client(backend)
+    return client, build_atelier_store(beads=client)
+
+
+def _load_skill_script(*parts: str):
+    script_path = REPO_ROOT / "src" / "atelier" / "skills" / parts[0] / "scripts" / parts[1]
+    module_name = "test_" + "_".join(part.replace("-", "_").replace(".", "_") for part in parts)
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_planner_startup_and_discovery_have_dual_backend_parity(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+) -> None:
+    _client, store = _store_for_backend(backend)
+    monkeypatch.setattr(planner_startup_check, "_build_store", lambda **_kwargs: store)
+    monkeypatch.setattr(planner_overview, "_build_store", lambda **_kwargs: store)
+
+    helper = planner_startup_check.StartupBeadsInvocationHelper(
+        beads_root=Path("/beads"),
+        cwd=Path("/repo"),
+    )
+    epics = helper.list_epics()
+    rendered_epics = planner_overview.render_epics(epics, show_drafts=True)
+    parity = helper.epic_discovery_parity_report()
+    snapshot = {
+        "inbox": tuple(
+            (item["id"], item["title"])
+            for item in sorted(
+                helper.list_inbox_messages("atelier/planner/codex/p200"),
+                key=lambda item: str(item["id"]),
+            )
+        ),
+        "queue": tuple(
+            (item["id"], item["queue"], item["title"], item["claimed_by"])
+            for item in sorted(
+                helper.list_queue_messages(queue="planner", unclaimed_only=False),
+                key=lambda item: str(item["id"]),
+            )
+        ),
+        "epics": tuple((item["id"], item["status"], item["title"]) for item in epics),
+        "changesets": tuple(
+            (item["id"], item["status"], item["title"])
+            for item in sorted(
+                helper.list_descendant_changesets("at-epic"),
+                key=lambda item: str(item["id"]),
+            )
+        ),
+        "parity": parity.model_dump(mode="json"),
+        "rendered_epics": rendered_epics,
+    }
+
+    assert snapshot == {
+        "inbox": (
+            (
+                "msg-inbox",
+                "NEEDS-DECISION: choose planner path "
+                "(changeset=at-epic.1; kind=needs-decision; audience=planner) | "
+                "Choose the planner migration path.",
+            ),
+        ),
+        "queue": (("msg-queue", "planner", "Queued planner follow-up", None),),
+        "epics": (("at-epic", "open", "Planner migration epic"),),
+        "changesets": (
+            ("at-epic.1", "open", "Planner execution slice"),
+            ("at-epic.2", "deferred", "Deferred planner follow-up"),
+        ),
+        "parity": {
+            "active_top_level_work_count": 1,
+            "indexed_active_epic_count": 1,
+            "missing_executable_identity": [],
+            "missing_from_index": [],
+        },
+        "rendered_epics": "\n".join(
+            [
+                "Epics by state:",
+                "",
+                "Open epics:",
+                "- at-epic [open] Planner migration epic",
+                "  root: root/planner | assignee: unassigned",
+            ]
+        ),
+    }
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_planner_authoring_and_message_flows_have_dual_backend_parity(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+    tmp_path: Path,
+) -> None:
+    client, store = _store_for_backend(backend)
+    context = type(
+        "Context",
+        (),
+        {
+            "project_dir": tmp_path / "repo",
+            "beads_root": tmp_path / ".beads",
+        },
+    )()
+
+    create_epic = _load_skill_script("plan-create-epic", "create_epic.py")
+    create_changeset = _load_skill_script("plan-changesets", "create_changeset.py")
+    mail_inbox = _load_skill_script("mail-inbox", "list_inbox.py")
+    mail_send = _load_skill_script("mail-send", "send_message.py")
+    mail_queue_claim = _load_skill_script("mail-queue-claim", "claim_message.py")
+    mail_mark_read = _load_skill_script("mail-mark-read", "mark_read.py")
+
+    monkeypatch.setattr(create_epic, "_build_store", lambda **_kwargs: store)
+    monkeypatch.setattr(
+        create_epic.auto_export,
+        "resolve_auto_export_context",
+        lambda **_kwargs: context,
+    )
+    monkeypatch.setattr(
+        create_epic.auto_export,
+        "auto_export_issue",
+        lambda issue_id, *, context: create_epic.auto_export.AutoExportResult(
+            status="skipped",
+            issue_id=issue_id,
+            provider=None,
+            message="auto-export disabled for test",
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "create_epic.py",
+            "--title",
+            "Planner contract proof epic",
+            "--scope",
+            "Prove planner store migration parity.",
+            "--acceptance",
+            "Planner startup and authoring depend on atelier.store.",
+            "--no-export",
+        ],
+    )
+    create_epic.main()
+
+    monkeypatch.setattr(create_changeset, "_build_store", lambda **_kwargs: store)
+    monkeypatch.setattr(
+        create_changeset.auto_export,
+        "resolve_auto_export_context",
+        lambda **_kwargs: context,
+    )
+    monkeypatch.setattr(
+        create_changeset.auto_export,
+        "auto_export_issue",
+        lambda issue_id, *, context: create_changeset.auto_export.AutoExportResult(
+            status="skipped",
+            issue_id=issue_id,
+            provider=None,
+            message="auto-export disabled for test",
+        ),
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "create_changeset.py",
+            "--epic-id",
+            "at-1",
+            "--title",
+            "Planner contract proof changeset",
+            "--acceptance",
+            "Planner message and authoring flows stay store-backed.",
+            "--description",
+            "Keep the proof deterministic.",
+            "--no-export",
+        ],
+    )
+    create_changeset.main()
+
+    monkeypatch.setattr(mail_inbox, "_build_store", lambda **_kwargs: store)
+    monkeypatch.setattr(mail_send, "SubprocessBeadsClient", lambda **_kwargs: client)
+    monkeypatch.setattr(
+        mail_send, "build_atelier_store", lambda *, beads: build_atelier_store(beads=beads)
+    )
+    monkeypatch.setattr(mail_queue_claim, "_build_store", lambda **_kwargs: store)
+    monkeypatch.setattr(mail_mark_read, "_build_store", lambda **_kwargs: store)
+
+    dispatched = mail_send.dispatch_message(
+        subject="NEEDS-DECISION: confirm planner contract",
+        body="Confirm the planner contract proof.",
+        to="atelier/planner/codex/p200",
+        from_agent="atelier/worker/codex/p100",
+        thread="at-epic.1",
+        reply_to=None,
+        beads_root=Path("/beads"),
+        cwd=Path("/repo"),
+    )
+    inbox_before_read = tuple(
+        item["id"]
+        for item in mail_inbox.list_inbox_messages(
+            agent_id="atelier/planner/codex/p200",
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+        )
+    )
+    claimed = mail_queue_claim.claim_message(
+        message_id="msg-queue",
+        claimed_by="atelier/planner/codex/p200",
+        queue="planner",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+    marked_read = mail_mark_read.mark_message_read(
+        message_id="msg-queue",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+    inbox_after_read = tuple(
+        item["id"]
+        for item in mail_inbox.list_inbox_messages(
+            agent_id="atelier/planner/codex/p200",
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+        )
+    )
+    dispatched_issue = asyncio.run(client.show(ShowIssueRequest(issue_id=dispatched.issue_id)))
+    created_epic = asyncio.run(store.get_epic("at-1"))
+    created_changeset = asyncio.run(store.get_changeset("at-2"))
+    snapshot = {
+        "created_epic": (
+            created_epic.id,
+            created_epic.lifecycle.value,
+            created_epic.labels,
+        ),
+        "created_changeset": (
+            created_changeset.id,
+            created_changeset.epic_id,
+            created_changeset.lifecycle.value,
+            created_changeset.labels,
+        ),
+        "dispatched": (
+            dispatched.decision,
+            dispatched.issue_id,
+            dispatched.recipient,
+            dispatched_issue.assignee,
+        ),
+        "inbox_before_read": inbox_before_read,
+        "claimed": (
+            claimed["id"],
+            claimed["queue"],
+            claimed["claimed_by"],
+            claimed["thread_id"],
+            claimed["thread_kind"],
+        ),
+        "marked_read": (
+            marked_read["id"],
+            marked_read["queue"],
+            marked_read["thread_id"],
+            marked_read["thread_kind"],
+            marked_read["read"],
+        ),
+        "inbox_after_read": inbox_after_read,
+    }
+
+    assert snapshot == {
+        "created_epic": ("at-1", "deferred", ("at:epic", "ext:no-export")),
+        "created_changeset": ("at-2", "at-1", "deferred", ("ext:no-export",)),
+        "dispatched": (
+            "delivered",
+            "at-3",
+            "atelier/planner/codex/p200",
+            "atelier/planner/codex/p200",
+        ),
+        "inbox_before_read": ("at-3", "msg-inbox", "msg-queue"),
+        "claimed": (
+            "msg-queue",
+            "planner",
+            "atelier/planner/codex/p200",
+            "at-epic.1",
+            "changeset",
+        ),
+        "marked_read": (
+            "msg-queue",
+            "planner",
+            "at-epic.1",
+            "changeset",
+            True,
+        ),
+        "inbox_after_read": ("at-3", "msg-inbox"),
+    }
+
+
+def test_planner_store_migration_docs_publish_boundary_and_deferred_gaps() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    startup_skill = (SKILLS_DIR / "planner-startup-check" / "SKILL.md").read_text(encoding="utf-8")
+    create_epic_skill = (SKILLS_DIR / "plan-create-epic" / "SKILL.md").read_text(encoding="utf-8")
+    create_changeset_skill = (SKILLS_DIR / "plan-changesets" / "SKILL.md").read_text(
+        encoding="utf-8"
+    )
+    mail_send_skill = (SKILLS_DIR / "mail-send" / "SKILL.md").read_text(encoding="utf-8")
+    promote_skill = (SKILLS_DIR / "plan-promote-epic" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "Planner Store Migration Contract" in doc
+    assert "Proven Planner Boundary" in doc
+    assert "Planner Compatibility Seams" in doc
+    assert "`mail-send`" in doc
+    assert "assignee recipient hint" in doc
+    assert "plan-promote-epic" in doc
+    assert "preview still expands raw issue detail" in doc
+    assert "worker lifecycle and finalization migrations onto `atelier.store`" in doc
+    assert "publish and integration orchestration migrations onto `atelier.store`" in doc
+
+    assert "[Planner Store Migration Contract]" in startup_skill
+    assert "adapter-local startup compatibility projections" in startup_skill
+    assert "`atelier.store.CreateEpicRequest`" in create_epic_skill
+    assert "`atelier.store.CreateChangesetRequest`" in create_changeset_skill
+    assert "`atelier.store.CreateMessageRequest`" in mail_send_skill
+    assert "compatibility-only metadata" in mail_send_skill
+    assert "[Planner Store Migration Contract]" in promote_skill
+    assert "preview still" in promote_skill
+    assert "raw issue detail" in promote_skill


### PR DESCRIPTION
# Summary

- add planner-facing dual-backend parity coverage for startup/discovery and authoring/message flows
- publish the planner store migration contract and point planner skill guidance at the store-backed boundary

# Changes

- add `tests/atelier/test_planner_store_migration_contract.py` to exercise planner startup/discovery helpers and planner skill scripts over in-memory and subprocess Beads backends
- add `docs/planner-store-migration-contract.md` describing the proven planner boundary, compatibility seams, and deferred follow-on work
- update planner skill docs for startup, authoring, messaging, and promotion to point at the contract and note the remaining promotion preview gap

# Testing

- `just format`
- `just test`
- `just lint`

## Tickets

- Fixes #654

# Risks / Rollout

- low risk; this changeset is documentation plus deterministic parity coverage
- `plan-promote-epic` preview still depends on raw issue detail until a richer store preview model lands

# Notes

- planner startup compatibility projections and mail recipient hints remain adapter-local compatibility state; the durable planner boundary is `atelier.store`
