### PR TITLE
Retry concurrent description metadata writes during worker finalize

### DIFF
--- a/docs/beads-facade-inventory.json
+++ b/docs/beads-facade-inventory.json
@@ -36,7 +36,7 @@
               "module": "atelier.beads"
             }
           ],
-          "dotted_refs": 327
+          "dotted_refs": 324
         }
       ]
     }

--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -152,6 +152,10 @@ _DOLT_SERVER_ERROR_MARKERS = (
     "no such host",
     "unknown database",
 )
+_CONCURRENT_DESCRIPTION_UPDATE_ERROR_MARKERS = (
+    "concurrent description update conflict",
+    "description update conflict",
+)
 _DRY_RUN_RENAME_PREFIX_SUMMARY = re.compile(
     r"DRY RUN: Would rename (\d+) issues from prefix '([^']+)' to '([^']+)'"
 )
@@ -4054,6 +4058,34 @@ def _description_matches_expected(
     return True
 
 
+def _is_concurrent_description_update_conflict(detail: str | None) -> bool:
+    normalized = detail.strip().lower() if isinstance(detail, str) else ""
+    if not normalized:
+        return False
+    return any(marker in normalized for marker in _CONCURRENT_DESCRIPTION_UPDATE_ERROR_MARKERS)
+
+
+def _try_update_issue_description(
+    issue_id: str,
+    description: str,
+    *,
+    beads_root: Path,
+    cwd: Path,
+) -> subprocess.CompletedProcess[str]:
+    with NamedTemporaryFile("w", encoding="utf-8", delete=False) as handle:
+        handle.write(description)
+        temp_path = Path(handle.name)
+    try:
+        return run_bd_command(
+            ["update", issue_id, "--body-file", str(temp_path)],
+            beads_root=beads_root,
+            cwd=cwd,
+            allow_failure=True,
+        )
+    finally:
+        temp_path.unlink(missing_ok=True)
+
+
 def _update_description_fields_optimistic(
     issue_id: str,
     *,
@@ -4065,6 +4097,7 @@ def _update_description_fields_optimistic(
 ) -> dict[str, object]:
     """Apply description field updates with optimistic retry + verification."""
     with _issue_write_lock(issue_id, beads_root=beads_root):
+        conflict_retries = 0
         for _attempt in range(_DESCRIPTION_UPDATE_MAX_ATTEMPTS):
             issues = run_bd_json(["show", issue_id], beads_root=beads_root, cwd=cwd)
             if not issues:
@@ -4085,8 +4118,32 @@ def _update_description_fields_optimistic(
                     changed = True
                     updated = next_value
             if not changed:
+                if conflict_retries > 0:
+                    atelier_log.info(
+                        f"issue={issue_id} converged after {conflict_retries} concurrent "
+                        "description update conflict retries"
+                    )
                 return issue
-            _update_issue_description(issue_id, updated, beads_root=beads_root, cwd=cwd)
+            result = _try_update_issue_description(
+                issue_id,
+                updated,
+                beads_root=beads_root,
+                cwd=cwd,
+            )
+            if result.returncode != 0:
+                detail = (result.stderr or result.stdout).strip()
+                if _is_concurrent_description_update_conflict(detail):
+                    conflict_retries += 1
+                    atelier_log.warning(
+                        f"issue={issue_id} concurrent description update conflict while "
+                        f"applying description fields; retrying "
+                        f"({conflict_retries}/{_DESCRIPTION_UPDATE_MAX_ATTEMPTS})"
+                    )
+                    continue
+                message = f"failed to update description for {issue_id}"
+                if detail:
+                    message = f"{message}\n{detail}"
+                die(message)
             refreshed = run_bd_json(["show", issue_id], beads_root=beads_root, cwd=cwd)
             if not refreshed:
                 continue
@@ -4099,6 +4156,11 @@ def _update_description_fields_optimistic(
                     return candidate
                 continue
             if _description_matches_updates(candidate, fields=fields):
+                if conflict_retries > 0:
+                    atelier_log.info(
+                        f"issue={issue_id} converged after {conflict_retries} concurrent "
+                        "description update conflict retries"
+                    )
                 return candidate
     die(f"concurrent description update conflict for {issue_id}")
     raise RuntimeError("unreachable")

--- a/src/atelier/store/beads_store.py
+++ b/src/atelier/store/beads_store.py
@@ -9,10 +9,12 @@ from dataclasses import dataclass, field
 from typing import cast
 
 from atelier import changesets, external_ticket_reconcile, lifecycle, messages
+from atelier import log as atelier_log
 from atelier.external_tickets import external_ticket_payload
 from atelier.lib.beads import (
     BeadError,
     Beads,
+    BeadsCommandError,
     BeadsCommandRequest,
     BeadsCommandResult,
     BeadsParseError,
@@ -100,6 +102,10 @@ _REVIEW_STATE_MAP = {
 }
 _EXTERNAL_CLOSE_NOTE_PREFIX = "external_close_pending:"
 _EXTERNAL_REOPEN_NOTE_PREFIX = "external_reopen_pending:"
+_CONCURRENT_DESCRIPTION_UPDATE_ERROR_MARKERS = (
+    "concurrent description update conflict",
+    "description update conflict",
+)
 
 
 def _clean_text(value: object) -> str | None:
@@ -117,6 +123,30 @@ def _has_contract_label(labels: set[str], label_name: str) -> bool:
 def _is_missing_issue_error(exc: BeadError) -> bool:
     detail = str(exc).lower()
     return any(marker in detail for marker in _ISSUE_NOT_FOUND_ERROR_MARKERS)
+
+
+def _is_retryable_description_update_conflict(
+    *,
+    request: UpdateIssueRequest,
+    error: BeadsCommandError,
+) -> bool:
+    if request.description is None:
+        return False
+    detail = str(error).lower()
+    return any(marker in detail for marker in _CONCURRENT_DESCRIPTION_UPDATE_ERROR_MARKERS)
+
+
+def _log_description_conflict_convergence(
+    *,
+    issue_id: str,
+    conflict_retries: int,
+) -> None:
+    if conflict_retries <= 0:
+        return
+    atelier_log.info(
+        f"issue={issue_id} converged after {conflict_retries} concurrent description "
+        "update conflict retries"
+    )
 
 
 async def _read_issue_slots(beads: Beads, issue_id: str) -> dict[str, str]:
@@ -1439,16 +1469,50 @@ class AtelierStore:
         verify: Callable[[IssueRecord], bool],
         failure_message: str,
     ) -> IssueRecord:
+        conflict_retries = 0
         for _attempt in range(_MAX_UPDATE_ATTEMPTS):
             current = await self._show_issue(issue_id)
             if verify(current):
+                _log_description_conflict_convergence(
+                    issue_id=issue_id,
+                    conflict_retries=conflict_retries,
+                )
                 return current
             request = build_request(current)
-            updated = await self._beads.update(request)
+            try:
+                updated = await self._beads.update(request)
+            except BeadsCommandError as exc:
+                if not _is_retryable_description_update_conflict(
+                    request=request,
+                    error=exc,
+                ):
+                    raise
+                conflict_retries += 1
+                atelier_log.warning(
+                    f"issue={issue_id} concurrent description update conflict while "
+                    f"verifying store mutation; retrying "
+                    f"({conflict_retries}/{_MAX_UPDATE_ATTEMPTS})"
+                )
+                refreshed = await self._show_issue(issue_id)
+                if verify(refreshed):
+                    _log_description_conflict_convergence(
+                        issue_id=issue_id,
+                        conflict_retries=conflict_retries,
+                    )
+                    return refreshed
+                continue
             if verify(updated):
+                _log_description_conflict_convergence(
+                    issue_id=issue_id,
+                    conflict_retries=conflict_retries,
+                )
                 return updated
             refreshed = await self._show_issue(issue_id)
             if verify(refreshed):
+                _log_description_conflict_convergence(
+                    issue_id=issue_id,
+                    conflict_retries=conflict_retries,
+                )
                 return refreshed
         raise RuntimeError(failure_message)
 

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -4254,10 +4254,20 @@ def test_set_agent_hook_updates_description() -> None:
         captured["description"] = description
         state["description"] = description
 
+    def fake_try_update(
+        issue_id: str,
+        description: str,
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> CompletedProcess[str]:
+        fake_update(issue_id, description, beads_root=beads_root, cwd=cwd)
+        return CompletedProcess(args=["bd", "update"], returncode=0, stdout="", stderr="")
+
     with (
         patch("atelier.beads.run_bd_json", side_effect=fake_json),
         patch("atelier.beads.run_bd_command", side_effect=fake_command),
-        patch("atelier.beads._update_issue_description", side_effect=fake_update),
+        patch.object(beads, "_try_update_issue_description", side_effect=fake_try_update),
     ):
         beads.set_agent_hook(
             "atelier-agent",
@@ -4282,7 +4292,13 @@ def test_update_issue_description_fields_serializes_concurrent_writers() -> None
         del args, beads_root, cwd
         return [{"id": "issue-1", "description": state["description"]}]
 
-    def fake_update(issue_id: str, description: str, *, beads_root: Path, cwd: Path) -> None:
+    def fake_update(
+        issue_id: str,
+        description: str,
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> CompletedProcess[str]:
         del issue_id, beads_root, cwd
         nonlocal write_order
         write_order += 1
@@ -4290,6 +4306,7 @@ def test_update_issue_description_fields_serializes_concurrent_writers() -> None
             first_write_started.set()
             assert release_first_write.wait(timeout=1.0)
         state["description"] = description
+        return CompletedProcess(args=["bd", "update"], returncode=0, stdout="", stderr="")
 
     def apply_fields(fields: dict[str, str | None]) -> None:
         try:
@@ -4304,7 +4321,7 @@ def test_update_issue_description_fields_serializes_concurrent_writers() -> None
 
     with (
         patch("atelier.beads.run_bd_json", side_effect=fake_json),
-        patch("atelier.beads._update_issue_description", side_effect=fake_update),
+        patch.object(beads, "_try_update_issue_description", side_effect=fake_update),
     ):
         first = threading.Thread(target=apply_fields, args=({"hook_bead": "epic-1"},))
         second = threading.Thread(target=apply_fields, args=({"pr_state": "in-review"},))
@@ -5962,9 +5979,19 @@ def test_update_changeset_review_feedback_cursor_updates_description() -> None:
         captured["description"] = description
         state["description"] = description
 
+    def fake_try_update(
+        issue_id: str,
+        description: str,
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> CompletedProcess[str]:
+        fake_update(issue_id, description, beads_root=beads_root, cwd=cwd)
+        return CompletedProcess(args=["bd", "update"], returncode=0, stdout="", stderr="")
+
     with (
         patch("atelier.beads.run_bd_json", side_effect=fake_json),
-        patch("atelier.beads._update_issue_description", side_effect=fake_update),
+        patch.object(beads, "_try_update_issue_description", side_effect=fake_try_update),
     ):
         beads.update_changeset_review_feedback_cursor(
             "atelier-99",
@@ -6022,18 +6049,25 @@ def test_update_issue_description_fields_retries_after_interleaved_overwrite() -
     def fake_json(args: list[str], *, beads_root: Path, cwd: Path) -> list[dict[str, object]]:
         return [{"id": "agent-1", "description": state["description"]}]
 
-    def fake_update(issue_id: str, description: str, *, beads_root: Path, cwd: Path) -> None:
+    def fake_update(
+        issue_id: str,
+        description: str,
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> CompletedProcess[str]:
         nonlocal writes
         del issue_id, beads_root, cwd
         writes += 1
         if writes == 1:
             state["description"] = "pr_state: in-review\n"
-            return
+            return CompletedProcess(args=["bd", "update"], returncode=0, stdout="", stderr="")
         state["description"] = description
+        return CompletedProcess(args=["bd", "update"], returncode=0, stdout="", stderr="")
 
     with (
         patch("atelier.beads.run_bd_json", side_effect=fake_json),
-        patch("atelier.beads._update_issue_description", side_effect=fake_update),
+        patch.object(beads, "_try_update_issue_description", side_effect=fake_update),
     ):
         beads.update_issue_description_fields(
             "agent-1",
@@ -6042,6 +6076,52 @@ def test_update_issue_description_fields_retries_after_interleaved_overwrite() -
             cwd=Path("/repo"),
         )
 
+    assert "hook_bead: epic-2" in state["description"]
+    assert "pr_state: in-review" in state["description"]
+
+
+def test_update_issue_description_fields_retries_after_command_conflict() -> None:
+    state = {"description": "hook_bead: epic-1\npr_state: draft-pr\n"}
+    writes = 0
+
+    def fake_json(args: list[str], *, beads_root: Path, cwd: Path) -> list[dict[str, object]]:
+        del args, beads_root, cwd
+        return [{"id": "agent-1", "description": state["description"]}]
+
+    def fake_command(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+        allow_failure: bool = False,
+    ) -> CompletedProcess[str]:
+        nonlocal writes
+        del beads_root, cwd, allow_failure
+        writes += 1
+        if writes == 1:
+            state["description"] = "pr_state: in-review\n"
+            return CompletedProcess(
+                args=["bd", *args],
+                returncode=1,
+                stdout="",
+                stderr="concurrent description update conflict for agent-1",
+            )
+        body_path = Path(args[args.index("--body-file") + 1])
+        state["description"] = body_path.read_text(encoding="utf-8")
+        return CompletedProcess(args=["bd", *args], returncode=0, stdout="", stderr="")
+
+    with (
+        patch("atelier.beads.run_bd_json", side_effect=fake_json),
+        patch("atelier.beads.run_bd_command", side_effect=fake_command),
+    ):
+        beads.update_issue_description_fields(
+            "agent-1",
+            {"hook_bead": "epic-2"},
+            beads_root=Path("/beads"),
+            cwd=Path("/repo"),
+        )
+
+    assert writes == 2
     assert "hook_bead: epic-2" in state["description"]
     assert "pr_state: in-review" in state["description"]
 
@@ -6058,9 +6138,19 @@ def test_update_worktree_path_writes_description() -> None:
         captured["description"] = description
         state["description"] = description
 
+    def fake_try_update(
+        issue_id: str,
+        description: str,
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> CompletedProcess[str]:
+        fake_update(issue_id, description, beads_root=beads_root, cwd=cwd)
+        return CompletedProcess(args=["bd", "update"], returncode=0, stdout="", stderr="")
+
     with (
         patch("atelier.beads.run_bd_json", side_effect=fake_json),
-        patch("atelier.beads._update_issue_description", side_effect=fake_update),
+        patch.object(beads, "_try_update_issue_description", side_effect=fake_try_update),
     ):
         beads.update_worktree_path(
             "epic-1", "worktrees/epic-1", beads_root=Path("/beads"), cwd=Path("/repo")

--- a/tests/atelier/test_store_contract.py
+++ b/tests/atelier/test_store_contract.py
@@ -271,6 +271,102 @@ def test_transition_lifecycle_fails_closed_when_unparseable_close_output_lacks_c
         )
 
 
+def test_update_review_retries_after_concurrent_description_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_client, issue_store = build_in_memory_beads_client(issues=_parity_seed_issues())
+    original_update = async_client.update
+    attempts = 0
+
+    async def conflict_then_update(request):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            current = issue_store.show("at-change")
+            issue_store.update(
+                "at-change",
+                description=(current.get("description") or "")
+                + "\nplanner_update: concurrent metadata refresh\n",
+            )
+            raise BeadsCommandError(
+                "bd command failed (1): bd update at-change --json\n"
+                "concurrent description update conflict for at-change"
+            )
+        return await original_update(request)
+
+    monkeypatch.setattr(async_client, "update", conflict_then_update)
+    store = build_atelier_store(beads=async_client)
+
+    review = _RUN(
+        store.update_review(
+            UpdateReviewRequest(
+                changeset_id="at-change",
+                review=ReviewMetadata(
+                    pr_state=ReviewState.IN_REVIEW,
+                    review_owner="reviewer-b",
+                    integrated_sha="abc1234",
+                ),
+                preserve_existing=True,
+            )
+        )
+    )
+
+    refreshed = _RUN(store._show_issue("at-change"))
+    assert attempts == 2
+    assert review.review.pr_state is ReviewState.IN_REVIEW
+    assert review.review.review_owner == "reviewer-b"
+    assert review.review.integrated_sha == "abc1234"
+    assert refreshed.description is not None
+    assert "planner_update: concurrent metadata refresh" in refreshed.description
+    assert "pr_state: in-review" in refreshed.description
+    assert "review_owner: reviewer-b" in refreshed.description
+    assert "changeset.integrated_sha: abc1234" in refreshed.description
+
+
+def test_append_notes_retries_after_concurrent_description_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_client, issue_store = build_in_memory_beads_client(issues=_parity_seed_issues())
+    original_update = async_client.update
+    attempts = 0
+    worker_note = "worker_update: preserved lifecycle mutation parity"
+
+    async def conflict_then_update(request):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            current = issue_store.show("at-change")
+            issue_store.update(
+                "at-change",
+                description=(current.get("description") or "")
+                + "\nplanner_update: concurrent verification note\n",
+            )
+            raise BeadsCommandError(
+                "bd command failed (1): bd update at-change --json\n"
+                "concurrent description update conflict for at-change"
+            )
+        return await original_update(request)
+
+    monkeypatch.setattr(async_client, "update", conflict_then_update)
+    store = build_atelier_store(beads=async_client)
+
+    appended = _RUN(
+        store.append_notes(
+            AppendNotesRequest(
+                issue_id="at-change",
+                notes=(worker_note,),
+            )
+        )
+    )
+
+    refreshed = _RUN(store._show_issue("at-change"))
+    assert attempts == 2
+    assert appended.id == "at-change"
+    assert refreshed.description is not None
+    assert "planner_update: concurrent verification note" in refreshed.description
+    assert refreshed.description.rstrip("\n").endswith(worker_note)
+
+
 def test_message_record_enforces_store_message_contract() -> None:
     record = MessageRecord(
         id="msg-1",


### PR DESCRIPTION
# Summary

- Retry concurrent description metadata writes so worker finalize and publish can converge instead of failing closed on a single interleaved description edit.

# Changes

- Retry store-backed description mutations after explicit concurrent-description conflicts by rereading the latest issue state, rebuilding the requested mutation, and logging convergence once verification succeeds.
- Retry the legacy optimistic description-field updater after conflicting `bd update --body-file` failures so metadata writes preserve concurrent edits instead of aborting immediately.
- Add regressions for review metadata updates, note appends, and legacy command-conflict recovery, and sync the retained beads facade inventory after reducing direct test references.

# Testing

- `just format`
- `just lint`
- `just test`

# Tickets

- Fixes #713

# Risks / Rollout

- This changes retry behavior only for explicit concurrent description conflicts; all other mutation failures still fail closed.
- Recovery depends on reread-and-verify semantics, so any future conflict-marker drift in `bd` output would fall back to the existing failure path.

# Notes

- The branch rebased cleanly onto `main` before push, so the published commit is `1618b79`.
