### PR TITLE
Repair finalize review updates after empty bd update stdout

### DIFF
--- a/src/atelier/store/beads_store.py
+++ b/src/atelier/store/beads_store.py
@@ -1613,19 +1613,23 @@ class AtelierStore:
             history = await self._beads.description_history(issue_id)
         except Exception:
             return None
-        for previous_description, new_description in reversed(history[evidence.history_length :]):
-            if not _same_description_value(new_description, evidence.requested_description):
-                continue
-            if not _same_description_value(previous_description, evidence.previous_description):
-                continue
-            candidate = refreshed.model_copy(update={"description": evidence.requested_description})
-            if not verify(candidate):
-                continue
-            atelier_log.info(
-                f"issue={issue_id} converged from description history after empty update stdout"
-            )
-            return candidate
-        return None
+        post_snapshot_history = history[evidence.history_length :]
+        if not post_snapshot_history:
+            return None
+        latest_previous, latest_description = post_snapshot_history[-1]
+        if not _same_description_value(refreshed.description, evidence.previous_description):
+            return None
+        if not _same_description_value(latest_description, evidence.requested_description):
+            return None
+        if not _same_description_value(latest_previous, evidence.previous_description):
+            return None
+        candidate = refreshed.model_copy(update={"description": evidence.requested_description})
+        if not verify(candidate):
+            return None
+        atelier_log.info(
+            f"issue={issue_id} converged from description history after empty update stdout"
+        )
+        return candidate
 
     async def _fail_closed_created_issue(
         self,

--- a/tests/atelier/test_store_contract.py
+++ b/tests/atelier/test_store_contract.py
@@ -513,6 +513,60 @@ def test_update_review_fails_closed_when_history_evidence_does_not_match_request
         )
 
 
+def test_update_review_fails_closed_when_later_history_entry_diverges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async_client, issue_store = build_in_memory_beads_client(issues=_parity_seed_issues())
+    store = build_atelier_store(beads=async_client)
+    original_show = store._show_issue
+    stale_reads_enabled = False
+    stale_issue = _RUN(original_show("at-change"))
+
+    async def stale_show(issue_id: str):
+        if issue_id == "at-change" and stale_reads_enabled:
+            return stale_issue
+        return await original_show(issue_id)
+
+    async def update_then_emit_empty_stdout(request):
+        nonlocal stale_reads_enabled
+        issue_store.update(
+            request.issue_id,
+            title=request.title,
+            description=request.description,
+            design=request.design,
+            acceptance_criteria=request.acceptance_criteria,
+            status=request.status,
+            assignee=request.assignee,
+            priority=request.priority,
+            estimate=request.estimate,
+            labels=request.labels if request.labels else None,
+        )
+        issue_store.update(
+            request.issue_id,
+            description=(request.description or "").replace("reviewer-b", "reviewer-c"),
+        )
+        stale_reads_enabled = True
+        raise BeadsParseError("expected JSON output from update, received empty stdout")
+
+    monkeypatch.setattr(store, "_show_issue", stale_show)
+    monkeypatch.setattr(async_client, "update", update_then_emit_empty_stdout)
+
+    with pytest.raises(RuntimeError, match="review metadata update could not be verified"):
+        _RUN(
+            store.update_review(
+                UpdateReviewRequest(
+                    changeset_id="at-change",
+                    review=ReviewMetadata(
+                        pr_state=ReviewState.IN_REVIEW,
+                        review_owner="reviewer-b",
+                        integrated_sha="abc1234",
+                    ),
+                    preserve_existing=True,
+                )
+            )
+        )
+
+
 def test_append_notes_retries_after_concurrent_description_conflict(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
# Summary

- Repair finalize review-metadata updates after empty `bd update --json` output by accepting only exact attempt-local description-history proof when the immediate follow-up read is stale.
- Keep finalize fail-closed when that proof is missing or does not match the requested review mutation.

# Changes

- Add attempt-scoped description-history evidence capture and verification in `AtelierStore._update_issue_until_verified`, enabled only for `update_review`.
- Preserve the existing bounded fresh-read recovery path and keep non-converged empty-stdout review updates blocked instead of silently finalizing.
- Add store-contract regressions for stale-read recovery and non-matching history evidence.

# Testing

- `just format`
- `just lint`
- `just test`

# Tickets

- Fixes #731

# Risks / Rollout

- Scoped to review-metadata verification after empty update stdout.
- Other store mutation paths keep their existing behavior.

# Notes

- Draft PR to match the project's sequential draft-PR policy.
