### PR TITLE
Define selected-scope worktree fast-path validation

### DIFF
--- a/src/atelier/worker/session/worktree_fast_path.py
+++ b/src/atelier/worker/session/worktree_fast_path.py
@@ -58,12 +58,6 @@ class SelectedScopeValidation:
         return self.outcome is SelectedScopeValidationOutcome.SAFE_REUSE
 
 
-@dataclass(frozen=True)
-class _MappingCandidateScan:
-    candidates: tuple[worktrees.WorktreeMapping, ...]
-    selected_mapping_invalid: bool
-
-
 def _normalize_text(value: object) -> str | None:
     if not isinstance(value, str):
         return None
@@ -91,39 +85,6 @@ def _default_selected_worktree_path(
     if changeset_id == epic_id:
         return worktrees.worktree_dir(project_data_dir, epic_id)
     return project_data_dir / worktrees.changeset_worktree_relpath(changeset_id)
-
-
-def _scan_mapping_candidates(
-    project_data_dir: Path,
-    *,
-    epic_id: str,
-    changeset_id: str,
-) -> _MappingCandidateScan:
-    meta_dir = worktrees.worktrees_root(project_data_dir) / worktrees.METADATA_DIRNAME
-    selected_mapping_path = worktrees.mapping_path(project_data_dir, epic_id)
-    selected_mapping_invalid = selected_mapping_path.exists() and (
-        worktrees.load_mapping(selected_mapping_path) is None
-    )
-    if not meta_dir.exists():
-        return _MappingCandidateScan(
-            candidates=(), selected_mapping_invalid=selected_mapping_invalid
-        )
-
-    candidates: list[worktrees.WorktreeMapping] = []
-    for candidate_path in sorted(meta_dir.glob("*.json")):
-        mapping = worktrees.load_mapping(candidate_path)
-        if mapping is None:
-            continue
-        if mapping.epic_id == epic_id:
-            candidates.append(mapping)
-            continue
-        if changeset_id in mapping.changesets or changeset_id in mapping.changeset_worktrees:
-            candidates.append(mapping)
-
-    return _MappingCandidateScan(
-        candidates=tuple(candidates),
-        selected_mapping_invalid=selected_mapping_invalid,
-    )
 
 
 def _validate_selected_issue(
@@ -162,10 +123,10 @@ def validate_selected_scope(*, context: SelectedScopeValidationContext) -> Selec
     """Classify selected-scope local state for fast-path worktree preparation.
 
     The validator is intentionally read-only. It inspects the selected
-    changeset's bead metadata, mapping ownership, mapped worktree path, and the
-    currently checked out branch to decide whether the worker can reuse the
-    selected scope directly, should create missing local state, needs fallback
-    repair, or must fail closed due to ambiguity.
+    changeset's bead metadata, the selected epic mapping, the mapped worktree
+    path, and the currently checked out branch to decide whether the worker can
+    reuse the selected scope directly, should create missing local state, needs
+    fallback repair, or must fail closed due to ambiguity.
 
     Args:
         context: Selected-scope inputs for the validation check.
@@ -229,12 +190,9 @@ def validate_selected_scope(*, context: SelectedScopeValidationContext) -> Selec
 
     metadata_root = _normalize_text(changeset_fields.root_branch(issue or {}))
     metadata_work = _normalize_text(changeset_fields.work_branch(issue or {}))
-    scan = _scan_mapping_candidates(
-        context.project_data_dir,
-        epic_id=selected_epic,
-        changeset_id=changeset_id,
-    )
-    if scan.selected_mapping_invalid:
+    selected_mapping_path = worktrees.mapping_path(context.project_data_dir, selected_epic)
+    mapping = worktrees.load_mapping(selected_mapping_path)
+    if selected_mapping_path.exists() and mapping is None:
         return SelectedScopeValidation(
             outcome=SelectedScopeValidationOutcome.AMBIGUOUS,
             mapping_epic_id=None,
@@ -250,26 +208,23 @@ def validate_selected_scope(*, context: SelectedScopeValidationContext) -> Selec
             ),
         )
 
-    if len(scan.candidates) > 1:
-        candidate_epics = ",".join(mapping.epic_id for mapping in scan.candidates)
+    if mapping is not None and mapping.epic_id != selected_epic:
         return SelectedScopeValidation(
             outcome=SelectedScopeValidationOutcome.AMBIGUOUS,
-            mapping_epic_id=None,
+            mapping_epic_id=mapping.epic_id,
             worktree_path=default_worktree_path,
             expected_work_branch=expected_work_branch,
             checked_out_branch=None,
             signals=(
                 _signal(
-                    "selected-scope-mapping-ambiguous",
-                    "multiple mappings claim the selected scope",
+                    "selected-scope-mapping-epic-mismatch",
+                    "selected epic mapping file points at a different epic",
                     selected_epic=selected_epic,
-                    changeset_id=changeset_id,
-                    candidate_epics=candidate_epics,
+                    mapping_epic_id=mapping.epic_id,
                 ),
             ),
         )
 
-    mapping = scan.candidates[0] if scan.candidates else None
     if mapping is None:
         if metadata_root is not None or metadata_work is not None:
             return SelectedScopeValidation(
@@ -331,24 +286,6 @@ def validate_selected_scope(*, context: SelectedScopeValidationContext) -> Selec
                     "no selected-scope mapping or worktree exists yet",
                     selected_epic=selected_epic,
                     changeset_id=changeset_id,
-                ),
-            ),
-        )
-
-    if mapping.epic_id != selected_epic:
-        return SelectedScopeValidation(
-            outcome=SelectedScopeValidationOutcome.REQUIRES_FALLBACK_REPAIR,
-            mapping_epic_id=mapping.epic_id,
-            worktree_path=default_worktree_path,
-            expected_work_branch=expected_work_branch,
-            checked_out_branch=None,
-            signals=(
-                _signal(
-                    "selected-scope-mapping-owned-by-other-epic",
-                    "selected changeset is still owned by a legacy mapping",
-                    selected_epic=selected_epic,
-                    changeset_id=changeset_id,
-                    mapping_epic_id=mapping.epic_id,
                 ),
             ),
         )

--- a/tests/atelier/worker/test_session_worktree_fast_path.py
+++ b/tests/atelier/worker/test_session_worktree_fast_path.py
@@ -138,20 +138,19 @@ def test_validate_selected_scope_requires_fallback_when_mapped_worktree_is_missi
     assert result.signals[0].code == "selected-scope-mapped-worktree-missing"
 
 
-def test_validate_selected_scope_reports_ambiguous_when_multiple_mappings_claim_changeset(
+def test_validate_selected_scope_reports_ambiguous_when_selected_mapping_points_at_other_epic(
     tmp_path: Path,
 ) -> None:
-    for epic_id in ("at-epic", "at-shadow"):
-        worktrees.write_mapping(
-            worktrees.mapping_path(tmp_path, epic_id),
-            worktrees.WorktreeMapping(
-                epic_id=epic_id,
-                worktree_path=f"worktrees/{epic_id}",
-                root_branch="feat/root",
-                changesets={"at-epic.1": f"feat/root-{epic_id}"},
-                changeset_worktrees={"at-epic.1": f"worktrees/{epic_id}.1"},
-            ),
-        )
+    worktrees.write_mapping(
+        worktrees.mapping_path(tmp_path, "at-epic"),
+        worktrees.WorktreeMapping(
+            epic_id="at-shadow",
+            worktree_path="worktrees/at-shadow",
+            root_branch="feat/root",
+            changesets={"at-epic.1": "feat/root-at-shadow"},
+            changeset_worktrees={"at-epic.1": "worktrees/at-shadow.1"},
+        ),
+    )
 
     with patch(
         "atelier.worker.session.worktree_fast_path.beads.run_bd_json",
@@ -160,5 +159,5 @@ def test_validate_selected_scope_reports_ambiguous_when_multiple_mappings_claim_
         result = worktree_fast_path.validate_selected_scope(context=_context(tmp_path))
 
     assert result.outcome is worktree_fast_path.SelectedScopeValidationOutcome.AMBIGUOUS
-    assert result.mapping_epic_id is None
-    assert result.signals[0].code == "selected-scope-mapping-ambiguous"
+    assert result.mapping_epic_id == "at-shadow"
+    assert result.signals[0].code == "selected-scope-mapping-epic-mismatch"


### PR DESCRIPTION
# Summary

- Define an explicit selected-scope validation contract for worker worktree fast-path reuse.

# Changes

- Add a read-only selected-scope validator that classifies local state as safe reuse, local creation, fallback repair, or ambiguity.
- Keep the validator scoped to the selected epic mapping file, selected changeset metadata, and the expected selected worktree path instead of scanning project-wide mapping ownership.
- Add focused regression coverage for reusable, local-create, fallback-repair, and selected-scope ambiguity states.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets
- None

# Risks / Rollout

- This change only defines the validation contract and tests; later changes will route startup control flow through these outcomes.

# Notes

- The validator is intentionally read-only so follow-on work can adopt it without broadening this changeset into reconciliation orchestration.
