### PR TITLE
Migrate external ticket persistence onto AtelierStore

### DIFF
--- a/docs/SPEC-external-ticket-integration.md
+++ b/docs/SPEC-external-ticket-integration.md
@@ -27,6 +27,10 @@ contracts.
 ## Canonical linkage model
 
 `external_tickets` remains a JSON list stored in bead description fields.
+Atelier store operations own persistence of that normalized list and its `ext:*`
+provider labels. Provider adapters own remote import, export, close, and sync
+behavior, then hand normalized metadata back to the store boundary for durable
+persistence.
 
 Recommended per-entry fields:
 

--- a/docs/atelier-store-contract.md
+++ b/docs/atelier-store-contract.md
@@ -15,6 +15,7 @@ Typed models:
 - `EpicIdentityViolation`
 - `ChangesetRecord`
 - `DependencyRecord`
+- `ExternalTicketLink`
 - `MessageRecord`
 - `HookRecord`
 - `ReviewMetadata`
@@ -35,6 +36,7 @@ Typed request/query models:
 - `MarkMessageReadRequest`
 - `SetHookRequest`
 - `ClearHookRequest`
+- `UpdateExternalTicketsRequest`
 - `UpdateReviewRequest`
 - `LifecycleTransitionRequest`
 
@@ -76,6 +78,11 @@ implementation is backed by Beads:
   lifecycle values `pushed|draft-pr|pr-open|in-review|approved|merged|closed`.
 - Changesets may carry branch metadata plus review and integration metadata
   without exposing how the backend persists those fields.
+- External ticket metadata is a store-owned persistence concern. Provider
+  adapters own remote import/export/sync behavior, while `AtelierStore` owns the
+  normalized persisted link shape, provider labels, and drift timestamps
+  (`state_updated_at`, `content_updated_at`, `notes_updated_at`,
+  `last_synced_at`).
 - Dependency satisfaction is an Atelier decision. Adapters may persist raw
   dependency edges, but whether a dependency counts as satisfied is owned by
   Atelier lifecycle policy.
@@ -115,10 +122,11 @@ The store contract is now proven against both supported `Beads` backends:
 
 The shared proof runs the same `AtelierStore` read and mutation flows over both
 backends. Representative read coverage includes epic discovery, changeset
-listing and ready discovery, message listing, hook lookup, branch metadata, and
-review/dependency state decoding. Representative mutation coverage includes epic
-and changeset authoring, review updates, note appends, lifecycle transitions,
-message create/claim/read, and agent hook set/clear.
+listing and ready discovery, message listing, hook lookup, branch metadata,
+review/dependency state decoding, and external ticket metadata reads.
+Representative mutation coverage includes epic and changeset authoring, review
+updates, external ticket metadata replacement, note appends, lifecycle
+transitions, message create/claim/read, and agent hook set/clear.
 
 This proof freezes one architecture shape: a single Atelier-owned store boundary
 implemented on top of multiple `Beads` backends. Future backend additions must
@@ -134,14 +142,15 @@ Downstream epics can rely on the following store surface today:
 
 - `AtelierStore`
 - `EpicRecord`, `ChangesetRecord`, `MessageRecord`, `HookRecord`
-- `ReviewMetadata`, `DependencyRecord`, `LifecycleTransition`
+- `ReviewMetadata`, `ExternalTicketLink`, `DependencyRecord`,
+  `LifecycleTransition`
 - the request/query models in `atelier.store.contract`, including
   `CreateEpicRequest`, `CreateChangesetRequest`, `AppendNotesRequest`,
-  `UpdateReviewRequest`, `LifecycleTransitionRequest`, `CreateMessageRequest`,
-  `ClaimMessageRequest`, `MarkMessageReadRequest`, `SetHookRequest`, and
-  `ClearHookRequest`
+  `UpdateReviewRequest`, `UpdateExternalTicketsRequest`,
+  `LifecycleTransitionRequest`, `CreateMessageRequest`, `ClaimMessageRequest`,
+  `MarkMessageReadRequest`, `SetHookRequest`, and `ClearHookRequest`
 - shared dual-backend parity for discovery/read flows plus notes, review,
-  lifecycle, authoring, message, and hook mutations
+  external-ticket metadata, lifecycle, authoring, message, and hook mutations
 
 Downstream code should not:
 
@@ -152,8 +161,8 @@ Downstream code should not:
   capability probing from planner/worker/publish policy modules
 
 Direct `atelier.lib.beads` usage remains appropriate only in boundary adapters
-that own transport, startup diagnostics, or other Beads-client-specific
-concerns.
+that own transport, startup diagnostics, provider API calls, or other
+Beads-client-specific concerns.
 
 Downstream migrations should treat the following as still deferred:
 

--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -4939,33 +4939,33 @@ def update_external_tickets(
     beads_root: Path,
     cwd: Path,
 ) -> dict[str, object]:
-    """Update external ticket references and labels on a bead."""
-    with _issue_write_lock(issue_id, beads_root=beads_root):
-        issues = run_bd_json(["show", issue_id], beads_root=beads_root, cwd=cwd)
-        if not issues:
-            die(f"issue not found: {issue_id}")
-        issue = issues[0]
-        payload = [external_ticket_payload(ticket) for ticket in tickets]
-        serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
-        desired_labels = {external_label(ticket.provider) for ticket in tickets}
-        labels = sorted(_issue_labels(issue))
-        remove_labels = [
-            label for label in labels if label.startswith("ext:") and label not in desired_labels
-        ]
-        add_labels = [label for label in desired_labels if label not in labels]
-        if add_labels or remove_labels:
-            args = ["update", issue_id]
-            for label in add_labels:
-                args.extend(["--add-label", label])
-            for label in remove_labels:
-                args.extend(["--remove-label", label])
-            run_bd_command(args, beads_root=beads_root, cwd=cwd)
-        return _update_description_fields_optimistic(
-            issue_id,
-            fields={EXTERNAL_TICKETS_KEY: serialized},
-            beads_root=beads_root,
-            cwd=cwd,
+    """Update external ticket references through the Atelier store contract."""
+
+    from .lib.beads import SubprocessBeadsClient
+    from .store import (
+        ExternalTicketLink,
+        UpdateExternalTicketsRequest,
+        build_atelier_store,
+    )
+
+    client = SubprocessBeadsClient(
+        cwd=cwd,
+        beads_root=beads_root,
+        env={"BEADS_DIR": str(beads_root)},
+    )
+    store = build_atelier_store(beads=client)
+    asyncio.run(
+        store.update_external_tickets(
+            UpdateExternalTicketsRequest(
+                issue_id=issue_id,
+                tickets=tuple(ExternalTicketLink.from_external_ref(ticket) for ticket in tickets),
+            )
         )
+    )
+    issues = run_bd_json(["show", issue_id], beads_root=beads_root, cwd=cwd)
+    if not issues:
+        die(f"issue not found: {issue_id}")
+    return issues[0]
 
 
 def clear_agent_hook(

--- a/src/atelier/store/__init__.py
+++ b/src/atelier/store/__init__.py
@@ -18,6 +18,7 @@ from .contract import (
     ReadyChangesetQuery,
     SetAgentBeadHookRequest,
     SetHookRequest,
+    UpdateExternalTicketsRequest,
     UpdateReviewRequest,
 )
 from .models import (
@@ -27,6 +28,7 @@ from .models import (
     EpicDiscoveryParity,
     EpicIdentityViolation,
     EpicRecord,
+    ExternalTicketLink,
     HookRecord,
     LifecycleStatus,
     LifecycleTransition,
@@ -58,6 +60,7 @@ __all__ = [
     "EpicIdentityViolation",
     "EpicQuery",
     "EpicRecord",
+    "ExternalTicketLink",
     "HookRecord",
     "LifecycleStatus",
     "LifecycleTransition",
@@ -73,6 +76,7 @@ __all__ = [
     "SetAgentBeadHookRequest",
     "SetHookRequest",
     "StartupMessageRecord",
+    "UpdateExternalTicketsRequest",
     "UpdateReviewRequest",
     "WorkItemKind",
     "WorkRef",

--- a/src/atelier/store/beads_store.py
+++ b/src/atelier/store/beads_store.py
@@ -42,6 +42,7 @@ from .contract import (
     ReadyChangesetQuery,
     SetAgentBeadHookRequest,
     SetHookRequest,
+    UpdateExternalTicketsRequest,
     UpdateReviewRequest,
 )
 from .models import (
@@ -51,6 +52,7 @@ from .models import (
     EpicDiscoveryParity,
     EpicIdentityViolation,
     EpicRecord,
+    ExternalTicketLink,
     HookRecord,
     LifecycleStatus,
     LifecycleTransition,
@@ -172,6 +174,19 @@ def _review_metadata(issue: IssueRecord) -> ReviewMetadata:
         review_owner=review.review_owner,
         integrated_sha=_clean_text(fields.get("changeset.integrated_sha")),
     )
+
+
+def _external_ticket_links(issue: IssueRecord) -> tuple[ExternalTicketLink, ...]:
+    tickets = beads_metadata.parse_external_tickets(issue.description or "")
+    return tuple(ExternalTicketLink.from_external_ref(ticket) for ticket in tickets)
+
+
+def _external_ticket_labels(tickets: tuple[ExternalTicketLink, ...]) -> set[str]:
+    return {f"ext:{ticket.provider}" for ticket in tickets}
+
+
+def _issue_external_ticket_labels(issue: IssueRecord) -> set[str]:
+    return {label for label in _normalized_labels(issue.labels) if label.startswith("ext:")}
 
 
 def _changeset_branches(issue: IssueRecord) -> ChangesetBranches | None:
@@ -448,6 +463,12 @@ class AtelierStore:
         if not (await self._role(issue, state=state)).is_changeset:
             raise LookupError(f"changeset not found: {changeset_id}")
         return await self._changeset_record(issue, state=state)
+
+    async def get_external_tickets(self, issue_id: str) -> tuple[ExternalTicketLink, ...]:
+        """Return persisted external ticket metadata for one issue."""
+
+        issue = await self._show_issue(issue_id)
+        return _external_ticket_links(issue)
 
     async def list_changesets(
         self,
@@ -1062,6 +1083,61 @@ class AtelierStore:
         )
         updated_state = _ReadState(self, issue_cache={updated.id: updated})
         return await self._changeset_record(updated, state=updated_state)
+
+    async def update_external_tickets(
+        self,
+        request: UpdateExternalTicketsRequest,
+    ) -> tuple[ExternalTicketLink, ...]:
+        """Replace persisted external ticket metadata for one issue."""
+
+        issue = await self._show_issue(request.issue_id)
+        desired_tickets = request.tickets
+        desired_labels = _external_ticket_labels(desired_tickets)
+        if (
+            _external_ticket_links(issue) == desired_tickets
+            and _issue_external_ticket_labels(issue) == desired_labels
+        ):
+            return desired_tickets
+
+        payload = [
+            beads_metadata.external_ticket_payload(ticket.to_external_ref())
+            for ticket in desired_tickets
+        ]
+        serialized = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+
+        def build_request(current: IssueRecord) -> UpdateIssueRequest:
+            current_labels = _normalized_labels(current.labels)
+            description = _apply_description_fields(
+                current.description or "",
+                fields={"external_tickets": serialized},
+            )
+            labels = tuple(
+                sorted(
+                    {label for label in current_labels if not label.startswith("ext:")}
+                    | desired_labels
+                )
+            )
+            return UpdateIssueRequest(
+                issue_id=current.id,
+                description=description,
+                labels=labels,
+            )
+
+        def verify(updated_issue: IssueRecord) -> bool:
+            return (
+                _external_ticket_links(updated_issue) == desired_tickets
+                and _issue_external_ticket_labels(updated_issue) == desired_labels
+            )
+
+        updated = await self._update_issue_until_verified(
+            request.issue_id,
+            build_request=build_request,
+            verify=verify,
+            failure_message=(
+                f"external ticket metadata update could not be verified for {request.issue_id}"
+            ),
+        )
+        return _external_ticket_links(updated)
 
     async def append_notes(
         self,

--- a/src/atelier/store/contract.py
+++ b/src/atelier/store/contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pydantic import field_validator, model_validator
 
 from .models import (
+    ExternalTicketLink,
     Identifier,
     LifecycleStatus,
     MessageDelivery,
@@ -229,6 +230,29 @@ class UpdateReviewRequest(StoreModel):
     preserve_existing: bool = False
 
 
+class UpdateExternalTicketsRequest(StoreModel):
+    """Mutation request for replacing persisted external ticket metadata."""
+
+    issue_id: Identifier
+    tickets: tuple[ExternalTicketLink, ...]
+
+    @field_validator("tickets")
+    @classmethod
+    def _dedupe_tickets(
+        cls,
+        value: tuple[ExternalTicketLink, ...],
+    ) -> tuple[ExternalTicketLink, ...]:
+        normalized: list[ExternalTicketLink] = []
+        seen: set[tuple[str, str]] = set()
+        for ticket in value:
+            key = (ticket.provider, ticket.ticket_id)
+            if key in seen:
+                continue
+            seen.add(key)
+            normalized.append(ticket)
+        return tuple(normalized)
+
+
 class LifecycleTransitionRequest(StoreModel):
     """Mutation request for canonical lifecycle changes."""
 
@@ -255,5 +279,6 @@ __all__ = [
     "ReadyChangesetQuery",
     "SetAgentBeadHookRequest",
     "SetHookRequest",
+    "UpdateExternalTicketsRequest",
     "UpdateReviewRequest",
 ]

--- a/src/atelier/store/models.py
+++ b/src/atelier/store/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Annotated, Literal
+from typing import Annotated, Literal, cast
 
 from pydantic import (
     BaseModel,
@@ -12,6 +12,19 @@ from pydantic import (
     StringConstraints,
     field_validator,
     model_validator,
+)
+
+from ..external_tickets import (
+    ExternalTicketRef,
+    normalize_direction,
+    normalize_identifier,
+    normalize_on_close,
+    normalize_optional_string,
+    normalize_relation,
+    normalize_slug,
+    normalize_state,
+    normalize_sync_mode,
+    normalize_timestamp,
 )
 
 Identifier = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1, strict=True)]
@@ -96,6 +109,152 @@ class ReviewMetadata(StoreModel):
     pr_state: ReviewState | None = None
     review_owner: Identifier | None = None
     integrated_sha: Identifier | None = None
+
+
+class ExternalTicketLink(StoreModel):
+    """Store-owned persisted metadata for one external ticket link."""
+
+    provider: Identifier
+    ticket_id: Identifier
+    url: str | None = None
+    title: str | None = None
+    summary: str | None = None
+    body: str | None = None
+    notes: str | None = None
+    relation: Literal["primary", "secondary", "context", "derived"] | None = None
+    direction: Literal["imported", "exported", "linked"] | None = None
+    sync_mode: Literal["manual", "import", "export", "sync"] | None = None
+    state: Literal["open", "in_progress", "blocked", "in_review", "closed", "unknown"] | None = None
+    raw_state: str | None = None
+    state_updated_at: str | None = None
+    parent_id: Identifier | None = None
+    on_close: Literal["none", "comment", "close", "sync"] | None = None
+    content_updated_at: str | None = None
+    notes_updated_at: str | None = None
+    last_synced_at: str | None = None
+
+    @field_validator("provider", mode="before")
+    @classmethod
+    def _normalize_provider(cls, value: object) -> object:
+        return normalize_slug(value)
+
+    @field_validator("ticket_id", "parent_id", mode="before")
+    @classmethod
+    def _normalize_identifiers(cls, value: object) -> object:
+        return normalize_identifier(value)
+
+    @field_validator(
+        "url",
+        "title",
+        "summary",
+        "body",
+        "notes",
+        "raw_state",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_optional_strings(cls, value: object) -> object:
+        return normalize_optional_string(value)
+
+    @field_validator("relation", mode="before")
+    @classmethod
+    def _normalize_relation(cls, value: object) -> object:
+        return normalize_relation(value)
+
+    @field_validator("direction", mode="before")
+    @classmethod
+    def _normalize_direction(cls, value: object) -> object:
+        return normalize_direction(value)
+
+    @field_validator("sync_mode", mode="before")
+    @classmethod
+    def _normalize_sync_mode(cls, value: object) -> object:
+        return normalize_sync_mode(value)
+
+    @field_validator("state", mode="before")
+    @classmethod
+    def _normalize_state(cls, value: object) -> object:
+        return normalize_state(value)
+
+    @field_validator("on_close", mode="before")
+    @classmethod
+    def _normalize_on_close(cls, value: object) -> object:
+        return normalize_on_close(value)
+
+    @field_validator(
+        "state_updated_at",
+        "content_updated_at",
+        "notes_updated_at",
+        "last_synced_at",
+        mode="before",
+    )
+    @classmethod
+    def _normalize_timestamps(cls, value: object) -> object:
+        return normalize_timestamp(value)
+
+    @classmethod
+    def from_external_ref(cls, ref: ExternalTicketRef) -> "ExternalTicketLink":
+        """Build a store model from one compatibility-layer ticket reference."""
+
+        return cls(
+            provider=ref.provider,
+            ticket_id=ref.ticket_id,
+            url=ref.url,
+            title=ref.title,
+            summary=ref.summary,
+            body=ref.body,
+            notes=ref.notes,
+            relation=cast(
+                Literal["primary", "secondary", "context", "derived"] | None,
+                ref.relation,
+            ),
+            direction=cast(
+                Literal["imported", "exported", "linked"] | None,
+                ref.direction,
+            ),
+            sync_mode=cast(
+                Literal["manual", "import", "export", "sync"] | None,
+                ref.sync_mode,
+            ),
+            state=cast(
+                Literal["open", "in_progress", "blocked", "in_review", "closed", "unknown"] | None,
+                ref.state,
+            ),
+            raw_state=ref.raw_state,
+            state_updated_at=ref.state_updated_at,
+            parent_id=ref.parent_id,
+            on_close=cast(
+                Literal["none", "comment", "close", "sync"] | None,
+                ref.on_close,
+            ),
+            content_updated_at=ref.content_updated_at,
+            notes_updated_at=ref.notes_updated_at,
+            last_synced_at=ref.last_synced_at,
+        )
+
+    def to_external_ref(self) -> ExternalTicketRef:
+        """Project the store model into the compatibility ticket shape."""
+
+        return ExternalTicketRef(
+            provider=self.provider,
+            ticket_id=self.ticket_id,
+            url=self.url,
+            title=self.title,
+            summary=self.summary,
+            body=self.body,
+            notes=self.notes,
+            relation=self.relation,
+            direction=self.direction,
+            sync_mode=self.sync_mode,
+            state=self.state,
+            raw_state=self.raw_state,
+            state_updated_at=self.state_updated_at,
+            parent_id=self.parent_id,
+            on_close=self.on_close,
+            content_updated_at=self.content_updated_at,
+            notes_updated_at=self.notes_updated_at,
+            last_synced_at=self.last_synced_at,
+        )
 
 
 class ChangesetBranches(StoreModel):
@@ -254,6 +413,7 @@ __all__ = [
     "EpicDiscoveryParity",
     "EpicIdentityViolation",
     "EpicRecord",
+    "ExternalTicketLink",
     "HookRecord",
     "Identifier",
     "LifecycleStatus",

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -6090,40 +6090,29 @@ def test_parse_external_tickets_reads_json() -> None:
 
 
 def test_update_external_tickets_updates_labels() -> None:
-    state = {"description": "scope: demo\n"}
-    issue = {"id": "issue-1", "description": state["description"], "labels": ["ext:github"]}
-    captured: dict[str, object] = {"commands": []}
+    captured: dict[str, object] = {}
 
-    def fake_json(args: list[str], *, beads_root: Path, cwd: Path) -> list[dict[str, object]]:
-        return [{**issue, "description": state["description"]}]
-
-    def fake_command(args: list[str], *, beads_root: Path, cwd: Path) -> None:
-        captured["commands"].append(args)
-
-    def fake_update(issue_id: str, description: str, *, beads_root: Path, cwd: Path) -> None:
-        captured["description"] = description
-        state["description"] = description
+    class FakeStore:
+        async def update_external_tickets(self, request) -> None:
+            captured["request"] = request
 
     with (
-        patch("atelier.beads.run_bd_json", side_effect=fake_json),
-        patch("atelier.beads.run_bd_command", side_effect=fake_command),
-        patch("atelier.beads._update_issue_description", side_effect=fake_update),
+        patch("atelier.store.build_atelier_store", return_value=FakeStore()),
+        patch("atelier.beads.run_bd_json", return_value=[{"id": "issue-1"}]),
     ):
-        beads.update_external_tickets(
+        result = beads.update_external_tickets(
             "issue-1",
             [beads.ExternalTicketRef(provider="jira", ticket_id="J-1")],
             beads_root=Path("/beads"),
             cwd=Path("/repo"),
         )
 
-    assert "external_tickets:" in str(captured.get("description", ""))
-    update_calls = [cmd for cmd in captured["commands"] if cmd and cmd[0] == "update"]
-    assert update_calls
-    combined = " ".join(update_calls[0])
-    assert "--add-label" in combined
-    assert "ext:jira" in combined
-    assert "--remove-label" in combined
-    assert "ext:github" in combined
+    request = captured["request"]
+    assert request.issue_id == "issue-1"
+    assert len(request.tickets) == 1
+    assert request.tickets[0].provider == "jira"
+    assert request.tickets[0].ticket_id == "J-1"
+    assert result == {"id": "issue-1"}
 
 
 def test_reconcile_closed_issue_exported_github_tickets_closes_and_updates() -> None:

--- a/tests/atelier/test_store_contract.py
+++ b/tests/atelier/test_store_contract.py
@@ -36,6 +36,7 @@ from atelier.store import (
     DependencyRecord,
     EpicQuery,
     EpicRecord,
+    ExternalTicketLink,
     HookRecord,
     LifecycleStatus,
     LifecycleTransitionRequest,
@@ -49,6 +50,7 @@ from atelier.store import (
     SetAgentBeadHookRequest,
     SetHookRequest,
     StartupMessageRecord,
+    UpdateExternalTicketsRequest,
     UpdateReviewRequest,
     WorkItemKind,
     WorkRef,
@@ -93,6 +95,8 @@ _STORE_METHOD_NAMES = (
     "set_agent_hook",
     "clear_agent_bead_hook",
     "clear_agent_hook",
+    "get_external_tickets",
+    "update_external_tickets",
     "update_review",
     "transition_lifecycle",
 )
@@ -140,6 +144,30 @@ def test_changeset_record_captures_store_owned_metadata() -> None:
     assert record.review.pr_number == 17
     assert record.review.pr_state is ReviewState.IN_REVIEW
     assert record.branches and record.branches.work_branch == "root/store-at-123"
+
+
+def test_external_ticket_link_normalizes_drift_metadata() -> None:
+    ticket = ExternalTicketLink(
+        provider=" GitHub ",
+        ticket_id=" 123 ",
+        relation="Primary",
+        direction="export",
+        sync_mode="two_way",
+        state="In Progress",
+        on_close="Close",
+        state_updated_at="2026-02-08T10:00:00Z",
+        content_updated_at="2026-02-08T10:05:00Z",
+        notes_updated_at="2026-02-08T10:06:00Z",
+        last_synced_at="2026-02-08T10:07:00Z",
+    )
+
+    assert ticket.provider == "github"
+    assert ticket.ticket_id == "123"
+    assert ticket.relation == "primary"
+    assert ticket.direction == "exported"
+    assert ticket.sync_mode == "sync"
+    assert ticket.state == "in_progress"
+    assert ticket.on_close == "close"
 
 
 def test_work_threaded_messages_require_thread_identity() -> None:
@@ -283,6 +311,8 @@ def test_store_contract_docs_record_invariants_and_deferred_work() -> None:
     assert "compatibility projections" in store_doc
     assert "implement `AtelierStore` itself" in store_doc
     assert "`atelier.lib.beads.Beads` remains the swappable boundary" in store_doc
+    assert "External ticket metadata is a store-owned persistence concern" in store_doc
+    assert "remote import/export/sync behavior" in store_doc
     assert "Dual-Backend Proof" in store_doc
     assert "Downstream Migration Contract" in store_doc
     assert "Known Contract Gaps" in store_doc
@@ -552,6 +582,26 @@ def _mutation_snapshot(backend: str) -> dict[str, object]:
             )
         )
     )
+    external_tickets = _RUN(
+        store.update_external_tickets(
+            UpdateExternalTicketsRequest(
+                issue_id="at-change",
+                tickets=(
+                    ExternalTicketLink(
+                        provider="github",
+                        ticket_id="77",
+                        relation="derived",
+                        direction="exported",
+                        sync_mode="export",
+                        state="open",
+                        state_updated_at="2026-03-15T23:02:27Z",
+                        content_updated_at="2026-03-15T23:02:27Z",
+                        last_synced_at="2026-03-15T23:02:27Z",
+                    ),
+                ),
+            )
+        )
+    )
     appended = _RUN(
         store.append_notes(
             AppendNotesRequest(
@@ -631,6 +681,7 @@ def _mutation_snapshot(backend: str) -> dict[str, object]:
             "raw_acceptance": created_changeset_issue.acceptance_criteria,
         },
         "review": review.review.model_dump(mode="json"),
+        "external_tickets": tuple(ticket.model_dump(mode="json") for ticket in external_tickets),
         "transition": transition.model_dump(mode="json"),
         "created_message": {
             "thread_id": created_message.thread_id,
@@ -844,6 +895,28 @@ def test_store_dual_backend_mutation_snapshot_matches_expected_contract(backend:
             "review_owner": "reviewer-b",
             "integrated_sha": "abc1234",
         },
+        "external_tickets": (
+            {
+                "provider": "github",
+                "ticket_id": "77",
+                "url": None,
+                "title": None,
+                "summary": None,
+                "body": None,
+                "notes": None,
+                "relation": "derived",
+                "direction": "exported",
+                "sync_mode": "export",
+                "state": "open",
+                "raw_state": None,
+                "state_updated_at": "2026-03-15T23:02:27Z",
+                "parent_id": None,
+                "on_close": None,
+                "content_updated_at": "2026-03-15T23:02:27Z",
+                "notes_updated_at": None,
+                "last_synced_at": "2026-03-15T23:02:27Z",
+            },
+        ),
         "transition": {
             "issue_id": "at-change",
             "issue_kind": "changeset",
@@ -1042,6 +1115,45 @@ def test_beads_store_mutation_paths(operation: str) -> None:
             ClearHookRequest(agent_id="atelier/worker/agent", expected_epic_id="at-epic")
         )
     ) == HookRecord(agent_id="atelier/worker/agent", epic_id="at-epic")
+
+    external_tickets = _RUN(
+        store.update_external_tickets(
+            UpdateExternalTicketsRequest(
+                issue_id="at-change",
+                tickets=(
+                    ExternalTicketLink(
+                        provider="github",
+                        ticket_id="77",
+                        relation="derived",
+                        direction="exported",
+                        sync_mode="export",
+                        state="open",
+                        state_updated_at="2026-03-15T23:02:27Z",
+                        content_updated_at="2026-03-15T23:02:27Z",
+                        last_synced_at="2026-03-15T23:02:27Z",
+                    ),
+                ),
+            )
+        )
+    )
+    assert external_tickets == (
+        ExternalTicketLink(
+            provider="github",
+            ticket_id="77",
+            relation="derived",
+            direction="exported",
+            sync_mode="export",
+            state="open",
+            state_updated_at="2026-03-15T23:02:27Z",
+            content_updated_at="2026-03-15T23:02:27Z",
+            last_synced_at="2026-03-15T23:02:27Z",
+        ),
+    )
+    assert _RUN(store.get_external_tickets("at-change")) == external_tickets
+    external_issue = _RUN(store._show_issue("at-change"))
+    assert "ext:github" in external_issue.labels
+    assert external_issue.description is not None
+    assert '"direction":"exported"' in external_issue.description
 
     probe = {
         ("bd", "--version"): _ok("bd", "--version", stdout="bd version 0.56.1 (dev)"),


### PR DESCRIPTION
# Summary

- Migrate external ticket metadata persistence onto `AtelierStore` while keeping provider-owned remote sync behavior outside the store boundary.

# Changes

- Add `ExternalTicketLink` and `UpdateExternalTicketsRequest` to the public `atelier.store` contract, plus verified external-ticket read/write operations on `AtelierStore`.
- Route the legacy `atelier.beads.update_external_tickets` helper through the store contract so auto-export and reconciliation flows persist metadata without direct Beads-shaped writes.
- Document the provider/store ownership boundary and extend regression coverage for dual-backend external ticket persistence, drift timestamps, and the compatibility wrapper.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #685

# Risks / Rollout

- This changes the persistence path for `external_tickets` metadata and `ext:*` label updates, but existing callers still enter through the legacy helper and the store write path is verified across both supported backends.

# Notes

- Provider adapters still own remote import/export/close/sync behavior; this PR only moves local persistence of normalized external ticket metadata.
