### PR TITLE
Surface event-history overflow during review verification

### DIFF
--- a/src/atelier/lib/beads/process.py
+++ b/src/atelier/lib/beads/process.py
@@ -43,6 +43,10 @@ from .models import (
 
 _SEMVER_SEARCH: Pattern[str] = compile(r"\bv?(\d+)\.(\d+)\.(\d+)\b")
 _FLAG_SEARCH: Pattern[str] = compile(r"--[a-z0-9][a-z0-9-]*")
+_EVENT_HISTORY_OVERFLOW_COLUMN_SEARCH: Pattern[str] = compile(
+    r"too large for column '([^']+)'",
+    flags=0,
+)
 _JSON_FLAG = "--json"
 _STARTUP_COUNT_SKEW_RECHECK_ATTEMPTS = 2
 _STARTUP_READY = "ready"
@@ -159,6 +163,19 @@ def _short_detail(value: str | None) -> str | None:
     if not flattened:
         return None
     return flattened[:220]
+
+
+def _parse_error_detail(result: BeadsCommandResult) -> str | None:
+    stderr = result.stderr.strip()
+    if stderr:
+        normalized = " ".join(part for part in stderr.splitlines() if part.strip())
+        lowered = normalized.lower()
+        if "failed to record event" in lowered:
+            match = _EVENT_HISTORY_OVERFLOW_COLUMN_SEARCH.search(normalized)
+            if match is not None:
+                return f"failed to record event: too large for column '{match.group(1)}'"
+        return _short_detail(stderr)
+    return _short_detail(result.stdout.strip())
 
 
 def _configured_backend(beads_root: Path) -> str | None:
@@ -829,5 +846,8 @@ def _parse_error(
     *,
     operation: SupportedOperation,
 ) -> BeadsParseError:
-    del result, operation
+    del operation
+    detail = _parse_error_detail(result)
+    if detail:
+        return BeadsParseError(f"{message} ({detail})")
     return BeadsParseError(message)

--- a/src/atelier/store/beads_store.py
+++ b/src/atelier/store/beads_store.py
@@ -107,6 +107,11 @@ _CONCURRENT_DESCRIPTION_UPDATE_ERROR_MARKERS = (
     "description update conflict",
 )
 _EMPTY_UPDATE_STDOUT_PARSE_ERROR = "expected JSON output from update, received empty stdout"
+_EVENT_HISTORY_OVERFLOW_ERROR_MARKERS = (
+    "failed to record event",
+    "too large for column 'old_value'",
+    "too large for column 'new_value'",
+)
 
 
 def _clean_text(value: object) -> str | None:
@@ -151,7 +156,26 @@ def _log_description_conflict_convergence(
 
 
 def _is_empty_output_update_parse_error(error: BeadsParseError) -> bool:
-    return str(error).strip() == _EMPTY_UPDATE_STDOUT_PARSE_ERROR
+    return str(error).strip().startswith(_EMPTY_UPDATE_STDOUT_PARSE_ERROR)
+
+
+def _is_event_history_overflow_detail(detail: str) -> bool:
+    normalized = detail.lower()
+    return _EVENT_HISTORY_OVERFLOW_ERROR_MARKERS[0] in normalized and (
+        _EVENT_HISTORY_OVERFLOW_ERROR_MARKERS[1] in normalized
+        or _EVENT_HISTORY_OVERFLOW_ERROR_MARKERS[2] in normalized
+    )
+
+
+def _event_history_overflow_failure_detail(
+    issue_id: str,
+    *,
+    detail: str | None = None,
+) -> str:
+    failure = f"event-history overflow blocked the mutation for {issue_id}"
+    if detail:
+        return f"{failure} ({detail})"
+    return failure
 
 
 def _same_description_value(left: str | None, right: str | None) -> bool:
@@ -1499,6 +1523,7 @@ class AtelierStore:
         eventually fails closed with ``failure_message``.
         """
         conflict_retries = 0
+        last_failure_detail: str | None = None
         for _attempt in range(_MAX_UPDATE_ATTEMPTS):
             current = await self._show_issue(issue_id)
             if verify(current):
@@ -1507,6 +1532,7 @@ class AtelierStore:
                     conflict_retries=conflict_retries,
                 )
                 return current
+            last_failure_detail = None
             request = build_request(current)
             history_evidence = await self._description_history_evidence(
                 issue_id=issue_id,
@@ -1561,6 +1587,17 @@ class AtelierStore:
                         conflict_retries=conflict_retries,
                     )
                     return history_verified
+                if _is_event_history_overflow_detail(str(exc)):
+                    raise RuntimeError(
+                        _event_history_overflow_failure_detail(
+                            issue_id,
+                            detail=str(exc).strip(),
+                        )
+                    ) from exc
+                last_failure_detail = (
+                    "empty update stdout did not converge via fresh read or description "
+                    "history evidence"
+                )
                 continue
             if verify(updated):
                 _log_description_conflict_convergence(
@@ -1575,6 +1612,9 @@ class AtelierStore:
                     conflict_retries=conflict_retries,
                 )
                 return refreshed
+            last_failure_detail = "update response did not satisfy verification after refresh"
+        if last_failure_detail is not None:
+            raise RuntimeError(f"{failure_message}: {last_failure_detail}")
         raise RuntimeError(failure_message)
 
     async def _description_history_evidence(

--- a/tests/atelier/test_store_contract.py
+++ b/tests/atelier/test_store_contract.py
@@ -567,6 +567,28 @@ def test_update_review_fails_closed_when_later_history_entry_diverges(
         )
 
 
+def test_update_review_fails_closed_with_event_history_overflow_detail() -> None:
+    command_backend = InMemoryBeadsBackend(seeded_issues=_parity_seed_issues())
+    transport = _EventOverflowSubprocessTransport(command_backend)
+    client = SubprocessBeadsClient(transport=transport)
+    store = build_atelier_store(beads=client)
+    with pytest.raises(
+        RuntimeError,
+        match="event-history overflow blocked the mutation.*too large for column 'old_value'",
+    ):
+        _RUN(
+            store.update_review(
+                UpdateReviewRequest(
+                    changeset_id="at-change",
+                    review=ReviewMetadata(pr_state=ReviewState.MERGED),
+                    preserve_existing=True,
+                )
+            )
+        )
+
+    assert transport.overflow_attempts == 1
+
+
 def test_append_notes_retries_after_concurrent_description_conflict(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -882,6 +904,34 @@ class _InMemorySubprocessTransport:
             stdout=completed.stdout,
             stderr=completed.stderr,
         )
+
+
+class _EventOverflowSubprocessTransport(_InMemorySubprocessTransport):
+    """Simulate a subprocess update blocked by event-history overflow."""
+
+    def __init__(self, backend: InMemoryBeadsBackend, *, issue_id: str = "at-change") -> None:
+        super().__init__(backend)
+        self._issue_id = issue_id
+        self.repaired = False
+        self.overflow_attempts = 0
+
+    async def execute(self, request: BeadsCommandRequest) -> BeadsCommandResult:
+        if (
+            request.argv[:4] == ("bd", "update", self._issue_id, "--json")
+            and "--description" in request.argv
+            and not self.repaired
+        ):
+            self.overflow_attempts += 1
+            return BeadsCommandResult(
+                argv=request.argv,
+                returncode=0,
+                stdout="",
+                stderr=(
+                    f"Error updating {self._issue_id}: failed to record event: "
+                    "Error 1105 (HY000): string is too large for column 'old_value'"
+                ),
+            )
+        return await super().execute(request)
 
 
 def _parity_seed_issues() -> tuple[dict[str, object], ...]:


### PR DESCRIPTION
# Summary

- Preserve the underlying event-history overflow cause when review metadata updates hit the remaining empty-stdout finalize failure.
- Fail closed with that explicit overflow class instead of collapsing back into the generic `review metadata update could not be verified` error.

# Changes

- Preserve concise stderr detail from subprocess-backed `bd update --json` parse failures when stdout is unexpectedly empty.
- Teach store-side review verification to distinguish the already-fixed convergent empty-stdout path from the remaining overflow-shaped empty-stdout failure.
- Add regression coverage for the `failed to record event` / `too large for column 'old_value'` update shape seen on `at-rhxbc.3`.

# Testing

- `pytest -q tests/atelier/test_store_contract.py -k 'update_review or event_history_overflow'`
- `python -m pytest tests/atelier/test_store_contract.py tests/atelier/lib/test_beads.py -k 'update_review or event_history_overflow or subprocess_client_reads_description_history_from_events_db'`
- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #733

# Risks / Rollout

- This change is intentionally fail-closed for the remaining non-convergent overflow case; finalize will still stop there, but it now stops with the preserved cause instead of a generic verification failure.

# Notes

- The publish check wrapper needed `PATH` prefixed with `/opt/homebrew/bin` so its `bash -lc` environment resolved the newer Bash required by the repo hook shell tests.
