### PR TITLE
Repair finalize close verification for empty Beads output

### DIFF
--- a/src/atelier/store/beads_store.py
+++ b/src/atelier/store/beads_store.py
@@ -15,6 +15,7 @@ from atelier.lib.beads import (
     Beads,
     BeadsCommandRequest,
     BeadsCommandResult,
+    BeadsParseError,
     CloseIssueRequest,
     CreateIssueRequest,
     DependencyMutationRequest,
@@ -1193,15 +1194,10 @@ class AtelierStore:
                 reason=request.reason,
             )
         if request.target_status is LifecycleStatus.CLOSED:
-            updated = await self._beads.close(
-                CloseIssueRequest(issue_id=request.issue_id, reason=request.reason)
+            await self._close_issue_until_verified(
+                request.issue_id,
+                reason=request.reason,
             )
-            if lifecycle.canonical_lifecycle_status(updated.status) != LifecycleStatus.CLOSED.value:
-                refreshed = await self._show_issue(request.issue_id)
-                if lifecycle.canonical_lifecycle_status(refreshed.status) != "closed":
-                    raise RuntimeError(
-                        f"lifecycle close could not be verified for {request.issue_id}"
-                    )
         else:
             expected_from = request.expected_current
 
@@ -1238,6 +1234,32 @@ class AtelierStore:
             to_status=request.target_status,
             reason=request.reason,
         )
+
+    async def _close_issue_until_verified(
+        self,
+        issue_id: str,
+        *,
+        reason: str | None,
+    ) -> IssueRecord:
+        try:
+            updated = await self._beads.close(CloseIssueRequest(issue_id=issue_id, reason=reason))
+        except BeadsParseError as exc:
+            refreshed = await self._show_issue(issue_id)
+            if (
+                lifecycle.canonical_lifecycle_status(refreshed.status)
+                == LifecycleStatus.CLOSED.value
+            ):
+                return refreshed
+            raise RuntimeError(f"lifecycle close could not be verified for {issue_id}") from exc
+
+        if lifecycle.canonical_lifecycle_status(updated.status) == LifecycleStatus.CLOSED.value:
+            return updated
+
+        refreshed = await self._show_issue(issue_id)
+        if lifecycle.canonical_lifecycle_status(refreshed.status) == LifecycleStatus.CLOSED.value:
+            return refreshed
+
+        raise RuntimeError(f"lifecycle close could not be verified for {issue_id}")
 
     async def _show_issue(self, issue_id: str) -> IssueRecord:
         try:
@@ -1278,9 +1300,7 @@ class AtelierStore:
     ) -> None:
         transition_detail = str(transition_error).strip() or "status update failed"
         try:
-            closed = await self._beads.close(
-                CloseIssueRequest(issue_id=issue_id, reason=_FAIL_CLOSED_REASON)
-            )
+            await self._close_issue_until_verified(issue_id, reason=_FAIL_CLOSED_REASON)
         except Exception as close_error:
             close_detail = str(close_error).strip() or "close command failed"
             raise RuntimeError(
@@ -1288,18 +1308,6 @@ class AtelierStore:
                 f"after {_MAX_UPDATE_ATTEMPTS} attempts; auto-close failed "
                 f"({transition_detail}; {close_detail})"
             ) from transition_error
-
-        if lifecycle.canonical_lifecycle_status(closed.status) != LifecycleStatus.CLOSED.value:
-            refreshed = await self._show_issue(issue_id)
-            if (
-                lifecycle.canonical_lifecycle_status(refreshed.status)
-                != LifecycleStatus.CLOSED.value
-            ):
-                raise RuntimeError(
-                    f"created {issue_label} {issue_id} but failed to set status=deferred "
-                    f"after {_MAX_UPDATE_ATTEMPTS} attempts; auto-close failed "
-                    f"({transition_detail}; close verification failed)"
-                ) from transition_error
 
         raise RuntimeError(
             f"created {issue_label} {issue_id} but failed to set status=deferred "

--- a/tests/atelier/test_store_contract.py
+++ b/tests/atelier/test_store_contract.py
@@ -14,6 +14,8 @@ from atelier.lib.beads import (
     BeadsCommandError,
     BeadsCommandRequest,
     BeadsCommandResult,
+    BeadsParseError,
+    CloseIssueRequest,
     ListIssuesRequest,
     RecordingBeadsTransport,
     ScriptedBeadsTransport,
@@ -204,6 +206,60 @@ def test_store_message_query_and_request_do_not_expose_assignee_routing() -> Non
     assert "assignee" not in MessageQuery.model_fields
     assert "assignee" not in CreateMessageRequest.model_fields
     assert "recipient" not in CreateMessageRequest.model_fields
+
+
+def test_transition_lifecycle_verifies_close_after_unparseable_close_output(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_client, issue_store = build_in_memory_beads_client(
+        issues=(BUILDER.issue("at-change", issue_type="task", status="in_progress"),)
+    )
+
+    async def close_then_fail(request: CloseIssueRequest):
+        issue_store.close(request.issue_id, reason=request.reason)
+        raise BeadsParseError("expected JSON output from close, received empty stdout")
+
+    monkeypatch.setattr(async_client, "close", close_then_fail)
+    store = build_atelier_store(beads=async_client)
+
+    transition = _RUN(
+        store.transition_lifecycle(
+            LifecycleTransitionRequest(
+                issue_id="at-change",
+                target_status=LifecycleStatus.CLOSED,
+                expected_current=LifecycleStatus.IN_PROGRESS,
+            )
+        )
+    )
+
+    assert transition.to_status is LifecycleStatus.CLOSED
+    assert _RUN(store._show_issue("at-change")).status == "closed"
+
+
+def test_transition_lifecycle_fails_closed_when_unparseable_close_output_lacks_convergence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_client, _issue_store = build_in_memory_beads_client(
+        issues=(BUILDER.issue("at-change", issue_type="task", status="in_progress"),)
+    )
+
+    async def close_then_fail(request: CloseIssueRequest):
+        del request
+        raise BeadsParseError("failed to parse JSON output from close")
+
+    monkeypatch.setattr(async_client, "close", close_then_fail)
+    store = build_atelier_store(beads=async_client)
+
+    with pytest.raises(RuntimeError, match="lifecycle close could not be verified for at-change"):
+        _RUN(
+            store.transition_lifecycle(
+                LifecycleTransitionRequest(
+                    issue_id="at-change",
+                    target_status=LifecycleStatus.CLOSED,
+                    expected_current=LifecycleStatus.IN_PROGRESS,
+                )
+            )
+        )
 
 
 def test_message_record_enforces_store_message_contract() -> None:

--- a/tests/atelier/worker/test_store_adapter.py
+++ b/tests/atelier/worker/test_store_adapter.py
@@ -2,7 +2,7 @@ import datetime as dt
 from pathlib import Path
 from unittest.mock import patch
 
-from atelier.lib.beads import IssueRecord, SyncBeadsClient
+from atelier.lib.beads import BeadsParseError, CloseIssueRequest, IssueRecord, SyncBeadsClient
 from atelier.messages import render_message
 from atelier.store import HookRecord, StartupMessageRecord, build_atelier_store
 from atelier.testing.beads import IssueFixtureBuilder
@@ -292,6 +292,48 @@ def test_transition_lifecycle_updates_changeset_status(monkeypatch) -> None:
 
     assert refreshed is not None
     assert refreshed["status"] == "blocked"
+    worker_store.clear_bundle_cache()
+
+
+def test_transition_lifecycle_closes_changeset_after_unparseable_close_output(
+    monkeypatch,
+) -> None:
+    builder = IssueFixtureBuilder()
+    async_client, issue_store = build_in_memory_beads_client(
+        issues=(builder.issue("at-epic.1", issue_type="task", status="in_progress"),),
+    )
+    store = build_atelier_store(beads=async_client)
+    worker_store.clear_bundle_cache()
+
+    async def close_then_fail(request: CloseIssueRequest) -> IssueRecord:
+        issue_store.close(request.issue_id, reason=request.reason)
+        raise BeadsParseError("expected JSON output from close, received empty stdout")
+
+    monkeypatch.setattr(async_client, "close", close_then_fail)
+    monkeypatch.setattr(
+        worker_store,
+        "_build_store_bundle",
+        lambda **_kwargs: worker_store._StoreBundle(  # pyright: ignore[reportPrivateUsage]
+            store=store,
+            sync_client=SyncBeadsClient(async_client),
+        ),
+    )
+
+    worker_store.transition_lifecycle(
+        "at-epic.1",
+        target_status="closed",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    refreshed = worker_store.show_issue(
+        "at-epic.1",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    assert refreshed is not None
+    assert refreshed["status"] == "closed"
     worker_store.clear_bundle_cache()
 
 


### PR DESCRIPTION
# Summary

- repair merged finalize and startup-finalize close handling when `bd close --json` returns empty or malformed stdout but the changeset has actually closed
- keep finalization fail-closed when a fresh Beads read does not prove the close converged

# Changes

- add `AtelierStore._close_issue_until_verified()` and route CLOSE lifecycle transitions through it
- fall back to `show` verification after `BeadsParseError` instead of crashing on empty stdout alone
- add store-contract and worker-store regressions that cover converged and non-converged close parsing failures

# Testing

- `just format`
- `just lint`
- `just test`

# Tickets

- Fixes #724

# Risks / Rollout

- touches the Beads close verification seam used by worker finalization; non-converged close attempts still stop with an explicit verification failure

# Notes

- scoped to the close-transition contract only; unrelated blocked-state and description-concurrency paths remain unchanged
