### PR TITLE
Route worker dependency recovery through AtelierStore

### DIFF
--- a/src/atelier/worker/reconcile.py
+++ b/src/atelier/worker/reconcile.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from .. import agent_home, beads, changesets, config, git, lifecycle, prs
 from . import stale_pr_lifecycle
+from . import store_adapter as worker_store
 from .models import FinalizeResult, ReconcileResult
 
 
@@ -182,7 +183,7 @@ def _converge_stale_terminal_metadata(
         )
         stored_state = lifecycle.normalize_review_state(metadata.pr_state)
         if stored_state != candidate.terminal_pr_state:
-            beads.update_changeset_review(
+            worker_store.update_changeset_review(
                 changeset_id,
                 changesets.ReviewMetadata(
                     pr_url=metadata.pr_url,
@@ -191,17 +192,17 @@ def _converge_stale_terminal_metadata(
                     review_owner=metadata.review_owner,
                 ),
                 beads_root=beads_root,
-                cwd=repo_root,
+                repo_root=repo_root,
             )
             updates.append(f"pr_state={candidate.terminal_pr_state}")
     if candidate.integrated_sha:
         recorded_sha = _recorded_integrated_sha(issue)
         if recorded_sha != candidate.integrated_sha:
-            beads.update_changeset_integrated_sha(
+            worker_store.update_changeset_integrated_sha(
                 changeset_id,
                 candidate.integrated_sha,
                 beads_root=beads_root,
-                cwd=repo_root,
+                repo_root=repo_root,
             )
             updates.append(f"changeset.integrated_sha={candidate.integrated_sha}")
     return tuple(updates)
@@ -626,10 +627,10 @@ def reconcile_blocked_merged_changesets(
             issue,
             active_pr_lifecycle=True,
         ):
-            beads.mark_issue_in_progress(
+            worker_store.mark_issue_in_progress(
                 changeset_id,
                 beads_root=beads_root,
-                cwd=repo_root,
+                repo_root=repo_root,
             )
             reconciled += 1
             if log:
@@ -844,8 +845,11 @@ def reconcile_blocked_merged_changesets(
     def load_issue(issue_id: str) -> dict[str, object] | None:
         if issue_id in issue_cache:
             return issue_cache[issue_id]
-        loaded = beads.run_bd_json(["show", issue_id], beads_root=beads_root, cwd=repo_root)
-        issue_cache[issue_id] = loaded[0] if loaded else None
+        issue_cache[issue_id] = worker_store.show_issue(
+            issue_id,
+            beads_root=beads_root,
+            repo_root=repo_root,
+        )
         return issue_cache[issue_id]
 
     dependency_finalized_cache: dict[str, bool] = {}
@@ -863,10 +867,10 @@ def reconcile_blocked_merged_changesets(
         ):
             dependency_finalized_cache[issue_id] = True
             return True
-        work_children = beads.list_work_children(
+        work_children = worker_store.list_work_children(
             issue_id,
             beads_root=beads_root,
-            cwd=repo_root,
+            repo_root=repo_root,
             include_closed=True,
         )
         if work_children:
@@ -979,11 +983,11 @@ def reconcile_blocked_merged_changesets(
                     cwd=repo_root,
                 )
                 if candidate.integrated_sha:
-                    beads.update_changeset_integrated_sha(
+                    worker_store.update_changeset_integrated_sha(
                         changeset_id,
                         candidate.integrated_sha,
                         beads_root=beads_root,
-                        cwd=repo_root,
+                        repo_root=repo_root,
                     )
                 if log:
                     log(
@@ -1058,11 +1062,11 @@ def reconcile_blocked_merged_changesets(
                 and _converged_integrated_sha(converged_updates) is None
                 and _recorded_integrated_sha(refreshed_issue or {}) is None
             ):
-                beads.update_changeset_integrated_sha(
+                worker_store.update_changeset_integrated_sha(
                     changeset_id,
                     candidate.integrated_sha,
                     beads_root=beads_root,
-                    cwd=repo_root,
+                    repo_root=repo_root,
                 )
             if log:
                 log(

--- a/src/atelier/worker/store_adapter.py
+++ b/src/atelier/worker/store_adapter.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import cast
 
-from .. import beads, lifecycle, messages
+from .. import beads, changesets, lifecycle, messages
 from ..io import die
 from ..lib.beads import (
     CreateIssueRequest,
@@ -30,12 +30,16 @@ from ..store import (
     ClearAgentBeadHookRequest,
     CreateMessageRequest,
     LifecycleStatus,
+    LifecycleTransitionRequest,
     MarkMessageReadRequest,
     MessageQuery,
     MessageThreadKind,
     ReadyChangesetQuery,
+    ReviewMetadata,
+    ReviewState,
     SetAgentBeadHookRequest,
     StartupMessageRecord,
+    UpdateReviewRequest,
     build_atelier_store,
 )
 from . import selection as worker_selection
@@ -208,6 +212,107 @@ def list_work_children(
         for issue in issues
         if lifecycle.is_work_issue(labels=set(issue.labels), issue_type=issue.type)
     ]
+
+
+def _normalize_review_state(value: str | None) -> ReviewState | None:
+    normalized = lifecycle.normalize_review_state(value)
+    return None if normalized is None else ReviewState(normalized)
+
+
+def _normalized_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    normalized = value.strip()
+    if not normalized:
+        return None
+    return normalized
+
+
+def _normalize_pr_number(value: str | None) -> int | None:
+    normalized = _normalized_text(value)
+    if normalized is None:
+        return None
+    return int(normalized)
+
+
+def update_changeset_review(
+    changeset_id: str,
+    metadata: changesets.ReviewMetadata,
+    *,
+    beads_root: Path,
+    repo_root: Path,
+) -> dict[str, object]:
+    """Update changeset review metadata through the worker-local store adapter."""
+
+    bundle = _bundle(beads_root=beads_root, repo_root=repo_root)
+    record = asyncio.run(
+        bundle.store.update_review(
+            UpdateReviewRequest(
+                changeset_id=changeset_id,
+                review=ReviewMetadata(
+                    pr_url=_normalized_text(metadata.pr_url),
+                    pr_number=_normalize_pr_number(metadata.pr_number),
+                    pr_state=_normalize_review_state(metadata.pr_state),
+                    review_owner=_normalized_text(metadata.review_owner),
+                ),
+            )
+        )
+    )
+    payload = _show_issue(issue_id=record.id, beads_root=beads_root, repo_root=repo_root)
+    return payload or cast(
+        dict[str, object],
+        record.model_dump(mode="json", by_alias=True, exclude_none=True),
+    )
+
+
+def update_changeset_integrated_sha(
+    changeset_id: str,
+    integrated_sha: str,
+    *,
+    beads_root: Path,
+    repo_root: Path,
+) -> dict[str, object]:
+    """Persist integrated SHA metadata through AtelierStore review updates."""
+
+    bundle = _bundle(beads_root=beads_root, repo_root=repo_root)
+    record = asyncio.run(
+        bundle.store.update_review(
+            UpdateReviewRequest(
+                changeset_id=changeset_id,
+                preserve_existing=True,
+                review=ReviewMetadata(integrated_sha=_normalized_text(integrated_sha)),
+            )
+        )
+    )
+    payload = _show_issue(issue_id=record.id, beads_root=beads_root, repo_root=repo_root)
+    return payload or cast(
+        dict[str, object],
+        record.model_dump(mode="json", by_alias=True, exclude_none=True),
+    )
+
+
+def mark_issue_in_progress(
+    issue_id: str,
+    *,
+    beads_root: Path,
+    repo_root: Path,
+) -> beads.ExternalTicketReconcileResult:
+    """Restore one issue to in-progress using the store lifecycle contract."""
+
+    bundle = _bundle(beads_root=beads_root, repo_root=repo_root)
+    asyncio.run(
+        bundle.store.transition_lifecycle(
+            LifecycleTransitionRequest(
+                issue_id=issue_id,
+                target_status=LifecycleStatus.IN_PROGRESS,
+            )
+        )
+    )
+    return beads.reconcile_reopened_issue_exported_github_tickets(
+        issue_id,
+        beads_root=beads_root,
+        cwd=repo_root,
+    )
 
 
 def ready_changesets_global(
@@ -1039,10 +1144,13 @@ __all__ = [
     "list_inbox_messages",
     "list_queue_messages",
     "list_work_children",
+    "mark_issue_in_progress",
     "mark_message_read",
     "ready_changesets_global",
     "release_epic_assignment",
     "resolve_hooked_epic",
     "set_agent_hook",
     "show_issue",
+    "update_changeset_integrated_sha",
+    "update_changeset_review",
 ]

--- a/tests/atelier/worker/test_reconcile.py
+++ b/tests/atelier/worker/test_reconcile.py
@@ -442,11 +442,6 @@ def test_reconcile_blocked_merged_changesets_converges_stale_terminal_metadata_b
     }
     operations: list[tuple[str, str]] = []
 
-    def run_bd_json(args: list[str], **_kwargs: object) -> list[dict[str, object]]:
-        if args[:2] == ["show", "at-1.2"]:
-            return [issue]
-        return []
-
     def finalize_changeset(**_kwargs: object) -> FinalizeResult:
         assert operations == [("review", "merged"), ("sha", "abc1234")]
         issue["status"] = "closed"
@@ -454,7 +449,7 @@ def test_reconcile_blocked_merged_changesets_converges_stale_terminal_metadata_b
 
     with (
         patch("atelier.worker.reconcile.beads.list_all_changesets", return_value=[issue]),
-        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
+        patch("atelier.worker.reconcile.worker_store.show_issue", return_value=issue),
         patch("atelier.worker.reconcile.git.git_ref_exists", return_value=True),
         patch(
             "atelier.worker.reconcile.prs.lookup_github_pr_status",
@@ -471,17 +466,18 @@ def test_reconcile_blocked_merged_changesets_converges_stale_terminal_metadata_b
             ),
         ),
         patch(
-            "atelier.worker.reconcile.beads.update_changeset_review",
+            "atelier.worker.reconcile.worker_store.update_changeset_review",
             side_effect=lambda _changeset_id, metadata, **_kwargs: operations.append(
                 ("review", str(metadata.pr_state))
             ),
         ),
         patch(
-            "atelier.worker.reconcile.beads.update_changeset_integrated_sha",
+            "atelier.worker.reconcile.worker_store.update_changeset_integrated_sha",
             side_effect=lambda _changeset_id, integrated_sha, **_kwargs: operations.append(
                 ("sha", integrated_sha)
             ),
         ),
+        patch("atelier.worker.reconcile.resolve_hook_agent_bead_for_epic", return_value=None),
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -525,11 +521,6 @@ def test_reconcile_blocked_merged_changesets_keeps_finalize_integrated_sha_autho
     }
     operations: list[tuple[str, str]] = []
 
-    def run_bd_json(args: list[str], **_kwargs: object) -> list[dict[str, object]]:
-        if args[:2] == ["show", "at-1.2"]:
-            return [issue]
-        return []
-
     def finalize_changeset(**_kwargs: object) -> FinalizeResult:
         issue["status"] = "closed"
         issue["description"] = (
@@ -541,7 +532,7 @@ def test_reconcile_blocked_merged_changesets_keeps_finalize_integrated_sha_autho
 
     with (
         patch("atelier.worker.reconcile.beads.list_all_changesets", return_value=[issue]),
-        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
+        patch("atelier.worker.reconcile.worker_store.show_issue", return_value=issue),
         patch("atelier.worker.reconcile.git.git_ref_exists", return_value=True),
         patch(
             "atelier.worker.reconcile.prs.lookup_github_pr_status",
@@ -558,17 +549,18 @@ def test_reconcile_blocked_merged_changesets_keeps_finalize_integrated_sha_autho
             ),
         ),
         patch(
-            "atelier.worker.reconcile.beads.update_changeset_review",
+            "atelier.worker.reconcile.worker_store.update_changeset_review",
             side_effect=lambda _changeset_id, metadata, **_kwargs: operations.append(
                 ("review", str(metadata.pr_state))
             ),
         ),
         patch(
-            "atelier.worker.reconcile.beads.update_changeset_integrated_sha",
+            "atelier.worker.reconcile.worker_store.update_changeset_integrated_sha",
             side_effect=lambda _changeset_id, integrated_sha, **_kwargs: operations.append(
                 ("sha", integrated_sha)
             ),
         ),
+        patch("atelier.worker.reconcile.resolve_hook_agent_bead_for_epic", return_value=None),
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -607,11 +599,6 @@ def test_reconcile_stale_terminal_metadata_next_run_uses_closed_path_without_ref
         "description": "changeset.work_branch: feat/at-1.16\npr_state: pushed\n",
     }
 
-    def run_bd_json(args: list[str], **_kwargs: object) -> list[dict[str, object]]:
-        if args[:2] == ["show", "at-1.16"]:
-            return [issue]
-        return []
-
     def finalize_changeset(**_kwargs: object) -> FinalizeResult:
         issue["status"] = "closed"
         issue["description"] = (
@@ -623,7 +610,7 @@ def test_reconcile_stale_terminal_metadata_next_run_uses_closed_path_without_ref
 
     with (
         patch("atelier.worker.reconcile.beads.list_all_changesets", return_value=[issue]),
-        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
+        patch("atelier.worker.reconcile.worker_store.show_issue", return_value=issue),
         patch("atelier.worker.reconcile.git.git_ref_exists", return_value=True),
         patch(
             "atelier.worker.reconcile.prs.lookup_github_pr_status",
@@ -639,8 +626,9 @@ def test_reconcile_stale_terminal_metadata_next_run_uses_closed_path_without_ref
                 },
             ),
         ),
-        patch("atelier.worker.reconcile.beads.update_changeset_review"),
-        patch("atelier.worker.reconcile.beads.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.worker_store.update_changeset_review"),
+        patch("atelier.worker.reconcile.worker_store.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.resolve_hook_agent_bead_for_epic", return_value=None),
     ):
         first = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -663,7 +651,7 @@ def test_reconcile_stale_terminal_metadata_next_run_uses_closed_path_without_ref
     logs: list[str] = []
     with (
         patch("atelier.worker.reconcile.beads.list_all_changesets", return_value=[issue]),
-        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
+        patch("atelier.worker.reconcile.worker_store.show_issue", return_value=issue),
         patch("atelier.worker.reconcile.git.git_ref_exists", return_value=True),
         patch(
             "atelier.worker.reconcile.prs.lookup_github_pr_status",
@@ -680,7 +668,8 @@ def test_reconcile_stale_terminal_metadata_next_run_uses_closed_path_without_ref
             ),
         ),
         patch("atelier.worker.reconcile.beads.reconcile_closed_issue_exported_github_tickets"),
-        patch("atelier.worker.reconcile.beads.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.worker_store.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.resolve_hook_agent_bead_for_epic", return_value=None),
     ):
         second = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -724,14 +713,9 @@ def test_reconcile_blocked_merged_changesets_fails_closed_when_stale_terminal_fi
     }
     logs: list[str] = []
 
-    def run_bd_json(args: list[str], **_kwargs: object) -> list[dict[str, object]]:
-        if args[:2] == ["show", "at-1.2"]:
-            return [issue]
-        return []
-
     with (
         patch("atelier.worker.reconcile.beads.list_all_changesets", return_value=[issue]),
-        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
+        patch("atelier.worker.reconcile.worker_store.show_issue", return_value=issue),
         patch("atelier.worker.reconcile.git.git_ref_exists", return_value=True),
         patch(
             "atelier.worker.reconcile.prs.lookup_github_pr_status",
@@ -747,8 +731,9 @@ def test_reconcile_blocked_merged_changesets_fails_closed_when_stale_terminal_fi
                 },
             ),
         ),
-        patch("atelier.worker.reconcile.beads.update_changeset_review"),
-        patch("atelier.worker.reconcile.beads.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.worker_store.update_changeset_review"),
+        patch("atelier.worker.reconcile.worker_store.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.resolve_hook_agent_bead_for_epic", return_value=None),
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -1139,7 +1124,9 @@ def test_reconcile_blocked_merged_changesets_reports_closed_active_pr_drift() ->
     logs: list[str] = []
     with (
         patch("atelier.worker.reconcile.beads.list_all_changesets", return_value=[drift_issue]),
-        patch("atelier.worker.reconcile.beads.mark_issue_in_progress") as mark_issue_in_progress,
+        patch(
+            "atelier.worker.reconcile.worker_store.mark_issue_in_progress"
+        ) as mark_issue_in_progress,
         patch("atelier.worker.reconcile.git.git_ref_exists", return_value=True),
         patch(
             "atelier.worker.reconcile.prs.lookup_github_pr_status",
@@ -1182,7 +1169,7 @@ def test_reconcile_blocked_merged_changesets_reports_closed_active_pr_drift() ->
     mark_issue_in_progress.assert_called_once_with(
         "at-1.9",
         beads_root=Path("/beads"),
-        cwd=Path("/repo"),
+        repo_root=Path("/repo"),
     )
     assert any(
         "closed+active-pr-lifecycle(evidence(source=live-pr,active=pr-open" in line for line in logs
@@ -1217,7 +1204,9 @@ def test_reconcile_does_not_reopen_closed_changeset_when_live_pr_is_merged() -> 
                 },
             ),
         ),
-        patch("atelier.worker.reconcile.beads.mark_issue_in_progress") as mark_issue_in_progress,
+        patch(
+            "atelier.worker.reconcile.worker_store.mark_issue_in_progress"
+        ) as mark_issue_in_progress,
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -1265,7 +1254,9 @@ def test_reconcile_flags_closed_pr_lookup_error_without_reopen() -> None:
             "atelier.worker.reconcile.prs.lookup_github_pr_status",
             return_value=prs.GithubPrLookup(outcome="error", error="gh timeout"),
         ),
-        patch("atelier.worker.reconcile.beads.mark_issue_in_progress") as mark_issue_in_progress,
+        patch(
+            "atelier.worker.reconcile.worker_store.mark_issue_in_progress"
+        ) as mark_issue_in_progress,
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -1326,7 +1317,9 @@ def test_reconcile_recovers_after_transient_pr_lookup_error_for_closed_active_pr
                 ),
             ],
         ) as lookup,
-        patch("atelier.worker.reconcile.beads.mark_issue_in_progress") as mark_issue_in_progress,
+        patch(
+            "atelier.worker.reconcile.worker_store.mark_issue_in_progress"
+        ) as mark_issue_in_progress,
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -1359,7 +1352,7 @@ def test_reconcile_recovers_after_transient_pr_lookup_error_for_closed_active_pr
     mark_issue_in_progress.assert_called_once_with(
         "at-1.15",
         beads_root=Path("/beads"),
-        cwd=Path("/repo"),
+        repo_root=Path("/repo"),
     )
     assert not any("closed+pr-lifecycle-lookup-error" in line for line in logs)
     assert any(
@@ -1430,20 +1423,15 @@ def test_reconcile_dependency_without_terminal_review_or_merge_blocks_finalize()
     def list_all_changesets(*, beads_root, cwd, include_closed):
         return [candidate]
 
-    def run_bd_json(args: list[str], **_kwargs):
-        if args[:2] == ["show", "at-1.1"]:
-            return [dependency]
-        if args[:3] == ["list", "--parent", "at-1.1"]:
-            return []
-        return []
-
     logs: list[str] = []
     with (
         patch(
             "atelier.worker.reconcile.beads.list_all_changesets", side_effect=list_all_changesets
         ),
-        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
-        patch("atelier.worker.reconcile.beads.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.worker_store.show_issue", return_value=dependency),
+        patch("atelier.worker.reconcile.worker_store.list_work_children", return_value=[]),
+        patch("atelier.worker.reconcile.worker_store.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.resolve_hook_agent_bead_for_epic", return_value=None),
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -1495,13 +1483,6 @@ def test_reconcile_closed_dependency_requires_strict_integration_proof() -> None
     def list_all_changesets(*, beads_root, cwd, include_closed):
         return [candidate]
 
-    def run_bd_json(args: list[str], **_kwargs):
-        if args[:2] == ["show", "at-1.1"]:
-            return [dependency]
-        if args[:3] == ["list", "--parent", "at-1.1"]:
-            return []
-        return []
-
     calls: list[tuple[str, bool]] = []
     logs: list[str] = []
 
@@ -1518,8 +1499,10 @@ def test_reconcile_closed_dependency_requires_strict_integration_proof() -> None
         patch(
             "atelier.worker.reconcile.beads.list_all_changesets", side_effect=list_all_changesets
         ),
-        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
-        patch("atelier.worker.reconcile.beads.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.worker_store.show_issue", return_value=dependency),
+        patch("atelier.worker.reconcile.worker_store.list_work_children", return_value=[]),
+        patch("atelier.worker.reconcile.worker_store.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.resolve_hook_agent_bead_for_epic", return_value=None),
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -1570,20 +1553,15 @@ def test_reconcile_dependency_with_integrated_signal_allows_finalize() -> None:
     def list_all_changesets(*, beads_root, cwd, include_closed):
         return [candidate]
 
-    def run_bd_json(args: list[str], **_kwargs):
-        if args[:2] == ["show", "at-1.1"]:
-            return [dependency]
-        if args[:3] == ["list", "--parent", "at-1.1"]:
-            return []
-        return []
-
     finalized: list[str] = []
     with (
         patch(
             "atelier.worker.reconcile.beads.list_all_changesets", side_effect=list_all_changesets
         ),
-        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
-        patch("atelier.worker.reconcile.beads.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.worker_store.show_issue", return_value=dependency),
+        patch("atelier.worker.reconcile.worker_store.list_work_children", return_value=[]),
+        patch("atelier.worker.reconcile.worker_store.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.resolve_hook_agent_bead_for_epic", return_value=None),
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -1642,24 +1620,19 @@ def test_reconcile_join_dependencies_require_all_integrated_signals() -> None:
     def list_all_changesets(*, beads_root, cwd, include_closed):
         return [candidate]
 
-    def run_bd_json(args: list[str], **_kwargs):
-        if args[:2] == ["show", "at-1.1"]:
-            return [dependency_one]
-        if args[:2] == ["show", "at-1.2"]:
-            return [dependency_two]
-        if args[:3] == ["list", "--parent", "at-1.1"]:
-            return []
-        if args[:3] == ["list", "--parent", "at-1.2"]:
-            return []
-        return []
-
     logs: list[str] = []
+    issues_by_id = {"at-1.1": dependency_one, "at-1.2": dependency_two}
     with (
         patch(
             "atelier.worker.reconcile.beads.list_all_changesets", side_effect=list_all_changesets
         ),
-        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
-        patch("atelier.worker.reconcile.beads.update_changeset_integrated_sha"),
+        patch(
+            "atelier.worker.reconcile.worker_store.show_issue",
+            side_effect=lambda issue_id, **_kwargs: issues_by_id.get(issue_id),
+        ),
+        patch("atelier.worker.reconcile.worker_store.list_work_children", return_value=[]),
+        patch("atelier.worker.reconcile.worker_store.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.resolve_hook_agent_bead_for_epic", return_value=None),
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -1720,24 +1693,19 @@ def test_reconcile_join_dependencies_all_integrated_allows_finalize() -> None:
     def list_all_changesets(*, beads_root, cwd, include_closed):
         return [candidate]
 
-    def run_bd_json(args: list[str], **_kwargs):
-        if args[:2] == ["show", "at-1.1"]:
-            return [dependency_one]
-        if args[:2] == ["show", "at-1.2"]:
-            return [dependency_two]
-        if args[:3] == ["list", "--parent", "at-1.1"]:
-            return []
-        if args[:3] == ["list", "--parent", "at-1.2"]:
-            return []
-        return []
-
     finalized: list[str] = []
+    issues_by_id = {"at-1.1": dependency_one, "at-1.2": dependency_two}
     with (
         patch(
             "atelier.worker.reconcile.beads.list_all_changesets", side_effect=list_all_changesets
         ),
-        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
-        patch("atelier.worker.reconcile.beads.update_changeset_integrated_sha"),
+        patch(
+            "atelier.worker.reconcile.worker_store.show_issue",
+            side_effect=lambda issue_id, **_kwargs: issues_by_id.get(issue_id),
+        ),
+        patch("atelier.worker.reconcile.worker_store.list_work_children", return_value=[]),
+        patch("atelier.worker.reconcile.worker_store.update_changeset_integrated_sha"),
+        patch("atelier.worker.reconcile.resolve_hook_agent_bead_for_epic", return_value=None),
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",
@@ -1793,18 +1761,12 @@ def test_reconcile_dependency_with_abandoned_label_requires_review_metadata() ->
     def list_all_changesets(*, beads_root, cwd, include_closed):
         return [candidate]
 
-    def run_bd_json(args: list[str], **_kwargs):
-        if args[:2] == ["show", "at-1.1"]:
-            return [dependency]
-        if args[:3] == ["list", "--parent", "at-1.1"]:
-            return []
-        return []
-
     with (
         patch(
             "atelier.worker.reconcile.beads.list_all_changesets", side_effect=list_all_changesets
         ),
-        patch("atelier.worker.reconcile.beads.run_bd_json", side_effect=run_bd_json),
+        patch("atelier.worker.reconcile.worker_store.show_issue", return_value=dependency),
+        patch("atelier.worker.reconcile.worker_store.list_work_children", return_value=[]),
     ):
         result = reconcile.reconcile_blocked_merged_changesets(
             agent_id="worker/1",

--- a/tests/atelier/worker/test_store_adapter.py
+++ b/tests/atelier/worker/test_store_adapter.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+from unittest.mock import patch
 
+from atelier import changesets
 from atelier.lib.beads import IssueRecord, SyncBeadsClient
 from atelier.messages import render_message
 from atelier.store import HookRecord, StartupMessageRecord, build_atelier_store
@@ -143,6 +145,128 @@ def test_list_work_children_filters_non_work_children(monkeypatch) -> None:
     )
 
     assert [child["id"] for child in children] == ["at-epic.1"]
+    worker_store.clear_bundle_cache()
+
+
+def test_update_changeset_review_updates_pr_state_via_store(monkeypatch) -> None:
+    builder = IssueFixtureBuilder()
+    _patch_bundle(
+        monkeypatch,
+        issues=(
+            builder.issue(
+                "at-epic",
+                issue_type="epic",
+                labels=("at:epic",),
+                children=("at-epic.1",),
+            ),
+            builder.issue(
+                "at-epic.1",
+                issue_type="task",
+                parent="at-epic",
+                status="blocked",
+                description="pr_state: pushed\n",
+            ),
+        ),
+    )
+
+    worker_store.update_changeset_review(
+        "at-epic.1",
+        changesets.ReviewMetadata(pr_state="merged"),
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+    updated = worker_store.show_issue(
+        "at-epic.1",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    assert updated is not None
+    assert "pr_state: merged" in str(updated.get("description"))
+    worker_store.clear_bundle_cache()
+
+
+def test_update_changeset_integrated_sha_preserves_existing_review_fields(monkeypatch) -> None:
+    builder = IssueFixtureBuilder()
+    _patch_bundle(
+        monkeypatch,
+        issues=(
+            builder.issue(
+                "at-epic",
+                issue_type="epic",
+                labels=("at:epic",),
+                children=("at-epic.1",),
+            ),
+            builder.issue(
+                "at-epic.1",
+                issue_type="task",
+                parent="at-epic",
+                status="blocked",
+                description="pr_state: merged\n",
+            ),
+        ),
+    )
+
+    worker_store.update_changeset_integrated_sha(
+        "at-epic.1",
+        "abc1234",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+    updated = worker_store.show_issue(
+        "at-epic.1",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    assert updated is not None
+    description = str(updated.get("description"))
+    assert "pr_state: merged" in description
+    assert "changeset.integrated_sha: abc1234" in description
+    worker_store.clear_bundle_cache()
+
+
+def test_mark_issue_in_progress_transitions_lifecycle_and_reconciles_tickets(monkeypatch) -> None:
+    builder = IssueFixtureBuilder()
+    _patch_bundle(
+        monkeypatch,
+        issues=(
+            builder.issue(
+                "at-epic",
+                issue_type="epic",
+                labels=("at:epic",),
+                children=("at-epic.1",),
+            ),
+            builder.issue(
+                "at-epic.1",
+                issue_type="task",
+                parent="at-epic",
+                status="blocked",
+            ),
+        ),
+    )
+
+    with patch(
+        "atelier.worker.store_adapter.beads.reconcile_reopened_issue_exported_github_tickets"
+    ) as reconcile_tickets:
+        worker_store.mark_issue_in_progress(
+            "at-epic.1",
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+        )
+
+    refreshed = worker_store.show_issue(
+        "at-epic.1",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+    assert refreshed is not None
+    assert refreshed["status"] == "in_progress"
+    reconcile_tickets.assert_called_once_with(
+        "at-epic.1",
+        beads_root=Path("/beads"),
+        cwd=Path("/repo"),
+    )
     worker_store.clear_bundle_cache()
 
 


### PR DESCRIPTION
# Summary

- Route worker dependency recovery and stale blocked-state correction through the worker-local AtelierStore adapter.

# Changes

- Rewire `src/atelier/worker/reconcile.py` to use store-adapter issue reads, child-work discovery, review metadata convergence, integrated SHA persistence, and reopen recovery instead of raw Beads helpers.
- Extend `src/atelier/worker/store_adapter.py` with AtelierStore-backed review metadata, integrated SHA, and lifecycle reopen mutations used by recovery flows.
- Add focused regression coverage for adapter mutations and dependency recovery routing in `tests/atelier/worker/test_reconcile.py` and `tests/atelier/worker/test_store_adapter.py`.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #669

# Risks / Rollout

- Main risk is recovery drift on rebased worker branches; coverage now exercises stale terminal metadata convergence, dependency ordering, and reopen correction paths.

# Notes

- This PR is rebased onto `main` after the parent worker-store slice merged, so the diff is limited to this dependency-lineage recovery changeset.
