### PR TITLE
Support explicit unread mode in mail inbox

### DIFF
--- a/src/atelier/skills/mail-inbox/SKILL.md
+++ b/src/atelier/skills/mail-inbox/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: mail-inbox
 description: >-
-  List compatibility-routed message beads assigned to the current agent,
-  optionally filtering to unread messages.
+  List compatibility-routed message beads assigned to the current agent, with
+  explicit unread-only and all-messages modes.
 ---
 
 # Mail inbox
@@ -10,13 +10,14 @@ description: >-
 ## Inputs
 
 - agent_id: Agent identity to filter by assignee.
-- unread_only: Whether to filter by `at:unread` (default true).
+- mode: Defaults to unread-only; use `--unread` for an explicit unread-only
+  invocation or `--all` to include already-read messages.
 - beads_dir: Optional Beads store path.
 
 ## Steps
 
 1. Use the inbox script:
-   - `python3 skills/mail-inbox/scripts/list_inbox.py --agent-id "<agent_id>" [--all] [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"]`
+   - `python3 skills/mail-inbox/scripts/list_inbox.py --agent-id "<agent_id>" [--unread | --all] [--beads-dir "<beads_dir>"] [--repo-dir "<repo_dir>"]`
 1. The script reads through `atelier.store` message models and filters by the
    agent runtime role.
 1. Treat assignee-based inbox delivery as compatibility-only routing:
@@ -29,8 +30,10 @@ description: >-
 
 ## Verification
 
-- Returned list includes only store-backed threaded messages for the agent
-  runtime role.
+- Default invocations and explicit `--unread` invocations return the unread-only
+  threaded messages for the agent runtime role.
+- `--all` broadens the result set to include already-read threaded messages for
+  the agent runtime role.
 
 <!-- inline reference link definitions. please keep alphabetized -->
 

--- a/src/atelier/skills/mail-inbox/scripts/list_inbox.py
+++ b/src/atelier/skills/mail-inbox/scripts/list_inbox.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""List store-backed inbox messages for one agent runtime."""
+"""List store-backed inbox messages for one agent runtime.
+
+Defaults to unread-only mode unless ``--all`` is requested.
+"""
 
 from __future__ import annotations
 
@@ -8,6 +11,7 @@ import asyncio
 import json
 import os
 import sys
+from collections.abc import Sequence
 from pathlib import Path
 
 _SHARED_SCRIPTS_ROOT = Path(__file__).resolve().parents[2] / "shared" / "scripts"
@@ -134,14 +138,22 @@ def list_inbox_messages(
     return sorted(matches, key=lambda item: (str(item["id"]), str(item["title"])))
 
 
-def main() -> None:
+def build_parser() -> argparse.ArgumentParser:
+    """Build the ``mail-inbox`` CLI parser."""
+
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--agent-id",
         default="",
         help="agent identity (defaults to ATELIER_AGENT_ID)",
     )
-    parser.add_argument(
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
+        "--unread",
+        action="store_true",
+        help="explicitly limit results to unread messages (default)",
+    )
+    mode_group.add_argument(
         "--all",
         action="store_true",
         help="include already-read messages",
@@ -161,7 +173,12 @@ def main() -> None:
         action="store_true",
         help="emit machine-readable JSON",
     )
-    args = parser.parse_args()
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
 
     agent_id = _resolve_agent_id(args.agent_id)
     beads_dir = str(args.beads_dir).strip() or None

--- a/tests/atelier/skills/test_mailbox_scripts.py
+++ b/tests/atelier/skills/test_mailbox_scripts.py
@@ -5,6 +5,8 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import pytest
+
 from atelier import messages
 from atelier.store import MessageQuery, build_atelier_store
 from atelier.testing.beads import IssueFixtureBuilder, build_in_memory_beads_client
@@ -80,6 +82,69 @@ def test_mail_inbox_lists_messages_for_runtime_role() -> None:
     assert [item["id"] for item in inbox] == ["at-msg-1"]
     assert "changeset=at-epic.1" in inbox[0]["title"]
     assert inbox[0]["blocking_roles"] == ["planner"]
+
+
+def test_mail_inbox_defaults_to_unread_only(tmp_path: Path) -> None:
+    module = _load_script("mail-inbox", "list_inbox.py")
+
+    unread_values: list[bool] = []
+
+    module._resolve_agent_id = lambda _agent_id: "atelier/planner/codex/p200"
+    module._resolve_context = lambda **_kwargs: (tmp_path, tmp_path, None)
+    module.list_inbox_messages = lambda **kwargs: unread_values.append(kwargs["unread_only"]) or []
+
+    module.main(["--agent-id", "atelier/planner/codex/p200"])
+
+    assert unread_values == [True]
+
+
+def test_mail_inbox_explicit_unread_matches_default_mode(tmp_path: Path) -> None:
+    module = _load_script("mail-inbox", "list_inbox.py")
+
+    unread_values: list[bool] = []
+
+    module._resolve_agent_id = lambda _agent_id: "atelier/planner/codex/p200"
+    module._resolve_context = lambda **_kwargs: (tmp_path, tmp_path, None)
+    module.list_inbox_messages = lambda **kwargs: unread_values.append(kwargs["unread_only"]) or []
+
+    module.main(["--agent-id", "atelier/planner/codex/p200", "--unread"])
+
+    assert unread_values == [True]
+
+
+def test_mail_inbox_all_includes_read_messages(tmp_path: Path) -> None:
+    module = _load_script("mail-inbox", "list_inbox.py")
+
+    unread_values: list[bool] = []
+
+    module._resolve_agent_id = lambda _agent_id: "atelier/planner/codex/p200"
+    module._resolve_context = lambda **_kwargs: (tmp_path, tmp_path, None)
+    module.list_inbox_messages = lambda **kwargs: unread_values.append(kwargs["unread_only"]) or []
+
+    module.main(["--agent-id", "atelier/planner/codex/p200", "--all"])
+
+    assert unread_values == [False]
+
+
+def test_mail_inbox_help_lists_unread_and_all_modes() -> None:
+    module = _load_script("mail-inbox", "list_inbox.py")
+
+    help_text = module.build_parser().format_help()
+
+    assert "--unread" in help_text
+    assert "--all" in help_text
+    assert "unread messages (default)" in help_text
+
+
+def test_mail_inbox_rejects_conflicting_mode_flags(capsys: pytest.CaptureFixture[str]) -> None:
+    module = _load_script("mail-inbox", "list_inbox.py")
+
+    with pytest.raises(SystemExit) as exc_info:
+        module.main(["--agent-id", "atelier/planner/codex/p200", "--unread", "--all"])
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 2
+    assert "not allowed with argument" in captured.err
 
 
 def test_mail_mark_read_updates_store_read_state() -> None:


### PR DESCRIPTION
# Summary

- Add an explicit `--unread` mode to `mail-inbox` without changing the current unread-only default behavior.

# Changes

- Add a mutually exclusive `--unread` / `--all` parser contract to the `mail-inbox` script.
- Keep default invocations and explicit `--unread` invocations on the unread-only code path, with deterministic conflicting-flag errors.
- Update the packaged `mail-inbox` skill docs and add regression coverage for default, explicit, all-mode, help text, and conflict handling.

# Testing

- `uv run pytest tests/atelier/skills/test_mailbox_scripts.py`
- `just format`
- `just lint`
- `just test`

# Tickets

- None

# Risks / Rollout

- Low risk; the change is isolated to mailbox CLI parsing, shipped skill docs, and focused regression coverage.

# Notes

- `--all` remains the explicit broadened mode, and `--unread` is now a documented synonym for the existing default behavior.
