### PR TITLE
Clarify planner ownership for lifecycle and boundary policy

### DIFF
--- a/src/atelier/templates/AGENTS.planner.md.tmpl
+++ b/src/atelier/templates/AGENTS.planner.md.tmpl
@@ -65,6 +65,25 @@ Planner ownership boundary:
   and route recovery to workers/overseer instead of silently reassigning.
 - Planner owns operator decision handling, deferred->open promotion,
   broken-state cleanup, and other non-commit orchestration.
+- Planner/operator also own policy decisions about lifecycle vocabulary, store
+  boundaries, and backend normalization whenever more than one plausible public
+  contract exists.
+- Workers implement the selected contract. They may choose implementation
+  details inside that contract, but they must not invent policy during
+  execution or in response to review feedback.
+
+Policy and boundary decisions:
+- If a backend exposes unsupported lifecycle status values, planner/operator
+  decide whether Atelier maps them to canonical lifecycle terms, rejects them,
+  or treats them as compatibility-only state.
+- If legacy backend data leaks across the store boundary, planner/operator
+  decide whether the boundary normalizes it, preserves it behind an adapter, or
+  blocks the flow until the contract is updated.
+- If review feedback asks a worker to choose lifecycle semantics, store
+  behavior, or normalization policy, treat that as a planner decision to record
+  in guidance or beads before implementation resumes.
+- Preserve worker autonomy for implementation details that stay within the
+  chosen contract.
 
 ## Project Architecture
 

--- a/tests/atelier/test_planner_agents_template.py
+++ b/tests/atelier/test_planner_agents_template.py
@@ -37,6 +37,18 @@ def test_planner_agents_template_contains_core_sections() -> None:
     assert "check_issue_ownership.py" in content
     assert "do not infer executable ownership from raw" in content
     assert "Planner owns operator decision handling" in content
+    assert "Planner/operator also own policy decisions" in content
+    assert "lifecycle vocabulary, store" in content
+    assert "backend normalization whenever more than one plausible public" in content
+    assert "Workers implement the selected contract." in content
+    assert "must not invent policy during" in content
+    assert "Policy and boundary decisions:" in content
+    assert "unsupported lifecycle status values" in content
+    assert "maps them to canonical lifecycle terms" in content
+    assert "legacy backend data leaks across the store boundary" in content
+    assert "normalizes it, preserves it behind an adapter" in content
+    assert "review feedback asks a worker to choose lifecycle semantics" in content
+    assert "Preserve worker autonomy for implementation details" in content
     assert "Do not dispatch cleanup-only beads as worker executable work." in content
     assert "intent, rationale, non-goals, constraints, edge" in content
     assert "related-context links" in content


### PR DESCRIPTION
# Summary

- Clarify that planner/operator own lifecycle vocabulary, store-boundary
  behavior, and backend-normalization policy decisions in planner guidance.

# Changes

- Add an explicit planner-template policy section stating that workers
  implement the selected contract and must not invent policy during execution
  or review response.
- Add concrete examples for unsupported lifecycle statuses, legacy backend
  data crossing the store boundary, and review feedback that requests policy
  choices.
- Extend the planner template test so CI enforces the new guidance wording.

# Testing

- `just test`
- `just format`
- `just lint`

# Tickets

- None

# Risks / Rollout

- Low risk. This only changes shipped guidance text and its template coverage.

# Notes

- The publish wrapper's `run_required_checks.sh` produced a shell-context false
  negative in `tests/shell/repo_hooks_test.sh`, but the direct repo-root
  verification commands above passed cleanly.
