### PR TITLE
Prove worker worktree startup fast path and fallback contract

### DIFF
--- a/docs/worker-runtime-architecture.md
+++ b/docs/worker-runtime-architecture.md
@@ -4,7 +4,9 @@ This document describes the worker runtime contracts used by `atelier work`.
 
 For service/use-case tier boundaries and migration sequencing, see
 `docs/service-tier-proposal.md`. For hotspot decomposition boundaries and
-complexity guardrails, see `docs/hotspot-architecture-contract.md`.
+complexity guardrails, see `docs/hotspot-architecture-contract.md`. For the
+selected-scope worktree startup contract, see
+[Worker Worktree Startup Contract].
 
 ## Goals
 
@@ -127,3 +129,7 @@ Lifecycle authority:
 - The stricter prose width keeps runtime contracts readable in terminals and
   review tools, while 100-character code lines avoid excessive wrapping for
   typed signatures.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[worker worktree startup contract]: ./worker-worktree-startup-contract.md

--- a/docs/worker-worktree-startup-contract.md
+++ b/docs/worker-worktree-startup-contract.md
@@ -1,0 +1,87 @@
+# Worker Worktree Startup Contract
+
+This document defines the worker-side contract for
+`src/atelier/worker/session/worktree.py::prepare_worktrees()` and
+`src/atelier/worker/session/worktree_fast_path.py::validate_selected_scope()`.
+
+The contract is simple:
+
+- selected-scope validation is the default startup path
+- global reconciliation and repair are fallback-only escape hatches
+- ambiguous state fails closed instead of mutating local or global state
+
+## Default Path
+
+Worker startup begins with the already selected epic and changeset. The worker
+must prove that selected local state is safe before it considers project-wide
+repair.
+
+`validate_selected_scope()` inspects only the selected changeset boundary:
+
+- selected changeset metadata from Beads
+- the selected epic's mapping file
+- the selected worktree path for that changeset
+- the checked-out branch only when the mapping and worktree already line up
+
+That ordering is part of the contract. Cheap rejection should happen before any
+global ownership scan, lineage synthesis, or repair workflow.
+
+## Outcomes
+
+`SelectedScopeValidationOutcome` defines four allowed decisions:
+
+- `SAFE_REUSE`: the selected mapping, worktree, and branch already agree, so
+  startup reuses the selected worktree directly
+- `LOCAL_CREATE`: the selected scope has no local lineage yet, so startup
+  creates only the selected epic/changeset worktrees and checkout state
+- `REQUIRES_FALLBACK_REPAIR`: selected-scope state is present but invalid, so
+  startup may enter the existing repair and reconciliation pipeline
+- `AMBIGUOUS`: state cannot be trusted safely, so startup stops immediately
+
+Only `SAFE_REUSE` and `LOCAL_CREATE` are fast-path outcomes.
+
+## Fallback Boundary
+
+Global repair is an escape hatch, not the default path. Startup may enter the
+fallback path only after selected-scope validation returns
+`REQUIRES_FALLBACK_REPAIR`.
+
+When that happens, `prepare_worktrees()` may run:
+
+- targeted startup preflight for prefix-migration residue
+- mapping ownership reconciliation
+- legacy lineage repair and worktree repair helpers
+
+The fast path must not call those global steps for reusable or locally creatable
+selected scope.
+
+## Fail-Closed Rules
+
+`AMBIGUOUS` outcomes block startup. They do not degrade into fallback repair.
+Representative cases include:
+
+- mapping ownership that points at a different epic
+- mapping files that cannot be parsed
+- selected worktree paths that exist but are not git worktrees
+- detached or unresolved checked-out branch state
+
+If startup cannot prove safety, it must fail closed and surface a deterministic
+reason signal.
+
+## Regression Proof
+
+The contract is enforced by proof-oriented tests:
+
+- `tests/atelier/worker/test_session_worktree_fast_path.py` proves the validator
+  stays cheap for reusable and local-create paths and rejects mismatches before
+  branch lookup
+- `tests/atelier/worker/test_session_worktree.py` proves `prepare_worktrees()`
+  reuses or creates selected scope before any global repair, routes invalid
+  local state into explicit fallback repair, and keeps ambiguous state
+  fail-closed
+
+For the broader worker runtime layering, see [Worker Runtime Architecture].
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[worker runtime architecture]: ./worker-runtime-architecture.md

--- a/tests/atelier/worker/test_session_worktree_fast_path.py
+++ b/tests/atelier/worker/test_session_worktree_fast_path.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from atelier import worktrees
 from atelier.worker.session import worktree_fast_path
@@ -96,6 +96,37 @@ def test_validate_selected_scope_reports_local_create_when_selected_mapping_has_
     assert result.signals[0].code == "selected-scope-create-locally"
 
 
+def test_validate_selected_scope_local_create_skips_branch_lookup_without_lineage(
+    tmp_path: Path,
+) -> None:
+    worktrees.write_mapping(
+        worktrees.mapping_path(tmp_path, "at-epic"),
+        worktrees.WorktreeMapping(
+            epic_id="at-epic",
+            worktree_path="worktrees/at-epic",
+            root_branch="feat/root",
+            changesets={},
+            changeset_worktrees={},
+        ),
+    )
+    current_branch = Mock(name="git_current_branch")
+
+    with (
+        patch(
+            "atelier.worker.session.worktree_fast_path.beads.run_bd_json",
+            return_value=[_issue()],
+        ),
+        patch(
+            "atelier.worker.session.worktree_fast_path.git.git_current_branch",
+            current_branch,
+        ),
+    ):
+        result = worktree_fast_path.validate_selected_scope(context=_context(tmp_path))
+
+    assert result.outcome is worktree_fast_path.SelectedScopeValidationOutcome.LOCAL_CREATE
+    current_branch.assert_not_called()
+
+
 def test_validate_selected_scope_requires_fallback_when_metadata_exists_without_mapping(
     tmp_path: Path,
 ) -> None:
@@ -110,6 +141,40 @@ def test_validate_selected_scope_requires_fallback_when_metadata_exists_without_
     )
     assert result.mapping_epic_id is None
     assert result.signals[0].code == "selected-scope-metadata-without-mapping"
+
+
+def test_validate_selected_scope_root_mismatch_falls_back_before_branch_lookup(
+    tmp_path: Path,
+) -> None:
+    worktrees.write_mapping(
+        worktrees.mapping_path(tmp_path, "at-epic"),
+        worktrees.WorktreeMapping(
+            epic_id="at-epic",
+            worktree_path="worktrees/at-epic",
+            root_branch="feat/legacy",
+            changesets={"at-epic.1": "feat/legacy-at-epic.1"},
+            changeset_worktrees={"at-epic.1": "worktrees/at-epic.1"},
+        ),
+    )
+    current_branch = Mock(name="git_current_branch")
+
+    with (
+        patch(
+            "atelier.worker.session.worktree_fast_path.beads.run_bd_json",
+            return_value=[_issue(root_branch="feat/root", work_branch="feat/root-at-epic.1")],
+        ),
+        patch(
+            "atelier.worker.session.worktree_fast_path.git.git_current_branch",
+            current_branch,
+        ),
+    ):
+        result = worktree_fast_path.validate_selected_scope(context=_context(tmp_path))
+
+    assert (
+        result.outcome is worktree_fast_path.SelectedScopeValidationOutcome.REQUIRES_FALLBACK_REPAIR
+    )
+    assert result.signals[0].code == "selected-scope-root-branch-mismatch"
+    current_branch.assert_not_called()
 
 
 def test_validate_selected_scope_requires_fallback_when_mapped_worktree_is_missing(

--- a/tests/atelier/worker/test_worktree_startup_contract_doc.py
+++ b/tests/atelier/worker/test_worktree_startup_contract_doc.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+DOC_PATH = REPO_ROOT / "docs" / "worker-worktree-startup-contract.md"
+ARCH_DOC_PATH = REPO_ROOT / "docs" / "worker-runtime-architecture.md"
+
+
+def test_worker_worktree_startup_contract_doc_covers_fast_path_and_fallback() -> None:
+    doc = DOC_PATH.read_text(encoding="utf-8")
+    arch_doc = ARCH_DOC_PATH.read_text(encoding="utf-8")
+
+    assert "Worker Worktree Startup Contract" in doc
+    assert "selected-scope validation is the default startup path" in doc
+    assert "global reconciliation and repair are fallback-only escape hatches" in doc
+    assert "SAFE_REUSE" in doc
+    assert "LOCAL_CREATE" in doc
+    assert "REQUIRES_FALLBACK_REPAIR" in doc
+    assert "AMBIGUOUS" in doc
+    assert "fail closed" in doc.lower()
+    assert "tests/atelier/worker/test_session_worktree_fast_path.py" in doc
+    assert "tests/atelier/worker/test_session_worktree.py" in doc
+
+    assert "[Worker Worktree Startup Contract]" in arch_doc


### PR DESCRIPTION
## Summary
Prove the worker worktree startup contract with timing-oriented regression
coverage and publish the fast-path versus fallback guidance for maintainers.

## Changes
- add selected-scope validator tests that prove cheap local-create and early
  fallback outcomes short-circuit before git branch lookup
- publish a worker worktree startup contract that defines selected-scope
  validation as the default path and global repair as a fallback-only escape
  hatch
- link the runtime architecture docs to the new contract and add a doc test so
  the guidance stays present

## Testing
- just format
- just lint
- just test

## Tickets
- Fixes #693

## Risks / Rollout
- Low risk; this changeset only updates tests and documentation.
- Future startup changes now have an explicit contract to review against.

## Notes
- Parent PR #702 is merged, so this draft PR targets `main`.
