### PR TITLE
Keep stale closed PR worker inbox threads visible during startup

### DIFF
--- a/src/atelier/worker/store_adapter.py
+++ b/src/atelier/worker/store_adapter.py
@@ -1083,8 +1083,6 @@ def _startup_message_thread_is_terminal(
     review_state = changeset_fields.review_state(issue)
     if lifecycle.is_integrated_review_state(review_state):
         return True
-    if lifecycle.is_terminal_review_without_integration(review_state):
-        return True
     fields = changeset_fields.issue_fields(issue)
     return changeset_fields.normalized_field(fields, "changeset.integrated_sha") is not None
 

--- a/tests/atelier/test_worker_store_migration_contract.py
+++ b/tests/atelier/test_worker_store_migration_contract.py
@@ -378,6 +378,58 @@ def test_worker_inbox_ignores_terminal_changeset_threads_with_dual_backend_parit
 
 
 @pytest.mark.parametrize("backend", _BACKENDS)
+def test_worker_inbox_keeps_open_changesets_with_stale_closed_pr_state_visible(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+) -> None:
+    _client, _store = _bind_worker_backend(
+        monkeypatch,
+        backend=backend,
+        issues=(
+            BUILDER.issue(
+                "at-agent",
+                title=_AGENT_ID,
+                issue_type="agent",
+                labels=("at:agent",),
+                description=f"agent_id: {_AGENT_ID}\nhook_bead: null\n",
+            ),
+            BUILDER.issue(
+                "at-epic",
+                title="Worker migration epic",
+                issue_type="epic",
+                status="open",
+                labels=("at:epic", "atelier"),
+            ),
+            BUILDER.issue(
+                "at-epic.1",
+                title="Open worker changeset with stale closed PR state",
+                parent="at-epic",
+                status="open",
+                labels=("atelier",),
+                description="pr_state: closed\n",
+            ),
+            _worker_message(
+                "msg-actionable",
+                title="Still block startup on open work",
+                body="A stale closed PR marker should not hide this message.",
+                thread_id="at-epic.1",
+                kind="needs-decision",
+                blocking=True,
+            ),
+        ),
+    )
+
+    inbox = worker_store.list_inbox_messages(
+        _AGENT_ID,
+        beads_root=_BEADS_ROOT,
+        repo_root=_REPO_ROOT,
+    )
+
+    assert tuple(item["id"] for item in inbox) == ("msg-actionable",)
+    worker_store.clear_bundle_cache()
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
 def test_worker_lifecycle_and_finalize_flows_have_dual_backend_parity(
     monkeypatch: pytest.MonkeyPatch,
     backend: str,

--- a/tests/atelier/worker/test_store_adapter.py
+++ b/tests/atelier/worker/test_store_adapter.py
@@ -835,6 +835,36 @@ def test_list_inbox_messages_skips_merged_changeset_threads(monkeypatch) -> None
     worker_store.clear_bundle_cache()
 
 
+def test_list_inbox_messages_keeps_open_changeset_threads_with_closed_pr_state(
+    monkeypatch,
+) -> None:
+    builder = IssueFixtureBuilder()
+    _patch_bundle(
+        monkeypatch,
+        issues=(
+            builder.issue("at-epic", issue_type="epic", labels=("at:epic",), status="open"),
+            builder.issue(
+                "at-epic.1",
+                issue_type="task",
+                parent="at-epic",
+                status="open",
+                description="pr_state: closed\n",
+            ),
+            _worker_message(builder, "at-msg", thread_id="at-epic.1"),
+        ),
+    )
+
+    inbox = worker_store.list_inbox_messages(
+        "atelier/worker/codex/p100",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    assert len(inbox) == 1
+    assert inbox[0]["id"] == "at-msg"
+    worker_store.clear_bundle_cache()
+
+
 def test_list_inbox_messages_skips_closed_epic_threads(monkeypatch) -> None:
     builder = IssueFixtureBuilder()
     _patch_bundle(


### PR DESCRIPTION
# Summary

- Keep unread worker inbox messages visible for open work when the only terminal signal is stale `pr_state: closed` metadata.
- Continue filtering startup inbox blockers for work threads that have durable terminal evidence.

# Changes

- Narrow the startup terminal-thread predicate so it suppresses unread worker messages only for closed work, terminal changeset labels, merged review state, or recorded integration SHA.
- Stop treating standalone `pr_state: closed` as terminal proof during startup inbox filtering.
- Add unit and dual-backend regression coverage for stale closed PR metadata on open changesets while preserving merged-thread suppression.

# Testing

- `pytest tests/atelier/worker/test_store_adapter.py -k 'list_inbox_messages'`
- `pytest tests/atelier/test_worker_store_migration_contract.py -k 'worker_inbox_ignores_terminal_changeset_threads_with_dual_backend_parity or worker_inbox_keeps_open_changesets_with_stale_closed_pr_state_visible'`
- `pytest` via the repository pre-push hook

## Tickets
- None

# Risks / Rollout

- Startup remains fail-closed when thread lookup is ambiguous or terminal proof is missing, so open-work messages continue to surface rather than being hidden by stale PR metadata.

# Notes

- Epic-thread suppression is still status-based.
