### PR TITLE
Speed up planner startup epic discovery

### DIFF
--- a/src/atelier/planner_overview.py
+++ b/src/atelier/planner_overview.py
@@ -52,7 +52,7 @@ def list_epics(*, beads_root: Path, repo_root: Path) -> list[dict[str, object]]:
         Epic issue payloads derived from the Atelier store.
     """
     store = _build_store(beads_root=beads_root, repo_root=repo_root)
-    epics = asyncio.run(store.list_epics(EpicQuery(include_closed=False)))
+    epics = asyncio.run(store.list_epics(EpicQuery(include_closed=False, include_changesets=False)))
     return [_epic_issue_payload(epic) for epic in epics]
 
 

--- a/src/atelier/planner_startup_check.py
+++ b/src/atelier/planner_startup_check.py
@@ -662,7 +662,11 @@ class StartupBeadsInvocationHelper:
     def list_epics(self, *, include_closed: bool = False) -> list[dict[str, object]]:
         """List indexed epics through the Atelier store."""
 
-        epics = asyncio.run(self._store().list_epics(EpicQuery(include_closed=include_closed)))
+        epics = asyncio.run(
+            self._store().list_epics(
+                EpicQuery(include_closed=include_closed, include_changesets=False)
+            )
+        )
         return [_epic_issue_payload(epic) for epic in epics]
 
     def list_descendant_changesets(

--- a/src/atelier/store/beads_store.py
+++ b/src/atelier/store/beads_store.py
@@ -364,12 +364,18 @@ class AtelierStore:
             if query.assignee is not None and issue.assignee != query.assignee:
                 continue
             if await self._is_indexed_epic(issue, state=state):
-                records.append(await self._epic_record(issue, state=state))
+                records.append(
+                    await self._epic_record(
+                        issue,
+                        state=state,
+                        include_changesets=query.include_changesets,
+                    )
+                )
         return tuple(records)
 
     async def epic_discovery_parity(self) -> EpicDiscoveryParity:
         state = _ReadState(self)
-        issues = await state.scan_issues(include_closed=True)
+        issues = await state.scan_issues(include_closed=False)
 
         active_top_level: list[IssueRecord] = []
         indexed_active_ids: set[str] = set()
@@ -1232,7 +1238,13 @@ class AtelierStore:
         )
 
     async def _is_indexed_epic(self, issue: IssueRecord, *, state: _ReadState) -> bool:
-        role = await self._role(issue, state=state)
+        del state
+        role = lifecycle.infer_work_role(
+            labels=_normalized_labels(issue.labels),
+            issue_type=issue.type,
+            parent_id=_parent_id(issue),
+            has_work_children=False,
+        )
         return role.is_epic and _has_contract_label(_normalized_labels(issue.labels), "epic")
 
     def _matches_issue_kind(self, issue: IssueRecord, kind: str) -> bool:
@@ -1380,16 +1392,24 @@ class AtelierStore:
             return (epic,)
         return ()
 
-    async def _epic_record(self, issue: IssueRecord, *, state: _ReadState) -> EpicRecord:
-        descendant_changesets = await self._descendant_changesets(
-            issue,
-            state=state,
-            include_closed=True,
-        )
-        changesets = tuple(
-            WorkRef(id=changeset.id, title=changeset.title, kind=WorkItemKind.CHANGESET)
-            for changeset in descendant_changesets
-        )
+    async def _epic_record(
+        self,
+        issue: IssueRecord,
+        *,
+        state: _ReadState,
+        include_changesets: bool = True,
+    ) -> EpicRecord:
+        changesets: tuple[WorkRef, ...] = ()
+        if include_changesets:
+            descendant_changesets = await self._descendant_changesets(
+                issue,
+                state=state,
+                include_closed=True,
+            )
+            changesets = tuple(
+                WorkRef(id=changeset.id, title=changeset.title, kind=WorkItemKind.CHANGESET)
+                for changeset in descendant_changesets
+            )
         return EpicRecord(
             id=issue.id,
             title=issue.title or issue.id,

--- a/src/atelier/store/contract.py
+++ b/src/atelier/store/contract.py
@@ -24,6 +24,7 @@ class EpicQuery(StoreModel):
 
     assignee: Identifier | None = None
     include_closed: bool = False
+    include_changesets: bool = True
 
 
 class ChangesetQuery(StoreModel):

--- a/tests/atelier/test_planner_overview.py
+++ b/tests/atelier/test_planner_overview.py
@@ -52,3 +52,24 @@ def test_list_epics_accepts_store_shaped_dependency_payloads(
     assert issues[0]["id"] == "at-epic"
     assert issues[0]["dependencies"] == [{"id": "at-dep", "status": "in_progress"}]
     assert "Blocked epics:" in planner_overview.render_epics(issues, show_drafts=True)
+
+
+def test_list_epics_requests_epic_records_without_changesets(monkeypatch, tmp_path: Path) -> None:
+    beads_root = tmp_path / ".beads"
+    repo_root = tmp_path / "repo"
+    beads_root.mkdir()
+    repo_root.mkdir()
+    captured_query = None
+
+    class _FakeStore:
+        async def list_epics(self, query):
+            nonlocal captured_query
+            captured_query = query
+            return ()
+
+    monkeypatch.setattr(planner_overview, "_build_store", lambda **_kwargs: _FakeStore())
+
+    assert planner_overview.list_epics(beads_root=beads_root, repo_root=repo_root) == []
+    assert captured_query is not None
+    assert captured_query.include_closed is False
+    assert captured_query.include_changesets is False

--- a/tests/atelier/test_planner_startup_check.py
+++ b/tests/atelier/test_planner_startup_check.py
@@ -280,6 +280,27 @@ def test_startup_helper_uses_in_memory_backend_for_inbox_queue_and_epic_queries(
     assert epics[0]["dependencies"] == [{"id": "at-dep", "status": "in_progress"}]
 
 
+def test_startup_helper_lists_epics_without_changesets() -> None:
+    helper = planner_startup_check.StartupBeadsInvocationHelper(
+        beads_root=Path("/beads"),
+        cwd=Path("/repo"),
+    )
+    captured_query = None
+
+    class _FakeStore:
+        async def list_epics(self, query):
+            nonlocal captured_query
+            captured_query = query
+            return ()
+
+    object.__setattr__(helper, "_store_cache", _FakeStore())
+
+    assert helper.list_epics(include_closed=False) == []
+    assert captured_query is not None
+    assert captured_query.include_closed is False
+    assert captured_query.include_changesets is False
+
+
 def test_startup_helper_lists_leaf_descendants_with_in_memory_backend(
     monkeypatch,
     tmp_path: Path,

--- a/tests/atelier/test_store_contract.py
+++ b/tests/atelier/test_store_contract.py
@@ -14,6 +14,7 @@ from atelier.lib.beads import (
     BeadsCommandError,
     BeadsCommandRequest,
     BeadsCommandResult,
+    ListIssuesRequest,
     RecordingBeadsTransport,
     ScriptedBeadsTransport,
     SubprocessBeadsClient,
@@ -33,6 +34,7 @@ from atelier.store import (
     CreateMessageRequest,
     DependencyMutation,
     DependencyRecord,
+    EpicQuery,
     EpicRecord,
     HookRecord,
     LifecycleStatus,
@@ -695,6 +697,50 @@ def test_store_epic_discovery_parity_reports_missing_identity(backend: str) -> N
         "bd update at-missing --type epic --add-label at:epic"
     )
     assert parity.missing_from_index == ()
+
+
+def test_list_epics_skips_descendant_scans_when_changesets_not_requested(monkeypatch) -> None:
+    issues = (
+        BUILDER.issue("at-epic", title="Indexed epic", issue_type="epic", labels=("at:epic",)),
+        *(BUILDER.issue(f"at-task-{index}", title=f"Task {index}") for index in range(12)),
+    )
+    client, _ = build_in_memory_beads_client(issues=issues)
+    recorded_requests: list[ListIssuesRequest] = []
+    original_list = client.list
+
+    async def _recording_list(request: ListIssuesRequest):
+        recorded_requests.append(request)
+        return await original_list(request)
+
+    monkeypatch.setattr(client, "list", _recording_list)
+    store = build_atelier_store(beads=client)
+
+    epics = _RUN(store.list_epics(EpicQuery(include_changesets=False)))
+
+    assert tuple(epic.id for epic in epics) == ("at-epic",)
+    assert all(request.parent_id is None for request in recorded_requests)
+
+
+def test_epic_discovery_parity_avoids_child_lookup_per_scanned_issue(monkeypatch) -> None:
+    issues = (
+        BUILDER.issue("at-epic", title="Indexed epic", issue_type="epic", labels=("at:epic",)),
+        *(BUILDER.issue(f"at-task-{index}", title=f"Task {index}") for index in range(12)),
+    )
+    client, _ = build_in_memory_beads_client(issues=issues)
+    recorded_requests: list[ListIssuesRequest] = []
+    original_list = client.list
+
+    async def _recording_list(request: ListIssuesRequest):
+        recorded_requests.append(request)
+        return await original_list(request)
+
+    monkeypatch.setattr(client, "list", _recording_list)
+    store = build_atelier_store(beads=client)
+
+    parity = _RUN(store.epic_discovery_parity())
+
+    assert parity.indexed_active_epic_count == 1
+    assert all(request.parent_id is None for request in recorded_requests)
 
 
 @pytest.mark.parametrize("backend", _BACKENDS)


### PR DESCRIPTION
# Summary

- Speed up planner startup epic discovery by removing work-child scans from indexed epic checks and by skipping descendant changeset loading when startup only needs epic metadata.
- Limit epic discovery parity to active-visible issues so startup hits the current store quickly, while leaving the separate tombstone normalization bug untouched.

# Changes

- Added `EpicQuery.include_changesets` and used it from planner overview/startup reads so startup avoids building full descendant changeset projections it never renders.
- Reworked indexed epic detection in `AtelierStore` to infer top-level epic identity without calling `work_children()` for every scanned issue.
- Scoped store parity scans to non-closed issues and added regression tests for the fast path and startup call sites.

# Testing

- `pytest -q tests/atelier/test_store_contract.py tests/atelier/test_planner_overview.py tests/atelier/test_planner_startup_check.py tests/atelier/test_planner_store_migration_contract.py`
- `pytest`
- `bash tests/shell/run.sh`
- Current-store source timing: `inbox=0.258s`, `queue=0.111s`, `epics=0.760s`, `parity=0.088s` before the existing tombstone fallback.

# Tickets

- None

# Risks / Rollout

- Startup still falls back on legacy tombstone records, but the failure now happens without the previous child-scan fan-out.

# Notes

- This change intentionally does not normalize tombstone lifecycle values; that follow-up remains separate work.
