### PR TITLE
Recover store-backed mutations after empty update output

### DIFF
--- a/docs/atelier-store-contract.md
+++ b/docs/atelier-store-contract.md
@@ -103,6 +103,11 @@ implementation is backed by Beads:
 - Hook ownership is an Atelier contract binding one agent to one epic.
 - Lifecycle transitions are store mutations with canonical target states, not
   free-form status edits.
+- Store-backed update mutations fail closed unless convergence can be proven
+  from an authoritative fresh store read. When process-backed `bd update --json`
+  emits empty stdout, absent command payload is not success by itself; the only
+  allowed recovery proof is a follow-up read that satisfies the
+  mutation-specific verification predicate.
 
 ## Beads-Client Responsibilities
 

--- a/src/atelier/store/beads_store.py
+++ b/src/atelier/store/beads_store.py
@@ -106,6 +106,7 @@ _CONCURRENT_DESCRIPTION_UPDATE_ERROR_MARKERS = (
     "concurrent description update conflict",
     "description update conflict",
 )
+_EMPTY_UPDATE_STDOUT_PARSE_ERROR = "expected JSON output from update, received empty stdout"
 
 
 def _clean_text(value: object) -> str | None:
@@ -147,6 +148,10 @@ def _log_description_conflict_convergence(
         f"issue={issue_id} converged after {conflict_retries} concurrent description "
         "update conflict retries"
     )
+
+
+def _is_empty_output_update_parse_error(error: BeadsParseError) -> bool:
+    return str(error).strip() == _EMPTY_UPDATE_STDOUT_PARSE_ERROR
 
 
 async def _read_issue_slots(beads: Beads, issue_id: str) -> dict[str, str]:
@@ -1469,6 +1474,15 @@ class AtelierStore:
         verify: Callable[[IssueRecord], bool],
         failure_message: str,
     ) -> IssueRecord:
+        """Persist one update mutation with bounded read-after-write verification.
+
+        The process-backed ``bd update --json`` path may occasionally emit empty
+        stdout even when the mutation lands. In that narrow case the
+        authoritative convergence check is a fresh store read that satisfies the
+        caller's ``verify`` predicate. Absent that proof, this helper keeps the
+        failure local to the current bounded retry loop and eventually fails
+        closed with ``failure_message``.
+        """
         conflict_retries = 0
         for _attempt in range(_MAX_UPDATE_ATTEMPTS):
             current = await self._show_issue(issue_id)
@@ -1495,6 +1509,20 @@ class AtelierStore:
                 )
                 refreshed = await self._show_issue(issue_id)
                 if verify(refreshed):
+                    _log_description_conflict_convergence(
+                        issue_id=issue_id,
+                        conflict_retries=conflict_retries,
+                    )
+                    return refreshed
+                continue
+            except BeadsParseError as exc:
+                if not _is_empty_output_update_parse_error(exc):
+                    raise
+                refreshed = await self._show_issue(issue_id)
+                if verify(refreshed):
+                    atelier_log.info(
+                        f"issue={issue_id} converged from fresh read after empty update stdout"
+                    )
                     _log_description_conflict_convergence(
                         issue_id=issue_id,
                         conflict_retries=conflict_retries,

--- a/tests/atelier/test_store_contract.py
+++ b/tests/atelier/test_store_contract.py
@@ -323,6 +323,85 @@ def test_update_review_retries_after_concurrent_description_conflict(
     assert "changeset.integrated_sha: abc1234" in refreshed.description
 
 
+def test_update_review_verifies_after_empty_update_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_client, issue_store = build_in_memory_beads_client(issues=_parity_seed_issues())
+    attempts = 0
+
+    async def update_then_emit_empty_stdout(request):
+        nonlocal attempts
+        attempts += 1
+        issue_store.update(
+            request.issue_id,
+            title=request.title,
+            description=request.description,
+            design=request.design,
+            acceptance_criteria=request.acceptance_criteria,
+            status=request.status,
+            assignee=request.assignee,
+            priority=request.priority,
+            estimate=request.estimate,
+            labels=request.labels if request.labels else None,
+        )
+        raise BeadsParseError("expected JSON output from update, received empty stdout")
+
+    monkeypatch.setattr(async_client, "update", update_then_emit_empty_stdout)
+    store = build_atelier_store(beads=async_client)
+
+    review = _RUN(
+        store.update_review(
+            UpdateReviewRequest(
+                changeset_id="at-change",
+                review=ReviewMetadata(
+                    pr_state=ReviewState.IN_REVIEW,
+                    review_owner="reviewer-b",
+                    integrated_sha="abc1234",
+                ),
+                preserve_existing=True,
+            )
+        )
+    )
+
+    refreshed = _RUN(store._show_issue("at-change"))
+    assert attempts == 1
+    assert review.review.pr_state is ReviewState.IN_REVIEW
+    assert review.review.review_owner == "reviewer-b"
+    assert review.review.integrated_sha == "abc1234"
+    assert refreshed.description is not None
+    assert "pr_state: in-review" in refreshed.description
+    assert "review_owner: reviewer-b" in refreshed.description
+    assert "changeset.integrated_sha: abc1234" in refreshed.description
+
+
+def test_update_review_fails_closed_when_empty_update_stdout_lacks_convergence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_client, _issue_store = build_in_memory_beads_client(issues=_parity_seed_issues())
+
+    async def fail_with_empty_stdout(request):
+        del request
+        raise BeadsParseError("expected JSON output from update, received empty stdout")
+
+    monkeypatch.setattr(async_client, "update", fail_with_empty_stdout)
+    store = build_atelier_store(beads=async_client)
+
+    with pytest.raises(RuntimeError, match="review metadata update could not be verified"):
+        _RUN(
+            store.update_review(
+                UpdateReviewRequest(
+                    changeset_id="at-change",
+                    review=ReviewMetadata(
+                        pr_state=ReviewState.IN_REVIEW,
+                        review_owner="reviewer-b",
+                        integrated_sha="abc1234",
+                    ),
+                    preserve_existing=True,
+                )
+            )
+        )
+
+
 def test_append_notes_retries_after_concurrent_description_conflict(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -364,6 +443,49 @@ def test_append_notes_retries_after_concurrent_description_conflict(
     assert appended.id == "at-change"
     assert refreshed.description is not None
     assert "planner_update: concurrent verification note" in refreshed.description
+    assert refreshed.description.rstrip("\n").endswith(worker_note)
+
+
+def test_append_notes_verifies_after_empty_update_stdout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_client, issue_store = build_in_memory_beads_client(issues=_parity_seed_issues())
+    attempts = 0
+    worker_note = "worker_update: preserved lifecycle mutation parity"
+
+    async def update_then_emit_empty_stdout(request):
+        nonlocal attempts
+        attempts += 1
+        issue_store.update(
+            request.issue_id,
+            title=request.title,
+            description=request.description,
+            design=request.design,
+            acceptance_criteria=request.acceptance_criteria,
+            status=request.status,
+            assignee=request.assignee,
+            priority=request.priority,
+            estimate=request.estimate,
+            labels=request.labels if request.labels else None,
+        )
+        raise BeadsParseError("expected JSON output from update, received empty stdout")
+
+    monkeypatch.setattr(async_client, "update", update_then_emit_empty_stdout)
+    store = build_atelier_store(beads=async_client)
+
+    appended = _RUN(
+        store.append_notes(
+            AppendNotesRequest(
+                issue_id="at-change",
+                notes=(worker_note,),
+            )
+        )
+    )
+
+    refreshed = _RUN(store._show_issue("at-change"))
+    assert attempts == 1
+    assert appended.id == "at-change"
+    assert refreshed.description is not None
     assert refreshed.description.rstrip("\n").endswith(worker_note)
 
 


### PR DESCRIPTION
# Summary

- Recover store-backed update mutations when the process-backed Beads update
  command returns empty stdout but a fresh read proves convergence.
- Keep the recovery contract store-owned and fail closed when convergence
  cannot be verified.

# Changes

- Teach `AtelierStore._update_issue_until_verified` to re-read and accept
  convergence only for the narrow empty-stdout update case.
- Add regression coverage for review metadata persistence, note appends, and
  fail-closed non-convergence.
- Document the fresh-read convergence contract in the Atelier store contract.

# Testing

- `just format`
- `just lint`
- `env -u PYTHONPATH -u VIRTUAL_ENV just test`

# Tickets

- Fixes #729

# Risks / Rollout

- The behavior change is limited to store-backed update mutations; create,
  close, and dependency command semantics are unchanged.

# Notes

- Legacy worker compatibility paths that still call `sync_client.update(...)`
  remain out of scope for this slice.
