### PR TITLE
Route worktree preparation through selected-scope validation

### DIFF
--- a/src/atelier/worker/session/worktree.py
+++ b/src/atelier/worker/session/worktree.py
@@ -814,8 +814,12 @@ def _prepare_selected_scope_fast_path(
             )
             changeset_worktree_path = epic_worktree_path
         else:
-            epic_worktree_path = _resolve_worktree_path(
-                context.project_data_dir, mapping.worktree_path
+            epic_worktree_path = worktrees.ensure_git_worktree(
+                context.project_data_dir,
+                context.repo_root,
+                selected_epic,
+                root_branch=root_branch_value,
+                git_path=git_path,
             )
             changeset_worktree_path = worktrees.ensure_changeset_worktree(
                 context.project_data_dir,

--- a/tests/atelier/worker/test_session_worktree.py
+++ b/tests/atelier/worker/test_session_worktree.py
@@ -500,6 +500,7 @@ def test_prepare_worktrees_creates_selected_scope_before_repair(tmp_path: Path) 
     logs: list[str] = []
     repo_root = tmp_path / "repo"
     repo_root.mkdir(parents=True)
+    epic_worktree_path = tmp_path / "worktrees" / "at-epic"
     changeset_worktree_path = tmp_path / "worktrees" / "at-epic.1"
     changeset_worktree_path.mkdir(parents=True)
     validation = worktree_fast_path.SelectedScopeValidation(
@@ -534,7 +535,10 @@ def test_prepare_worktrees_creates_selected_scope_before_repair(tmp_path: Path) 
         patch(
             "atelier.worker.session.worktree.worktrees.reconcile_mapping_ownership"
         ) as reconcile_mapping,
-        patch("atelier.worker.session.worktree.worktrees.ensure_git_worktree") as ensure_epic,
+        patch(
+            "atelier.worker.session.worktree.worktrees.ensure_git_worktree",
+            return_value=epic_worktree_path,
+        ) as ensure_epic,
         patch(
             "atelier.worker.session.worktree.worktrees.ensure_changeset_branch",
             return_value=("feat/root-at-epic.1", mapping),
@@ -575,7 +579,13 @@ def test_prepare_worktrees_creates_selected_scope_before_repair(tmp_path: Path) 
     preflight.assert_not_called()
     ownership_lookup.assert_not_called()
     reconcile_mapping.assert_not_called()
-    ensure_epic.assert_not_called()
+    ensure_epic.assert_called_once_with(
+        tmp_path,
+        repo_root,
+        "at-epic",
+        root_branch="feat/root",
+        git_path="git",
+    )
     ensure_branch.assert_called_once_with(
         tmp_path,
         "at-epic",
@@ -619,7 +629,7 @@ def test_prepare_worktrees_creates_selected_scope_before_repair(tmp_path: Path) 
         cwd=repo_root,
         allow_override=False,
     )
-    assert result.epic_worktree_path == tmp_path / "worktrees" / "at-epic"
+    assert result.epic_worktree_path == epic_worktree_path
     assert result.changeset_worktree_path == changeset_worktree_path
     assert result.branch == "feat/root-at-epic.1"
     assert any("Selected-scope validation: selected-scope-create-locally" in line for line in logs)


### PR DESCRIPTION
# Summary

- route worker worktree preparation through selected-scope validation before repair
- keep selected-scope local creation coherent by ensuring the epic root worktree exists before returning

# Changes

- run selected-scope validation before startup preflight or global mapping ownership repair in `prepare_worktrees`
- keep the child `LOCAL_CREATE` fast path selected-scope only while ensuring the selected epic root worktree and child worktree stay coherent
- preserve startup metadata synchronization on the fast path and cover the review-feedback case with regression tests

# Testing

- `pytest tests/atelier/worker/test_session_worktree.py tests/atelier/worker/test_session_worktree_fast_path.py`
- full pre-push suite via repo hooks (`pytest`, shell hook tests)

## Tickets
- Fixes #691

# Risks / Rollout

- fallback and ambiguous states still use the existing repair path in this slice

# Notes

- this changeset remains scoped to the selected-scope routing and coherent local-create behavior; broader fallback repair orchestration remains follow-on work
