### PR TITLE
Fix plan-promote-epic notes preview contract

### DIFF
--- a/src/atelier/skills/plan-promote-epic/scripts/promote_epic.py
+++ b/src/atelier/skills/plan-promote-epic/scripts/promote_epic.py
@@ -98,6 +98,22 @@ def _note_lines(description: str | None) -> tuple[str, ...]:
     return tuple(lines)
 
 
+def _issue_notes_text(issue: object) -> str | None:
+    notes = getattr(issue, "notes", None)
+    if isinstance(notes, str):
+        return _clean_text(notes)
+    if isinstance(notes, (list, tuple)):
+        cleaned_lines = tuple(
+            cleaned for item in notes if (cleaned := _clean_text(item)) is not None
+        )
+        if cleaned_lines:
+            return "\n".join(cleaned_lines)
+    legacy_notes = _note_lines(_issue_text(issue, "description"))
+    if legacy_notes:
+        return "\n".join(legacy_notes)
+    return None
+
+
 def _related_context(issue: object) -> tuple[str, ...]:
     fields = beads_metadata.parse_description_fields(_issue_text(issue, "description") or "")
     related = list(_split_field_values(fields.get("related_context")))
@@ -116,7 +132,7 @@ def _missing_detail_sections(issue: object) -> tuple[str, ...]:
     missing: list[str] = []
     if _issue_text(issue, "description") is None:
         missing.append("description")
-    if not _note_lines(_issue_text(issue, "description")):
+    if _issue_notes_text(issue) is None:
         missing.append("notes")
     if _issue_text(issue, "acceptance_criteria") is None:
         missing.append("acceptance criteria")
@@ -150,7 +166,7 @@ def _dependency_ids(issue: object) -> tuple[str, ...]:
 def _render_issue_preview(*, header: str, issue: object) -> str:
     dependencies = _dependency_ids(issue)
     related_context = _related_context(issue)
-    notes = _note_lines(_issue_text(issue, "description"))
+    notes = _issue_notes_text(issue)
     missing = _missing_detail_sections(issue)
     lines = [
         header,
@@ -159,7 +175,7 @@ def _render_issue_preview(*, header: str, issue: object) -> str:
         "Description:",
         _issue_text(issue, "description") or "(missing)",
         "Notes:",
-        "\n".join(notes) if notes else "(missing)",
+        notes or "(missing)",
         "Acceptance Criteria:",
         _issue_text(issue, "acceptance_criteria") or "(missing)",
         "Dependencies:",

--- a/tests/atelier/skills/test_plan_promote_epic_script.py
+++ b/tests/atelier/skills/test_plan_promote_epic_script.py
@@ -33,6 +33,7 @@ def _issue(
     status: str = "deferred",
     description: str = "",
     acceptance: str = "Acceptance text",
+    notes: str | tuple[str, ...] | None = None,
     dependencies: tuple[str, ...] = (),
 ):
     return SimpleNamespace(
@@ -41,6 +42,7 @@ def _issue(
         status=status,
         description=description,
         acceptance_criteria=acceptance,
+        notes=notes,
         dependencies=tuple(SimpleNamespace(id=dependency) for dependency in dependencies),
     )
 
@@ -159,6 +161,89 @@ def test_promote_epic_applies_store_lifecycle_transitions(monkeypatch, tmp_path:
     assert [request.issue_id for request in transitions] == ["at-epic", "at-epic.1"]
 
 
+def test_promote_epic_preview_reads_canonical_notes_for_epic_and_child(
+    monkeypatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+    transitions: list[object] = []
+
+    monkeypatch.setattr(
+        module,
+        "_resolve_context",
+        lambda **_kwargs: (tmp_path / ".beads", tmp_path / "repo", None),
+    )
+
+    epic_issue = _issue(
+        "at-epic",
+        title="Epic",
+        description=("changeset_strategy: Keep review scope small.\nrelated_context: at-context\n"),
+        notes="canonical epic note\n- preserves preview readiness",
+    )
+    child_issue = _issue(
+        "at-epic.1",
+        title="Child",
+        description="related_context: at-context\n",
+        notes="canonical child note",
+    )
+
+    class FakeStore:
+        async def get_epic(self, epic_id):
+            assert epic_id == "at-epic"
+            from atelier.store import LifecycleStatus
+
+            return SimpleNamespace(id=epic_id, lifecycle=LifecycleStatus.DEFERRED)
+
+        async def list_changesets(self, query):
+            del query
+            from atelier.store import LifecycleStatus
+
+            return (SimpleNamespace(id="at-epic.1", lifecycle=LifecycleStatus.DEFERRED),)
+
+        async def transition_lifecycle(self, request):
+            transitions.append(request)
+            return request
+
+    class FakeClient:
+        async def show(self, request):
+            return {"at-epic": epic_issue, "at-epic.1": child_issue}[request.issue_id]
+
+    monkeypatch.setattr(
+        module, "_build_store_and_client", lambda **_kwargs: (FakeStore(), FakeClient())
+    )
+    monkeypatch.setattr(sys, "argv", ["promote_epic.py", "--epic-id", "at-epic"])
+
+    module.main()
+
+    captured = capsys.readouterr()
+    assert "canonical epic note" in captured.out
+    assert "canonical child note" in captured.out
+    assert "Missing detail sections: notes" not in captured.out
+    assert "confirmation_required" in captured.out
+    assert transitions == []
+
+
+def test_render_issue_preview_prefers_canonical_notes_over_description_markers() -> None:
+    module = _load_script_module()
+    issue = _issue(
+        "at-epic",
+        title="Epic",
+        description="related_context: at-context\npromotion_note: legacy note marker\n",
+        notes="canonical notes field",
+    )
+
+    preview = module._render_issue_preview(header="EPIC at-epic", issue=issue)
+
+    notes_section = preview.split("Notes:\n", maxsplit=1)[1].split(
+        "\nAcceptance Criteria:",
+        maxsplit=1,
+    )[0]
+
+    assert notes_section == "canonical notes field"
+    assert "Missing detail sections: notes" not in preview
+
+
 def test_promote_epic_fails_when_one_child_has_no_decomposition_rationale(
     monkeypatch,
     capsys: pytest.CaptureFixture[str],
@@ -215,3 +300,59 @@ def test_promote_epic_fails_when_one_child_has_no_decomposition_rationale(
     assert (
         "one-child promotion requires explicit decomposition rationale" in capsys.readouterr().err
     )
+
+
+def test_promote_epic_still_fails_when_notes_are_actually_absent(
+    monkeypatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+
+    monkeypatch.setattr(
+        module,
+        "_resolve_context",
+        lambda **_kwargs: (tmp_path / ".beads", tmp_path / "repo", None),
+    )
+
+    epic_issue = _issue(
+        "at-epic",
+        title="Epic",
+        description=("changeset_strategy: Keep review scope small.\nrelated_context: at-context\n"),
+    )
+    child_issue = _issue(
+        "at-epic.1",
+        title="Child",
+        description="related_context: at-context\n",
+    )
+
+    class FakeStore:
+        async def get_epic(self, epic_id):
+            assert epic_id == "at-epic"
+            from atelier.store import LifecycleStatus
+
+            return SimpleNamespace(id=epic_id, lifecycle=LifecycleStatus.DEFERRED)
+
+        async def list_changesets(self, query):
+            del query
+            from atelier.store import LifecycleStatus
+
+            return (SimpleNamespace(id="at-epic.1", lifecycle=LifecycleStatus.DEFERRED),)
+
+        async def transition_lifecycle(self, request):  # pragma: no cover - defensive
+            raise AssertionError(request)
+
+    class FakeClient:
+        async def show(self, request):
+            return {"at-epic": epic_issue, "at-epic.1": child_issue}[request.issue_id]
+
+    monkeypatch.setattr(
+        module, "_build_store_and_client", lambda **_kwargs: (FakeStore(), FakeClient())
+    )
+    monkeypatch.setattr(sys, "argv", ["promote_epic.py", "--epic-id", "at-epic"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.main()
+
+    assert excinfo.value.code == 1
+    assert "epic missing detail sections: notes" in capsys.readouterr().err


### PR DESCRIPTION
# Summary

- Make `plan-promote-epic` read canonical Beads notes during preview and apply.
- Stop false `missing detail sections: notes` failures when notes already exist.

# Changes

- Added canonical `issue.notes` handling in the promotion script and kept legacy description-note fallback for compatibility.
- Reused the normalized notes value in preview rendering and readiness checks.
- Added regression tests for canonical epic notes, canonical child notes, canonical-over-legacy precedence, and true missing-notes failures.

# Testing

- `just format`
- `just test`
- `just lint`

# Tickets

- None

# Risks / Rollout

- Low risk; the change is scoped to planner promotion preview/readiness note sourcing.

# Notes

- Legacy description note markers still work when canonical Beads notes are absent.
