### PR TITLE
Prove worker store migration parity and publish the contract

### DIFF
--- a/docs/atelier-store-contract.md
+++ b/docs/atelier-store-contract.md
@@ -175,12 +175,14 @@ This proof slice leaves only the following work deferred:
 
 - planner migrations onto `atelier.store`; that remains deferred to
   [GitHub issue #582]
-- worker migrations onto `atelier.store`; that remains deferred to
-  [GitHub issue #583]
 - publish/integration migrations onto `atelier.store`; that remains deferred to
   [GitHub issue #584]
 - dependency add/remove parity in the in-memory backend so those mutations can
   graduate from process-backed-only coverage into the shared proof suite
+
+Worker lifecycle migrations now follow the [Worker Store Migration Contract].
+Remaining worker-side deferred work stays on publish/integration orchestration
+plus richer worktree and epic-close store semantics.
 
 The core store contract, discovery methods, mutation methods, and dual-backend
 proof are no longer deferred work. Downstream epics should build on that landed
@@ -189,5 +191,5 @@ surface instead of re-deriving store semantics from Beads issue payloads.
 <!-- inline reference link definitions. please keep alphabetized -->
 
 [github issue #582]: https://github.com/shaug/atelier/issues/582
-[github issue #583]: https://github.com/shaug/atelier/issues/583
 [github issue #584]: https://github.com/shaug/atelier/issues/584
+[worker store migration contract]: ./worker-store-migration-contract.md

--- a/docs/planner-store-migration-contract.md
+++ b/docs/planner-store-migration-contract.md
@@ -69,12 +69,14 @@ other planner mutations.
 
 This planner migration slice leaves the following work deferred:
 
-- worker lifecycle and finalization migrations onto `atelier.store`
 - publish and integration orchestration migrations onto `atelier.store`
 - a richer planner preview read model in `atelier.store` so `plan-promote-epic`
   can drop its raw issue reads
 - shared dual-backend proof for dependency add/remove once the in-memory Beads
   backend supports those mutations at planner parity
+
+Worker lifecycle and hook/message migrations now follow the
+[Worker Store Migration Contract].
 
 No new planner business flow should introduce a fresh Beads-shaped contract. If
 a planner path needs more state than `atelier.store` currently exposes, add that
@@ -98,3 +100,4 @@ planning future planner, worker, or publish migrations.
 <!-- inline reference link definitions. please keep alphabetized -->
 
 [atelier store contract]: ./atelier-store-contract.md
+[worker store migration contract]: ./worker-store-migration-contract.md

--- a/docs/worker-store-migration-contract.md
+++ b/docs/worker-store-migration-contract.md
@@ -1,0 +1,107 @@
+# Worker Store Migration Contract
+
+Worker startup, lifecycle, hook, queue, and reconcile flows now depend on
+`atelier.store` as the worker-side issue-store boundary.
+
+This document narrows that statement to the worker runtime. It explains which
+worker entry points are proven against `AtelierStore`, which compatibility seams
+remain adapter-local, and which follow-on gaps stay deferred for later epics.
+
+## Proven Worker Boundary
+
+Worker code can treat the following paths as store-backed today:
+
+- startup discovery in `work_startup_runtime` and `queueing`
+- epic claim/release and agent hook mutations in `store_adapter`, `claim-epic`,
+  `release-epic`, and `hook-status`
+- worker inbox and queue reads plus queue claim/read mutations in
+  `startup-contract`, `mail-queue-claim`, and `mail-mark-read`
+- lifecycle and review metadata mutations in `changeset_state`, `finalize`,
+  `reconcile`, and `work_finalization_state`
+- descendant changeset discovery and lifecycle summaries used for startup
+  selection, no-ready notifications, and reconcile corrections
+
+Those flows should depend on `AtelierStore` plus the typed request/query models
+it publishes:
+
+- `ChangesetQuery` and `ReadyChangesetQuery` for startup and lineage reads
+- `MessageQuery`, `ClaimMessageRequest`, and `MarkMessageReadRequest` for inbox
+  and queue behavior
+- `SetAgentBeadHookRequest` and `ClearAgentBeadHookRequest` for hook ownership
+- `LifecycleTransitionRequest`, `AppendNotesRequest`, and `UpdateReviewRequest`
+  for blocked/finalize/reconcile lifecycle updates
+
+Worker modules should not compose raw `bd` argv for those business flows. Raw
+Beads usage remains appropriate only for compatibility-only metadata,
+filesystem-oriented worktree state, or lifecycle seams that `atelier.store` does
+not publish yet.
+
+## Worker Compatibility Seams
+
+Four worker-visible compatibility seams remain intentional for now:
+
+- agent-bead discovery still scans agent issues by title and compatibility
+  description fields before worker code can switch to the store-owned hook
+  lookup by bead id
+- operator escalations without a work thread (`thread_id=None`) still use the
+  legacy `create_message_bead()` path; durable worker/planner coordination stays
+  on threaded `atelier.store.CreateMessageRequest`
+- worktree and branch metadata writes still go through the legacy Beads helper
+  layer because `atelier.store` does not yet publish worktree-path, root-branch,
+  or parent-branch mutations
+- epic-close and lineage-repair fallback reads still use adapter-local Beads
+  helpers when worker teardown must recover from missing parent metadata or
+  legacy description fields
+
+Worker logic should rely on the store-backed lifecycle contract first and treat
+those compatibility seams as explicit exceptions rather than alternate public
+APIs.
+
+## Newly Exposed Worker Gap
+
+`work-done` still closes epics through the deterministic Beads helper rather
+than a store-owned epic-close mutation.
+
+That gap is explicit rather than accidental: the current store models publish
+changeset lifecycle transitions and hook mutations, but not the composite "close
+epic if descendants are terminal, clear the hook, and reconcile external close
+state" operation that `work-done` and worker finalize teardown need.
+
+Until that richer epic-finalization semantic lands in `atelier.store`, keep epic
+close on the compatibility helper and do not treat it as a reason to bypass the
+store for worker claim, queue, hook, or changeset lifecycle work.
+
+## Deferred Work
+
+This worker migration slice leaves the following work deferred:
+
+- publish/integration orchestration migrations onto `atelier.store`
+- store-owned worktree and branch metadata mutations for worker session setup
+  and teardown
+- a store-owned epic-close/finalize semantic so `work-done` can drop its
+  compatibility helper
+- removal of the unthreaded operator escalation fallback once every worker
+  coordination path has a durable epic or changeset thread
+
+No new worker business flow should introduce a fresh Beads-shaped contract. If a
+worker path needs more state than `atelier.store` currently exposes, add that
+store semantic first and extend the shared parity proof before moving the worker
+logic onto it.
+
+## Proof Surface
+
+Representative worker parity is covered by deterministic tests that exercise
+worker-facing entry points over both supported Beads backends:
+
+- startup hook, inbox, queue, descendant, and ready-changeset discovery through
+  `work_startup_runtime` and `store_adapter`
+- epic claim and agent hook set/clear through `store_adapter`
+- threaded queue claim/read and lifecycle notes through `store_adapter`
+- merged/finalize lifecycle persistence through `changeset_state` and `finalize`
+
+Use this document together with the broader [Atelier Store Contract] when
+planning future worker, publish, or review migrations.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[atelier store contract]: ./atelier-store-contract.md

--- a/src/atelier/skills/claim-epic/SKILL.md
+++ b/src/atelier/skills/claim-epic/SKILL.md
@@ -16,15 +16,21 @@ description: >-
 
 ## Steps
 
-1. Claim the epic:
-   - `bd update <epic_id> --assignee <agent_id> --status in_progress --add-label at:hooked`
-1. Re-read the epic to verify the assignee is still `<agent_id>`.
-1. Load the agent bead description:
-   - `bd show <agent_bead_id>`
-1. Update `hook_bead` in the agent bead description:
-   - Write a new description with `hook_bead: <epic_id>` (use `--body-file`).
+1. Claim the epic through the worker lifecycle helper:
+   - persist assignee, `in_progress`, and `at:hooked` together as one verified
+     claim mutation
+1. Re-read the epic to verify the assignee is still `<agent_id>` and the hook
+   label remains present.
+1. Persist the agent hook through the store-owned hook mutation for
+   `<agent_bead_id>`.
+1. See [Worker Store Migration Contract] for the store-backed claim/hook
+   boundary and the remaining compatibility seams.
 
 ## Verification
 
 - Epic shows assignee and `at:hooked` label.
-- Agent bead description includes `hook_bead: <epic_id>`.
+- Agent bead hook resolves to `<epic_id>`.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[worker store migration contract]: ../../../../docs/worker-store-migration-contract.md

--- a/src/atelier/skills/hook-status/SKILL.md
+++ b/src/atelier/skills/hook-status/SKILL.md
@@ -16,7 +16,12 @@ description: >-
 1. Run the hook-status script:
    - `python3 skills/hook-status/scripts/hook_status.py <agent_bead_id> [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"]`
 1. Read the current hook through the `atelier.store` hook model.
+1. See [Worker Store Migration Contract] for the store-backed hook boundary.
 
 ## Verification
 
 - Report the current `hook_bead` value (or `null` if none).
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[worker store migration contract]: ../../../../docs/worker-store-migration-contract.md

--- a/src/atelier/skills/mail-mark-read/SKILL.md
+++ b/src/atelier/skills/mail-mark-read/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 1. Run the mark-read script:
    - `python3 skills/mail-mark-read/scripts/mark_read.py <message_id> [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"]`
 1. The script verifies the unread transition through `atelier.store`.
-1. See [Planner Store Migration Contract] for the current planner-side message
+1. See [Worker Store Migration Contract] for the worker-side unread transition
    boundary and deferred gaps.
 
 ## Verification
@@ -25,4 +25,4 @@ description: >-
 
 <!-- inline reference link definitions. please keep alphabetized -->
 
-[planner store migration contract]: ../../../../docs/planner-store-migration-contract.md
+[worker store migration contract]: ../../../../docs/worker-store-migration-contract.md

--- a/src/atelier/skills/mail-queue-claim/SKILL.md
+++ b/src/atelier/skills/mail-queue-claim/SKILL.md
@@ -21,8 +21,8 @@ description: >-
    - `python3 skills/mail-queue-claim/scripts/claim_message.py <message_id> [--queue "<queue>"] [--claimed-by "<agent_id>"] [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"]`
 1. The script validates queue identity, enforces claim ownership, and persists
    claim metadata through `atelier.store`.
-1. See [Planner Store Migration Contract] for the current planner-side message
-   boundary and deferred gaps.
+1. See [Worker Store Migration Contract] for the worker-side queue boundary and
+   deferred gaps.
 
 ## Verification
 
@@ -31,4 +31,4 @@ description: >-
 
 <!-- inline reference link definitions. please keep alphabetized -->
 
-[planner store migration contract]: ../../../../docs/planner-store-migration-contract.md
+[worker store migration contract]: ../../../../docs/worker-store-migration-contract.md

--- a/src/atelier/skills/release-epic/SKILL.md
+++ b/src/atelier/skills/release-epic/SKILL.md
@@ -15,14 +15,19 @@ description: >-
 
 ## Steps
 
-1. Release the epic:
-   - `bd update <epic_id> --assignee "" --status open --remove-label at:hooked`
-1. Load the agent bead description:
-   - `bd show <agent_bead_id>`
-1. Clear the hook in the agent bead description:
-   - Write a new description with `hook_bead: null` (use `--body-file`).
+1. Release the epic through the worker lifecycle helper:
+   - clear assignee, reset lifecycle to `open` when appropriate, and remove the
+     `at:hooked` label with verification
+1. Clear the agent hook through the store-owned hook mutation for
+   `<agent_bead_id>`.
+1. See [Worker Store Migration Contract] for the worker-side release boundary
+   and the remaining compatibility seams.
 
 ## Verification
 
 - Epic has no assignee and no `at:hooked` label.
-- Agent bead description includes `hook_bead: null`.
+- Agent bead hook resolves to `null`.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[worker store migration contract]: ../../../../docs/worker-store-migration-contract.md

--- a/src/atelier/skills/startup-contract/SKILL.md
+++ b/src/atelier/skills/startup-contract/SKILL.md
@@ -17,7 +17,8 @@ description: >-
 ## Steps
 
 1. Check the current hook:
-   - Use `hook-status` (or `bd show <agent_bead_id>`) to read `hook_bead`.
+   - Use `hook-status` to read the store-backed hook model for
+     `<agent_bead_id>`.
 1. If `hook_bead` is present:
    - Verify the epic exists and is still assigned to `agent_id`.
    - Resume work on that epic (do not claim a new one).
@@ -25,8 +26,8 @@ description: >-
    - Check inbox/queue (message beads) and handle any messages; stop if a
      message requires action before claiming new work.
 1. If still idle:
-   - List eligible epics (`bd list --label at:epic`). `at:epic` is required
-     identity/index metadata for epic discovery.
+   - List eligible epics through the worker store adapter. `at:epic` remains
+     required identity/index metadata for epic discovery.
    - Keep only executable top-level work with status `open`/`in_progress` after
      status+graph evaluation.
    - `cs:*` lifecycle labels are not execution gates.
@@ -35,6 +36,8 @@ description: >-
    - In prompt mode: list eligible epics and ask for an epic id.
 1. Claim the selected epic with `claim-epic`, then proceed with work.
 1. If no eligible epics exist, send a `NEEDS-DECISION` message to the overseer.
+1. See [Worker Store Migration Contract] for the exact worker-side store
+   boundary and deferred seams.
 
 ## Verification
 
@@ -42,3 +45,7 @@ description: >-
 - Messages are marked read when processed.
 - Epic eligibility decisions remain status+graph based after `at:epic` indexed
   discovery.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[worker store migration contract]: ../../../../docs/worker-store-migration-contract.md

--- a/src/atelier/skills/work-done/SKILL.md
+++ b/src/atelier/skills/work-done/SKILL.md
@@ -23,6 +23,8 @@ description: >-
    - `python src/atelier/skills/work-done/scripts/close_epic.py --epic-id <epic_id> --agent-bead-id <agent_bead_id>`
 1. For explicit direct-close flows (skip readiness checks), use:
    - `python src/atelier/skills/work-done/scripts/close_epic.py --epic-id <epic_id> --agent-bead-id <agent_bead_id> --direct-close`
+1. This remains a compatibility path until `atelier.store` publishes an explicit
+   epic-close/finalize mutation. See [Worker Store Migration Contract].
 
 ## Verification
 
@@ -30,3 +32,7 @@ description: >-
 - Agent hook slot is empty.
 - If `external_tickets` has exported GitHub links, close-state metadata is
   reconciled.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[worker store migration contract]: ../../../../docs/worker-store-migration-contract.md

--- a/tests/atelier/test_planner_store_migration_contract.py
+++ b/tests/atelier/test_planner_store_migration_contract.py
@@ -432,7 +432,7 @@ def test_planner_store_migration_docs_publish_boundary_and_deferred_gaps() -> No
     assert "assignee recipient hint" in doc
     assert "plan-promote-epic" in doc
     assert "preview still expands raw issue detail" in doc
-    assert "worker lifecycle and finalization migrations onto `atelier.store`" in doc
+    assert "[Worker Store Migration Contract]" in doc
     assert "publish and integration orchestration migrations onto `atelier.store`" in doc
 
     assert "[Planner Store Migration Contract]" in startup_skill

--- a/tests/atelier/test_store_contract.py
+++ b/tests/atelier/test_store_contract.py
@@ -291,6 +291,7 @@ def test_store_contract_docs_record_invariants_and_deferred_work() -> None:
     assert "This proof slice leaves only the following work deferred" in store_doc
     assert "planner migrations onto `atelier.store`" in store_doc
     assert "publish/integration migrations onto `atelier.store`" in store_doc
+    assert "[Worker Store Migration Contract]" in store_doc
     assert "The core store contract, discovery methods, mutation methods, and dual-backend" in (
         store_doc
     )

--- a/tests/atelier/test_worker_store_migration_contract.py
+++ b/tests/atelier/test_worker_store_migration_contract.py
@@ -1,0 +1,511 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from atelier.lib.beads import (
+    BeadsCommandRequest,
+    BeadsCommandResult,
+    ShowIssueRequest,
+    SubprocessBeadsClient,
+    SyncBeadsClient,
+)
+from atelier.messages import render_message
+from atelier.store import build_atelier_store
+from atelier.testing.beads import (
+    InMemoryBeadsBackend,
+    IssueFixtureBuilder,
+    build_in_memory_beads_client,
+)
+from atelier.worker import changeset_state, finalize, work_startup_runtime
+from atelier.worker import store_adapter as worker_store
+from atelier.worker.models import FinalizeResult
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC_PATH = REPO_ROOT / "docs" / "worker-store-migration-contract.md"
+PLANNER_DOC_PATH = REPO_ROOT / "docs" / "planner-store-migration-contract.md"
+STORE_DOC_PATH = REPO_ROOT / "docs" / "atelier-store-contract.md"
+SKILLS_DIR = REPO_ROOT / "src" / "atelier" / "skills"
+BUILDER = IssueFixtureBuilder()
+_BACKENDS = ("in-memory", "subprocess")
+_BEADS_ROOT = Path("/beads")
+_REPO_ROOT = Path("/repo")
+_AGENT_ID = "atelier/worker/codex/p100"
+
+
+class _InMemorySubprocessTransport:
+    """Drive ``SubprocessBeadsClient`` from the in-memory command backend."""
+
+    def __init__(self, backend: InMemoryBeadsBackend) -> None:
+        self._backend = backend
+
+    async def execute(self, request: BeadsCommandRequest) -> BeadsCommandResult:
+        completed = self._backend.run(request.argv, cwd=request.cwd, env=request.env)
+        return BeadsCommandResult(
+            argv=request.argv,
+            returncode=completed.returncode,
+            stdout=completed.stdout,
+            stderr=completed.stderr,
+        )
+
+
+def _worker_message(
+    message_id: str,
+    *,
+    title: str,
+    body: str,
+    thread_id: str,
+    audience: tuple[str, ...] = ("worker",),
+    queue: str | None = None,
+    kind: str = "instruction",
+    blocking: bool | None = None,
+) -> dict[str, object]:
+    return BUILDER.issue(
+        message_id,
+        title=title,
+        issue_type="message",
+        labels=("at:message", "at:unread"),
+        description=render_message(
+            {
+                "from": "atelier/planner/codex/p200",
+                "delivery": "work-threaded",
+                "thread": thread_id,
+                "thread_kind": "changeset" if "." in thread_id else "epic",
+                "audience": list(audience),
+                "queue": queue,
+                "kind": kind,
+                "blocking": blocking,
+            },
+            body,
+        ),
+    )
+
+
+def _startup_seed_issues() -> tuple[dict[str, object], ...]:
+    return (
+        BUILDER.issue(
+            "at-agent",
+            title=_AGENT_ID,
+            issue_type="agent",
+            labels=("at:agent",),
+            description=f"agent_id: {_AGENT_ID}\nhook_bead: null\n",
+        ),
+        BUILDER.issue(
+            "at-epic",
+            title="Worker migration epic",
+            issue_type="epic",
+            status="in_progress",
+            labels=("at:epic", "at:hooked", "atelier"),
+            assignee=_AGENT_ID,
+        ),
+        BUILDER.issue(
+            "at-epic.1",
+            title="Worker lifecycle slice",
+            parent="at-epic",
+            status="open",
+            labels=("atelier",),
+            dependencies=("at-dep",),
+            description=(
+                "changeset.root_branch: root/worker\n"
+                "changeset.parent_branch: main\n"
+                "changeset.work_branch: root/worker-at-epic.1\n"
+                "pr_state: pushed\n"
+            ),
+        ),
+        BUILDER.issue(
+            "at-dep",
+            title="Merged dependency",
+            parent="at-epic",
+            status="closed",
+            labels=("atelier",),
+            description="pr_state: merged\n",
+        ),
+        _worker_message(
+            "msg-inbox",
+            title="NEEDS-DECISION: review worker contract",
+            body="Review the worker migration contract.",
+            thread_id="at-epic.1",
+            kind="needs-decision",
+            blocking=True,
+        ),
+        _worker_message(
+            "msg-terminal",
+            title="Ignore closed-thread message",
+            body="This message should be filtered because the thread is closed.",
+            thread_id="at-dep",
+        ),
+        _worker_message(
+            "msg-queue",
+            title="Queued worker follow-up",
+            body="Queue this worker follow-up.",
+            thread_id="at-epic.1",
+            queue="worker",
+        ),
+    )
+
+
+def _mutation_seed_issues() -> tuple[dict[str, object], ...]:
+    return (
+        BUILDER.issue(
+            "at-agent",
+            title=_AGENT_ID,
+            issue_type="agent",
+            labels=("at:agent",),
+            description=f"agent_id: {_AGENT_ID}\nhook_bead: null\n",
+        ),
+        BUILDER.issue(
+            "at-epic",
+            title="Worker finalize epic",
+            issue_type="epic",
+            status="open",
+            labels=("at:epic", "atelier"),
+        ),
+        BUILDER.issue(
+            "at-epic.1",
+            title="Finalize worker changeset",
+            parent="at-epic",
+            status="open",
+            labels=("atelier",),
+            description=(
+                "pr_url: https://example.invalid/pr/41\n"
+                "pr_number: 41\n"
+                "pr_state: pushed\n"
+                "review_owner: reviewer-a\n"
+            ),
+        ),
+        _worker_message(
+            "msg-queue",
+            title="Queued finalize follow-up",
+            body="Queue this finalize follow-up.",
+            thread_id="at-epic.1",
+            queue="worker",
+        ),
+    )
+
+
+def _bind_worker_backend(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    backend: str,
+    issues: tuple[dict[str, object], ...],
+):
+    if backend == "in-memory":
+        async_client, _ = build_in_memory_beads_client(issues=issues)
+    elif backend == "subprocess":
+        command_backend = InMemoryBeadsBackend(seeded_issues=issues)
+        async_client = SubprocessBeadsClient(
+            transport=_InMemorySubprocessTransport(command_backend)
+        )
+    else:
+        raise AssertionError(f"unexpected backend: {backend}")
+
+    store = build_atelier_store(beads=async_client)
+    worker_store.clear_bundle_cache()
+    monkeypatch.setattr(
+        worker_store,
+        "_build_store_bundle",
+        lambda **_kwargs: worker_store._StoreBundle(  # pyright: ignore[reportPrivateUsage]
+            store=store,
+            sync_client=SyncBeadsClient(async_client),
+        ),
+    )
+    return async_client, store
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_worker_startup_and_queue_flows_have_dual_backend_parity(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+) -> None:
+    _client, store = _bind_worker_backend(
+        monkeypatch,
+        backend=backend,
+        issues=_startup_seed_issues(),
+    )
+
+    worker_store.set_agent_hook(
+        "at-agent",
+        "at-epic",
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+    )
+
+    summary = worker_store.epic_changeset_summary(
+        "at-epic",
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+    )
+    snapshot = {
+        "hooked": work_startup_runtime.resolve_hooked_epic(
+            "at-agent",
+            _AGENT_ID,
+            beads_root=_BEADS_ROOT,
+            repo_root=_REPO_ROOT,
+        ),
+        "inbox": tuple(
+            item["id"]
+            for item in worker_store.list_inbox_messages(
+                _AGENT_ID,
+                beads_root=_BEADS_ROOT,
+                repo_root=_REPO_ROOT,
+            )
+        ),
+        "queue": tuple(
+            (item["id"], item["queue"], item["claimed_by"])
+            for item in worker_store.list_queue_messages(
+                beads_root=_BEADS_ROOT,
+                repo_root=_REPO_ROOT,
+                queue="worker",
+                unclaimed_only=False,
+            )
+        ),
+        "changesets": tuple(
+            (item["id"], item["status"])
+            for item in sorted(
+                worker_store.list_descendant_changesets(
+                    "at-epic",
+                    beads_root=_BEADS_ROOT,
+                    repo_root=_REPO_ROOT,
+                    include_closed=True,
+                ),
+                key=lambda item: str(item["id"]),
+            )
+        ),
+        "ready": tuple(
+            item["id"]
+            for item in worker_store.ready_changesets_global(
+                beads_root=_BEADS_ROOT,
+                repo_root=_REPO_ROOT,
+            )
+        ),
+        "summary": {
+            "total": summary.total,
+            "ready": summary.ready,
+            "remaining": summary.remaining,
+        },
+        "hook_record": asyncio.run(store.get_agent_bead_hook("at-agent")).model_dump(mode="json"),
+    }
+
+    assert snapshot == {
+        "hooked": "at-epic",
+        "inbox": ("msg-inbox",),
+        "queue": (("msg-queue", "worker", None),),
+        "changesets": (
+            ("at-dep", "closed"),
+            ("at-epic.1", "open"),
+        ),
+        "ready": ("at-epic.1",),
+        "summary": {
+            "total": 2,
+            "ready": 0,
+            "remaining": 1,
+        },
+        "hook_record": {
+            "agent_id": _AGENT_ID,
+            "epic_id": "at-epic",
+        },
+    }
+
+    worker_store.clear_bundle_cache()
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_worker_lifecycle_and_finalize_flows_have_dual_backend_parity(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+) -> None:
+    _client, store = _bind_worker_backend(
+        monkeypatch,
+        backend=backend,
+        issues=_mutation_seed_issues(),
+    )
+    monkeypatch.setattr(
+        changeset_state.beads,
+        "reconcile_closed_issue_exported_github_tickets",
+        lambda *args, **kwargs: None,
+    )
+    monkeypatch.setattr(
+        changeset_state,
+        "_load_changeset_issue",
+        lambda issue_id, *, beads_root, repo_root: worker_store.show_issue(
+            issue_id,
+            beads_root=beads_root,
+            repo_root=repo_root,
+        ),
+    )
+
+    claimed = worker_store.claim_epic(
+        "at-epic",
+        _AGENT_ID,
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+    )
+    worker_store.set_agent_hook(
+        "at-agent",
+        "at-epic",
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+    )
+    worker_store.append_notes(
+        "at-epic.1",
+        notes=("worker_contract: parity verified",),
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+    )
+    worker_store.update_changeset_review(
+        "at-epic.1",
+        pr_state="merged",
+        review_owner="reviewer-b",
+        preserve_existing=True,
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+    )
+
+    result = finalize.finalize_terminal_changeset(
+        changeset_id="at-epic.1",
+        epic_id="at-epic",
+        terminal_state="merged",
+        integrated_sha="abc1234",
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+        mark_changeset_merged=lambda issue_id: changeset_state.mark_changeset_merged(
+            issue_id,
+            beads_root=_BEADS_ROOT,
+            repo_root=_REPO_ROOT,
+        ),
+        mark_changeset_abandoned=lambda _issue_id: None,
+        close_completed_ancestor_container_changesets=lambda _issue_id: [],
+        finalize_epic_if_complete=lambda: FinalizeResult(
+            continue_running=True,
+            reason="changeset_complete",
+        ),
+    )
+    worker_store.claim_queue_message(
+        "msg-queue",
+        _AGENT_ID,
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+        queue="worker",
+    )
+    worker_store.mark_message_read(
+        "msg-queue",
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+    )
+    hooked_before_clear = worker_store.get_agent_hook(
+        "at-agent",
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+    )
+    worker_store.clear_agent_hook(
+        "at-agent",
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+        expected_hook="at-epic",
+    )
+    changeset_record = asyncio.run(store.get_changeset("at-epic.1"))
+    queue_after = worker_store.list_queue_messages(
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+        queue="worker",
+        unclaimed_only=False,
+        unread_only=False,
+    )
+    unread_queue_after = worker_store.list_queue_messages(
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+        queue="worker",
+        unclaimed_only=False,
+        unread_only=True,
+    )
+    refreshed_issue = asyncio.run(store._show_issue("at-epic.1"))
+    snapshot = {
+        "claimed": {
+            "assignee": claimed["assignee"],
+            "status": claimed["status"],
+            "labels": tuple(sorted(str(label) for label in claimed["labels"])),
+        },
+        "finalize_reason": result.reason,
+        "review": changeset_record.review.model_dump(mode="json"),
+        "changeset_status": changeset_record.lifecycle.value,
+        "changeset_labels": tuple(sorted(changeset_record.labels)),
+        "hooked_before_clear": hooked_before_clear,
+        "hooked_after_clear": worker_store.get_agent_hook(
+            "at-agent",
+            beads_root=_BEADS_ROOT,
+            repo_root=_REPO_ROOT,
+        ),
+        "queue_after": tuple(
+            (item["id"], item["queue"], item["claimed_by"]) for item in queue_after
+        ),
+        "unread_queue_after": tuple(item["id"] for item in unread_queue_after),
+        "note_present": "worker_contract: parity verified" in (refreshed_issue.description or ""),
+    }
+
+    assert snapshot == {
+        "claimed": {
+            "assignee": _AGENT_ID,
+            "status": "in_progress",
+            "labels": ("at:epic", "at:hooked", "atelier"),
+        },
+        "finalize_reason": "changeset_complete",
+        "review": {
+            "pr_url": "https://example.invalid/pr/41",
+            "pr_number": 41,
+            "pr_state": "merged",
+            "review_owner": "reviewer-b",
+            "integrated_sha": "abc1234",
+        },
+        "changeset_status": "closed",
+        "changeset_labels": ("atelier", "cs:merged"),
+        "hooked_before_clear": "at-epic",
+        "hooked_after_clear": None,
+        "queue_after": (("msg-queue", "worker", _AGENT_ID),),
+        "unread_queue_after": (),
+        "note_present": True,
+    }
+
+    worker_store.clear_bundle_cache()
+
+
+def test_worker_store_migration_docs_publish_boundary_and_deferred_gaps() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    planner_doc = PLANNER_DOC_PATH.read_text(encoding="utf-8")
+    store_doc = STORE_DOC_PATH.read_text(encoding="utf-8")
+    startup_skill = (SKILLS_DIR / "startup-contract" / "SKILL.md").read_text(encoding="utf-8")
+    claim_skill = (SKILLS_DIR / "claim-epic" / "SKILL.md").read_text(encoding="utf-8")
+    release_skill = (SKILLS_DIR / "release-epic" / "SKILL.md").read_text(encoding="utf-8")
+    work_done_skill = (SKILLS_DIR / "work-done" / "SKILL.md").read_text(encoding="utf-8")
+    hook_status_skill = (SKILLS_DIR / "hook-status" / "SKILL.md").read_text(encoding="utf-8")
+    queue_claim_skill = (SKILLS_DIR / "mail-queue-claim" / "SKILL.md").read_text(encoding="utf-8")
+    mark_read_skill = (SKILLS_DIR / "mail-mark-read" / "SKILL.md").read_text(encoding="utf-8")
+
+    assert "Worker Store Migration Contract" in doc
+    assert "Proven Worker Boundary" in doc
+    assert "Worker Compatibility Seams" in doc
+    assert "thread_id=None" in doc
+    assert "worktree and branch metadata writes still go through" in doc
+    assert "epic-close and lineage-repair fallback reads still use" in doc
+    assert "publish/integration orchestration migrations onto `atelier.store`" in doc
+    assert "`work-done` still closes epics through the deterministic Beads helper" in doc
+
+    assert "[Worker Store Migration Contract]" in planner_doc
+    assert "[Worker Store Migration Contract]" in store_doc
+
+    assert "[Worker Store Migration Contract]" in startup_skill
+    assert "store-backed hook model" in startup_skill
+    assert "worker store adapter" in startup_skill
+    assert "[Worker Store Migration Contract]" in claim_skill
+    assert "store-backed claim/hook" in claim_skill
+    assert "hook resolves to `<epic_id>`" in claim_skill
+    assert "[Worker Store Migration Contract]" in release_skill
+    assert "worker-side release boundary" in release_skill
+    assert "[Worker Store Migration Contract]" in work_done_skill
+    assert "compatibility path" in work_done_skill
+    assert "[Worker Store Migration Contract]" in hook_status_skill
+    assert "[Worker Store Migration Contract]" in queue_claim_skill
+    assert "worker-side queue boundary" in queue_claim_skill
+    assert "[Worker Store Migration Contract]" in mark_read_skill
+    assert "worker-side unread transition" in mark_read_skill


### PR DESCRIPTION
# Summary

- Prove worker store migration parity across the supported Beads backends.
- Publish the worker migration contract for downstream worker and publish work.

# Changes

- Add a worker migration contract that defines the proven boundary,
  compatibility seams, deferred gaps, and proof surface.
- Add dual-backend tests for representative worker startup, queue, claim,
  hook, lifecycle, and finalize flows.
- Align related store/planner docs and worker-facing skill docs with the landed
  worker contract.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets
- Addresses #670

# Risks / Rollout

- Low risk. This change is docs and tests only, but it tightens contract
  assertions around the worker store boundary.

# Notes

- Epic close, worktree metadata, and unthreaded operator escalation remain
  documented compatibility seams until the store publishes those semantics.
