### PR TITLE
Route integration proof persistence through AtelierStore

### DIFF
--- a/docs/atelier-store-contract.md
+++ b/docs/atelier-store-contract.md
@@ -180,14 +180,16 @@ This proof slice leaves only the following work deferred:
 
 - planner migrations onto `atelier.store`; that remains deferred to
   [GitHub issue #582]
-- publish/integration migrations onto `atelier.store`; that remains deferred to
+- publish/orchestration migrations onto `atelier.store` beyond the store-backed
+  integration-proof persistence seam; that remains deferred to
   [GitHub issue #584]
 - dependency add/remove parity in the in-memory backend so those mutations can
   graduate from process-backed-only coverage into the shared proof suite
 
 Worker lifecycle migrations now follow the [Worker Store Migration Contract].
-Remaining worker-side deferred work stays on publish/integration orchestration
-plus richer worktree and epic-close store semantics.
+Remaining worker-side deferred work stays on publish/orchestration work above
+the integration-proof persistence seam plus richer worktree and epic-close store
+semantics.
 
 The core store contract, discovery methods, mutation methods, and dual-backend
 proof are no longer deferred work. Downstream epics should build on that landed

--- a/docs/worker-store-migration-contract.md
+++ b/docs/worker-store-migration-contract.md
@@ -16,8 +16,9 @@ Worker code can treat the following paths as store-backed today:
   `release-epic`, and `hook-status`
 - worker inbox and queue reads plus queue claim/read mutations in
   `startup-contract`, `mail-queue-claim`, and `mail-mark-read`
-- lifecycle and review metadata mutations in `changeset_state`, `finalize`,
-  `reconcile`, and `work_finalization_state`
+- lifecycle, review, and integration-proof mutations in `changeset_state`,
+  `finalize`, `integration`, `reconcile`, `work_finalization_state`, and
+  `work_startup_runtime`
 - descendant changeset discovery and lifecycle summaries used for startup
   selection, no-ready notifications, and reconcile corrections
 
@@ -75,7 +76,8 @@ store for worker claim, queue, hook, or changeset lifecycle work.
 
 This worker migration slice leaves the following work deferred:
 
-- publish/integration orchestration migrations onto `atelier.store`
+- publish/orchestration migrations onto `atelier.store` beyond the now
+  store-backed integration-proof persistence seam
 - store-owned worktree and branch metadata mutations for worker session setup
   and teardown
 - a store-owned epic-close/finalize semantic so `work-done` can drop its
@@ -97,7 +99,9 @@ worker-facing entry points over both supported Beads backends:
   `work_startup_runtime` and `store_adapter`
 - epic claim and agent hook set/clear through `store_adapter`
 - threaded queue claim/read and lifecycle notes through `store_adapter`
-- merged/finalize lifecycle persistence through `changeset_state` and `finalize`
+- merged/finalize lifecycle persistence plus integration-proof persistence
+  through `changeset_state`, `finalize`, `integration`, and
+  `work_startup_runtime`
 
 Use this document together with the broader [Atelier Store Contract] when
 planning future worker, publish, or review migrations.

--- a/src/atelier/integration.py
+++ b/src/atelier/integration.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
-from . import beads, git
 from . import exec as exec_util
+from . import git
 from .io import die
+from .worker import store_adapter as worker_store
 
 
 @dataclass(frozen=True)
@@ -70,11 +71,11 @@ def integrate_changeset(
     if result.returncode != 0:
         die("root branch moved; rebase required")
 
-    beads.update_changeset_integrated_sha(
+    worker_store.update_changeset_integrated_sha(
         changeset_id,
         new_head,
         beads_root=beads_root,
-        cwd=repo_root,
+        repo_root=repo_root,
     )
     return IntegrationResult(
         root_branch=root_branch,

--- a/src/atelier/worker/work_startup_runtime.py
+++ b/src/atelier/worker/work_startup_runtime.py
@@ -839,11 +839,11 @@ class _StartupContractService(worker_startup.StartupContractService):
         )
 
     def update_changeset_integrated_sha(self, changeset_id: str, integrated_sha: str) -> None:
-        beads.update_changeset_integrated_sha(
+        worker_store.update_changeset_integrated_sha(
             changeset_id,
             integrated_sha,
             beads_root=self._beads_root,
-            cwd=self._repo_root,
+            repo_root=self._repo_root,
             allow_override=True,
         )
 

--- a/tests/atelier/test_integration.py
+++ b/tests/atelier/test_integration.py
@@ -33,7 +33,7 @@ def test_integrate_changeset_updates_root_with_cas(tmp_path: Path) -> None:
         patch("atelier.integration.exec_util.run_command", side_effect=fake_run),
         patch("atelier.integration.exec_util.try_run_command", side_effect=fake_try_run),
         patch("atelier.integration.git.git_rev_parse", side_effect=fake_rev_parse),
-        patch("atelier.integration.beads.update_changeset_integrated_sha") as update_sha,
+        patch("atelier.integration.worker_store.update_changeset_integrated_sha") as update_sha,
     ):
         result = integration.integrate_changeset(
             changeset_id="epic.1",
@@ -46,7 +46,12 @@ def test_integrate_changeset_updates_root_with_cas(tmp_path: Path) -> None:
 
     assert result.integrated_sha == "newsha"
     assert any("rebase" in cmd for cmd in calls)
-    update_sha.assert_called_once_with("epic.1", "newsha", beads_root=Path("/beads"), cwd=repo_root)
+    update_sha.assert_called_once_with(
+        "epic.1",
+        "newsha",
+        beads_root=Path("/beads"),
+        repo_root=repo_root,
+    )
 
 
 def test_integrate_changeset_raises_on_cas_mismatch(tmp_path: Path) -> None:
@@ -70,7 +75,7 @@ def test_integrate_changeset_raises_on_cas_mismatch(tmp_path: Path) -> None:
         patch("atelier.integration.exec_util.run_command"),
         patch("atelier.integration.exec_util.try_run_command", side_effect=fake_try_run),
         patch("atelier.integration.git.git_rev_parse", side_effect=fake_rev_parse),
-        patch("atelier.integration.beads.update_changeset_integrated_sha") as update_sha,
+        patch("atelier.integration.worker_store.update_changeset_integrated_sha") as update_sha,
     ):
         with pytest.raises(SystemExit):
             integration.integrate_changeset(

--- a/tests/atelier/test_store_contract.py
+++ b/tests/atelier/test_store_contract.py
@@ -292,7 +292,7 @@ def test_store_contract_docs_record_invariants_and_deferred_work() -> None:
     assert "shared dual-backend parity for discovery/read flows" in store_doc
     assert "This proof slice leaves only the following work deferred" in store_doc
     assert "planner migrations onto `atelier.store`" in store_doc
-    assert "publish/integration migrations onto `atelier.store`" in store_doc
+    assert "publish/orchestration migrations onto `atelier.store` beyond the" in store_doc
     assert "[Worker Store Migration Contract]" in store_doc
     assert "The core store contract, discovery methods, mutation methods, and dual-backend" in (
         store_doc

--- a/tests/atelier/test_worker_store_migration_contract.py
+++ b/tests/atelier/test_worker_store_migration_contract.py
@@ -606,7 +606,7 @@ def test_worker_store_migration_docs_publish_boundary_and_deferred_gaps() -> Non
     assert "thread_id=None" in doc
     assert "worktree and branch metadata writes still go through" in doc
     assert "epic-close and lineage-repair fallback reads still use" in doc
-    assert "publish/integration orchestration migrations onto `atelier.store`" in doc
+    assert "publish/orchestration migrations onto `atelier.store` beyond the now" in doc
     assert "`work-done` still closes epics through the deterministic Beads helper" in doc
 
     assert "[Worker Store Migration Contract]" in planner_doc

--- a/tests/atelier/worker/test_work_startup_runtime.py
+++ b/tests/atelier/worker/test_work_startup_runtime.py
@@ -117,3 +117,32 @@ def test_startup_contract_service_lists_work_children_via_store_adapter(monkeypa
     )
 
     assert service.list_work_children("at-epic", include_closed=False) == [expected_child]
+
+
+def test_startup_contract_service_updates_integrated_sha_via_store_adapter(monkeypatch) -> None:
+    def _raise_on_raw_beads(*_args, **_kwargs):
+        raise AssertionError(
+            "raw beads.update_changeset_integrated_sha should not be used during startup"
+        )
+
+    calls: list[tuple[str, str, Path, Path, bool]] = []
+    monkeypatch.setattr(
+        work_startup_runtime.beads,
+        "update_changeset_integrated_sha",
+        _raise_on_raw_beads,
+    )
+    monkeypatch.setattr(
+        worker_store,
+        "update_changeset_integrated_sha",
+        lambda changeset_id, integrated_sha, *, beads_root, repo_root, allow_override=False: (
+            calls.append((changeset_id, integrated_sha, beads_root, repo_root, allow_override))
+        ),
+    )
+
+    service = work_startup_runtime._StartupContractService(  # pyright: ignore[reportPrivateUsage]
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+    service.update_changeset_integrated_sha("at-epic.1", "abc1234")
+
+    assert calls == [("at-epic.1", "abc1234", Path("/beads"), Path("/repo"), True)]


### PR DESCRIPTION
# Summary

- Route the remaining integration-proof persistence paths through the store-backed worker adapter so publish/finalize evidence stays on the AtelierStore seam.

# Changes

- Switch the non-PR integration helper to persist `changeset.integrated_sha` through `worker_store.update_changeset_integrated_sha`.
- Switch startup finalize/reconcile integration-proof persistence to the same store-backed adapter path.
- Add regression tests that fail if either seam falls back to raw Beads writes.
- Update the worker/store migration contract docs to mark integration-proof persistence as store-backed while broader publish orchestration remains deferred.

# Testing

- `just lint`
- `just test`

# Tickets

- None

# Risks / Rollout

- Low risk: the change reuses the existing store-backed adapter and preserves current override/finalize semantics.

# Notes

- This is a stacked draft PR targeting the already-merged review-metadata migration branch.
