### PR TITLE
Repair oversized Beads snapshot overflow recovery

### DIFF
--- a/docs/event-history-overflow-recovery.md
+++ b/docs/event-history-overflow-recovery.md
@@ -29,13 +29,22 @@ deterministic:
 
 1. Primes the project-scoped Beads store.
 1. Creates a verified SQLite backup before mutating a SQLite-backed store.
-1. Compacts oversized historical notes for the target issue.
-1. Verifies that the issue is mutable again before reporting success.
+1. Checks the full serialized issue snapshot against the safe mutation budget
+   used for representative note/status writes.
+1. Compacts oversized historical notes for the target issue when that can bring
+   the snapshot back under the safe budget.
+1. Emits convergence evidence only when the repaired snapshot proves the
+   supported mutation classes are safe again.
 1. Prints backend-specific guidance for inspecting pre-repair content.
 
 For Dolt-backed stores, the output points operators at `bd history` and
 `bd restore`. For SQLite-backed stores, the output reports the backup path to
 inspect if the full pre-repair notes are needed.
+
+If large dependency payloads or other serialized fields still keep the issue
+above the safe mutation budget after note compaction, the command now fails
+closed with an explicit `repair unavailable for this mutation class` diagnostic
+instead of reporting a false `verified_mutable: true` result.
 
 ## After Repair
 

--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -26,7 +26,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from . import bd_invocation, changesets, config, exec, git, lifecycle, messages, paths, prs
 from . import log as atelier_log
-from .external_tickets import ExternalTicketRef, external_ticket_payload
+from .external_tickets import ExternalTicketRef
 from .io import die, say
 from .lib.beads.description_fields import (
     normalize_description as _normalize_description_text,
@@ -121,6 +121,10 @@ _EVENT_HISTORY_REPAIR_TARGET_BYTES = (
     _EVENT_HISTORY_VALUE_TEXT_LIMIT_BYTES - _EVENT_HISTORY_REPAIR_HEADROOM_BYTES
 )
 _EVENT_HISTORY_REPAIR_MARKER = "overflow_repair:"
+_EVENT_HISTORY_REPAIR_VERIFIED_MUTATION_CLASSES = (
+    "notes_append",
+    "status_transition",
+)
 _DOLT_SERVER_PRECHECK_BYPASS_COMMANDS = {
     "completion",
     "doctor",
@@ -452,6 +456,8 @@ class EventHistoryOverflowRepairResult:
     snapshot_bytes_before: int
     snapshot_bytes_after: int
     retained_notes_chars: int
+    verified_mutation_classes: tuple[str, ...]
+    convergence_evidence: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -4839,6 +4845,24 @@ def _issue_snapshot_bytes(issue: dict[str, object]) -> int:
     return len(payload.encode("utf-8"))
 
 
+def _snapshot_within_event_history_repair_target(snapshot_bytes: int) -> bool:
+    return snapshot_bytes <= _EVENT_HISTORY_REPAIR_TARGET_BYTES
+
+
+def _event_history_repair_convergence_evidence(
+    *,
+    snapshot_bytes_before: int,
+    snapshot_bytes_after: int,
+    verified_mutation_classes: tuple[str, ...],
+) -> tuple[str, ...]:
+    return (
+        f"snapshot_bytes_before={snapshot_bytes_before}",
+        f"snapshot_bytes_after={snapshot_bytes_after}",
+        f"safe_snapshot_target_bytes={_EVENT_HISTORY_REPAIR_TARGET_BYTES}",
+        f"verified_mutation_classes={','.join(verified_mutation_classes)}",
+    )
+
+
 def event_history_overflow_recovery_guidance(*, issue_id: str, backend: str | None) -> str:
     """Describe how operators can inspect repaired note history by backend.
 
@@ -5012,11 +5036,12 @@ def repair_issue_event_history_overflow(
     """Repair issue notes when Beads event-history overflow blocks mutation.
 
     The repair path is explicit and rerunnable:
-    1. Reproduce the failure with a no-op lifecycle write.
-    2. Compact only historical notes through a direct database update that
-       bypasses event recording.
-    3. Re-run the same no-op lifecycle write to verify the issue is mutable
-       again before reporting success.
+    1. Measure the full serialized issue snapshot against the safe mutation
+       budget, not just the notes payload.
+    2. When required, compact only historical notes through a direct database
+       update that bypasses event recording.
+    3. Re-run a bounded verification write and emit convergence evidence only
+       when the resulting snapshot remains within the safe mutation budget.
 
     Args:
         issue_id: Bead identifier to repair.
@@ -5045,36 +5070,47 @@ def repair_issue_event_history_overflow(
         issue = issues[0]
         status = _clean_text(issue.get("status")) or "open"
         snapshot_bytes_before = _issue_snapshot_bytes(issue)
-
-        noop_result = run_bd_command(
-            ["update", cleaned_issue_id, "--status", status],
-            beads_root=beads_root,
-            cwd=cwd,
-            allow_failure=True,
+        verified_mutation_classes = _EVENT_HISTORY_REPAIR_VERIFIED_MUTATION_CLASSES
+        snapshot_requires_repair = not _snapshot_within_event_history_repair_target(
+            snapshot_bytes_before
         )
-        if noop_result.returncode == 0:
-            return EventHistoryOverflowRepairResult(
-                issue_id=cleaned_issue_id,
-                repaired=False,
-                verified_mutable=True,
-                snapshot_bytes_before=snapshot_bytes_before,
-                snapshot_bytes_after=snapshot_bytes_before,
-                retained_notes_chars=len(str(issue.get("notes") or "")),
-            )
 
-        noop_detail = _command_output_detail(
-            exec.CommandResult(
-                argv=tuple(noop_result.args),
-                returncode=noop_result.returncode,
-                stdout=noop_result.stdout,
-                stderr=noop_result.stderr,
+        if not snapshot_requires_repair:
+            noop_result = run_bd_command(
+                ["update", cleaned_issue_id, "--status", status],
+                beads_root=beads_root,
+                cwd=cwd,
+                allow_failure=True,
             )
-        )
-        if not _is_event_history_overflow_detail(noop_detail):
-            raise RuntimeError(
-                "issue mutation failed, but the error did not match event-history "
-                f"overflow for {cleaned_issue_id}: {noop_detail or 'unknown failure'}"
+            if noop_result.returncode == 0:
+                return EventHistoryOverflowRepairResult(
+                    issue_id=cleaned_issue_id,
+                    repaired=False,
+                    verified_mutable=True,
+                    snapshot_bytes_before=snapshot_bytes_before,
+                    snapshot_bytes_after=snapshot_bytes_before,
+                    retained_notes_chars=len(str(issue.get("notes") or "")),
+                    verified_mutation_classes=verified_mutation_classes,
+                    convergence_evidence=_event_history_repair_convergence_evidence(
+                        snapshot_bytes_before=snapshot_bytes_before,
+                        snapshot_bytes_after=snapshot_bytes_before,
+                        verified_mutation_classes=verified_mutation_classes,
+                    ),
+                )
+
+            noop_detail = _command_output_detail(
+                exec.CommandResult(
+                    argv=tuple(noop_result.args),
+                    returncode=noop_result.returncode,
+                    stdout=noop_result.stdout,
+                    stderr=noop_result.stderr,
+                )
             )
+            if not _is_event_history_overflow_detail(noop_detail):
+                raise RuntimeError(
+                    "issue mutation failed, but the error did not match event-history "
+                    f"overflow for {cleaned_issue_id}: {noop_detail or 'unknown failure'}"
+                )
 
         repair_notes = _find_overflow_repair_notes(
             cleaned_issue_id,
@@ -5083,8 +5119,12 @@ def repair_issue_event_history_overflow(
         )
         if repair_notes is None:
             raise RuntimeError(
-                "event-history overflow repair requires notes compaction, but the "
-                f"issue has no repairable notes payload: {cleaned_issue_id}"
+                "event-history overflow repair could not bring the full issue snapshot "
+                f"for {cleaned_issue_id} under the safe mutation size "
+                f"({_EVENT_HISTORY_REPAIR_TARGET_BYTES} bytes); "
+                "notes compaction is unavailable or insufficient, so large "
+                "dependencies or other serialized fields still dominate the "
+                "snapshot. Repair unavailable for this mutation class."
             )
         repaired_notes, estimated_snapshot_bytes_after, retained_notes_chars = repair_notes
         _repair_overflowed_issue_notes_sql(
@@ -5108,10 +5148,13 @@ def repair_issue_event_history_overflow(
                 f"overflow repair could not be verified for {cleaned_issue_id}: notes mismatch"
             )
         snapshot_bytes_after = _issue_snapshot_bytes(repaired_issue)
-        if snapshot_bytes_after > _EVENT_HISTORY_REPAIR_TARGET_BYTES:
+        if not _snapshot_within_event_history_repair_target(snapshot_bytes_after):
             raise RuntimeError(
-                f"overflow repair for {cleaned_issue_id} remained above the safe snapshot "
-                f"size ({snapshot_bytes_after} > {_EVENT_HISTORY_REPAIR_TARGET_BYTES})"
+                f"overflow repair for {cleaned_issue_id} compacted notes, but the full "
+                "issue snapshot remained above the safe mutation size "
+                f"({snapshot_bytes_after} > {_EVENT_HISTORY_REPAIR_TARGET_BYTES}); "
+                "large dependencies or other serialized fields still dominate "
+                "the snapshot. Repair unavailable for this mutation class."
             )
 
         verify_result = run_bd_command(
@@ -5140,6 +5183,12 @@ def repair_issue_event_history_overflow(
             snapshot_bytes_before=snapshot_bytes_before,
             snapshot_bytes_after=min(snapshot_bytes_after, estimated_snapshot_bytes_after),
             retained_notes_chars=retained_notes_chars,
+            verified_mutation_classes=verified_mutation_classes,
+            convergence_evidence=_event_history_repair_convergence_evidence(
+                snapshot_bytes_before=snapshot_bytes_before,
+                snapshot_bytes_after=min(snapshot_bytes_after, estimated_snapshot_bytes_after),
+                verified_mutation_classes=verified_mutation_classes,
+            ),
         )
 
 

--- a/src/atelier/commands/repair_event_history.py
+++ b/src/atelier/commands/repair_event_history.py
@@ -102,6 +102,7 @@ def repair_event_history_overflow(args: object) -> None:
     payload = {
         "backend": backend,
         "backup_path": str(backup_path) if backup_path is not None else None,
+        "convergence_evidence": result.convergence_evidence,
         "issue_id": issue_id,
         "recovery_guidance": beads.event_history_overflow_recovery_guidance(
             issue_id=issue_id,
@@ -112,6 +113,7 @@ def repair_event_history_overflow(args: object) -> None:
         "snapshot_bytes_after": result.snapshot_bytes_after,
         "snapshot_bytes_before": result.snapshot_bytes_before,
         "verified_mutable": result.verified_mutable,
+        "verified_mutation_classes": result.verified_mutation_classes,
     }
     if format_value == "json":
         say(json.dumps(payload, indent=2, sort_keys=True))
@@ -126,6 +128,8 @@ def repair_event_history_overflow(args: object) -> None:
         say(f"-> sqlite backup: {backup_path}")
     say(f"-> snapshot bytes: {result.snapshot_bytes_before} -> {result.snapshot_bytes_after}")
     say(f"-> retained recent notes chars: {result.retained_notes_chars}")
+    say(f"-> verified mutation classes: {', '.join(result.verified_mutation_classes)}")
+    say(f"-> convergence evidence: {'; '.join(result.convergence_evidence)}")
     say(
         "-> recovery guidance: "
         f"{beads.event_history_overflow_recovery_guidance(issue_id=issue_id, backend=backend)}"

--- a/src/atelier/lib/beads/overflow.py
+++ b/src/atelier/lib/beads/overflow.py
@@ -16,6 +16,28 @@ class EventHistoryOverflowRepairResult:
     snapshot_bytes_before: int
     snapshot_bytes_after: int
     retained_notes_chars: int
+    verified_mutation_classes: tuple[str, ...]
+    convergence_evidence: tuple[str, ...]
+
+
+_REQUIRED_MUTATION_CLASSES = frozenset({"notes_append", "status_transition"})
+
+
+def _parse_convergence_evidence(
+    result: EventHistoryOverflowRepairResult,
+) -> dict[str, str] | None:
+    raw_evidence = getattr(result, "convergence_evidence", None)
+    if not isinstance(raw_evidence, tuple) or not raw_evidence:
+        return None
+    parsed: dict[str, str] = {}
+    for entry in raw_evidence:
+        if not isinstance(entry, str) or "=" not in entry:
+            return None
+        key, value = entry.split("=", 1)
+        if not key or not value or key in parsed:
+            return None
+        parsed[key] = value
+    return parsed
 
 
 @runtime_checkable
@@ -53,8 +75,25 @@ def overflow_repair_result_proves_convergence(
     issue_id: str, result: EventHistoryOverflowRepairResult
 ) -> bool:
     """Return whether a repair result proves the target issue is mutable."""
-
-    return result.issue_id == issue_id and result.verified_mutable is True
+    if result.issue_id != issue_id or result.verified_mutable is not True:
+        return False
+    classes = getattr(result, "verified_mutation_classes", None)
+    if not isinstance(classes, tuple) or not _REQUIRED_MUTATION_CLASSES.issubset(classes):
+        return False
+    evidence = _parse_convergence_evidence(result)
+    if evidence is None:
+        return False
+    try:
+        before = int(evidence["snapshot_bytes_before"])
+        after = int(evidence["snapshot_bytes_after"])
+        target = int(evidence["safe_snapshot_target_bytes"])
+    except (KeyError, ValueError):
+        return False
+    if before != result.snapshot_bytes_before or after != result.snapshot_bytes_after:
+        return False
+    if evidence.get("verified_mutation_classes") != ",".join(classes):
+        return False
+    return after <= target
 
 
 async def maybe_repair_after_event_history_overflow(

--- a/src/atelier/lib/beads/process.py
+++ b/src/atelier/lib/beads/process.py
@@ -327,6 +327,8 @@ class SubprocessBeadsClient(Beads):
             snapshot_bytes_before=repair_result.snapshot_bytes_before,
             snapshot_bytes_after=repair_result.snapshot_bytes_after,
             retained_notes_chars=repair_result.retained_notes_chars,
+            verified_mutation_classes=repair_result.verified_mutation_classes,
+            convergence_evidence=repair_result.convergence_evidence,
         )
 
     async def inspect_environment(self) -> BeadsEnvironment:

--- a/tests/atelier/commands/test_repair_event_history.py
+++ b/tests/atelier/commands/test_repair_event_history.py
@@ -36,6 +36,13 @@ def test_repair_event_history_overflow_json_reports_sqlite_backup() -> None:
             snapshot_bytes_before=90000,
             snapshot_bytes_after=32000,
             retained_notes_chars=4096,
+            verified_mutation_classes=("notes_append", "status_transition"),
+            convergence_evidence=(
+                "snapshot_bytes_before=90000",
+                "snapshot_bytes_after=32000",
+                "safe_snapshot_target_bytes=49151",
+                "verified_mutation_classes=notes_append,status_transition",
+            ),
         )
 
         with (
@@ -74,6 +81,10 @@ def test_repair_event_history_overflow_json_reports_sqlite_backup() -> None:
     assert payload["issue_id"] == "at-overflow"
     assert payload["repaired"] is True
     assert payload["verified_mutable"] is True
+    assert payload["verified_mutation_classes"] == ["notes_append", "status_transition"]
+    assert payload["convergence_evidence"][-1] == (
+        "verified_mutation_classes=notes_append,status_transition"
+    )
     assert "does not support `bd history` or `bd restore`" in payload["recovery_guidance"]
 
 
@@ -96,6 +107,13 @@ def test_repair_event_history_overflow_table_uses_dolt_guidance_without_backup()
             snapshot_bytes_before=1200,
             snapshot_bytes_after=1200,
             retained_notes_chars=12,
+            verified_mutation_classes=("notes_append", "status_transition"),
+            convergence_evidence=(
+                "snapshot_bytes_before=1200",
+                "snapshot_bytes_after=1200",
+                "safe_snapshot_target_bytes=49151",
+                "verified_mutation_classes=notes_append,status_transition",
+            ),
         )
 
         with (
@@ -132,3 +150,4 @@ def test_repair_event_history_overflow_table_uses_dolt_guidance_without_backup()
     assert "sqlite backup" not in output
     assert "bd history at-overflow" in output
     assert "bd restore at-overflow" in output
+    assert "verified mutation classes: notes_append, status_transition" in output

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -6706,7 +6706,7 @@ def test_repair_issue_event_history_overflow_compacts_notes_and_restores_mutabil
         nonlocal status_attempts
         if args[:3] == ["update", "at-overflow", "--status"]:
             status_attempts += 1
-            if status_attempts == 1:
+            if status_attempts == 1 and not sql_calls:
                 return CompletedProcess(
                     args=["bd", *args],
                     returncode=1,
@@ -6749,7 +6749,11 @@ def test_repair_issue_event_history_overflow_compacts_notes_and_restores_mutabil
     assert result.verified_mutable is True
     assert result.snapshot_bytes_before > result.snapshot_bytes_after
     assert result.retained_notes_chars > 0
-    assert status_attempts == 2
+    assert result.verified_mutation_classes == ("notes_append", "status_transition")
+    assert result.convergence_evidence[-1] == (
+        "verified_mutation_classes=notes_append,status_transition"
+    )
+    assert status_attempts == 1
     assert sql_calls
     assert "UPDATE issues" in sql_calls[0]
     repaired_notes = str(issue_state["notes"])
@@ -6791,9 +6795,48 @@ def test_repair_issue_event_history_overflow_is_rerunnable_when_issue_is_already
     assert result.verified_mutable is True
     assert result.snapshot_bytes_before == result.snapshot_bytes_after
     assert result.retained_notes_chars == len(issue["notes"])
+    assert result.verified_mutation_classes == ("notes_append", "status_transition")
+    assert result.convergence_evidence[-1] == (
+        "verified_mutation_classes=notes_append,status_transition"
+    )
     run_command.assert_called_once_with(
         ["update", "at-safe", "--status", "open"],
         beads_root=Path("/beads"),
         cwd=Path("/repo"),
         allow_failure=True,
     )
+
+
+def test_repair_issue_event_history_overflow_fails_closed_for_oversized_dependency_snapshot() -> (
+    None
+):
+    issue = {
+        "id": "at-dependency-heavy",
+        "title": "Dependency heavy",
+        "description": "scope: repair event overflow\n",
+        "acceptance_criteria": "restore issue mutability\n",
+        "notes": "",
+        "status": "open",
+        "priority": 2,
+        "issue_type": "task",
+        "owner": "scott",
+        "created_at": "2026-03-26T00:00:00Z",
+        "created_by": "planner",
+        "updated_at": "2026-03-26T00:00:00Z",
+        "dependencies": [{"id": f"dep-{index}", "title": "x" * 256} for index in range(200)],
+    }
+
+    assert (
+        len(json.dumps(issue, separators=(",", ":"), ensure_ascii=False).encode("utf-8")) > 50_000
+    )
+
+    with patch.object(beads, "run_bd_json", return_value=[issue]):
+        with pytest.raises(
+            RuntimeError,
+            match=r"Repair unavailable for this mutation class",
+        ):
+            beads.repair_issue_event_history_overflow(
+                "at-dependency-heavy",
+                beads_root=Path("/beads"),
+                cwd=Path("/repo"),
+            )

--- a/tests/atelier/test_store_contract.py
+++ b/tests/atelier/test_store_contract.py
@@ -2156,7 +2156,19 @@ def test_update_review_repairs_event_history_overflow_and_retries(
 
     async def repair_event_history_overflow(issue_id: str):
         repairs.append(issue_id)
-        return SimpleNamespace(issue_id=issue_id, verified_mutable=True)
+        return SimpleNamespace(
+            issue_id=issue_id,
+            verified_mutable=True,
+            snapshot_bytes_before=90000,
+            snapshot_bytes_after=32000,
+            verified_mutation_classes=("notes_append", "status_transition"),
+            convergence_evidence=(
+                "snapshot_bytes_before=90000",
+                "snapshot_bytes_after=32000",
+                "safe_snapshot_target_bytes=49151",
+                "verified_mutation_classes=notes_append,status_transition",
+            ),
+        )
 
     monkeypatch.setattr(client, "repair_event_history_overflow", repair_event_history_overflow)
 
@@ -2201,8 +2213,8 @@ def test_update_review_fails_closed_when_overflow_repair_lacks_convergence_evide
         client, "is_event_history_overflow_detail", lambda detail: "old_value" in detail
     )
 
-    async def repair_event_history_overflow(_issue_id: str):
-        return SimpleNamespace(issue_id="wrong-issue", verified_mutable=False)
+    async def repair_event_history_overflow(issue_id: str):
+        return SimpleNamespace(issue_id=issue_id, verified_mutable=True)
 
     monkeypatch.setattr(client, "repair_event_history_overflow", repair_event_history_overflow)
 

--- a/tests/atelier/worker/test_store_adapter.py
+++ b/tests/atelier/worker/test_store_adapter.py
@@ -1,7 +1,6 @@
 import datetime as dt
 from pathlib import Path
 from types import SimpleNamespace
-from unittest.mock import patch
 
 import pytest
 
@@ -493,7 +492,19 @@ def test_mark_issue_blocked_repairs_event_history_overflow_and_retries(monkeypat
 
         def repair_event_history_overflow(self, issue_id):
             repairs.append(issue_id)
-            return SimpleNamespace(issue_id=issue_id, verified_mutable=True)
+            return SimpleNamespace(
+                issue_id=issue_id,
+                verified_mutable=True,
+                snapshot_bytes_before=90000,
+                snapshot_bytes_after=32000,
+                verified_mutation_classes=("notes_append", "status_transition"),
+                convergence_evidence=(
+                    "snapshot_bytes_before=90000",
+                    "snapshot_bytes_after=32000",
+                    "safe_snapshot_target_bytes=49151",
+                    "verified_mutation_classes=notes_append,status_transition",
+                ),
+            )
 
         def update(self, request):
             nonlocal attempts
@@ -550,8 +561,8 @@ def test_mark_issue_blocked_surfaces_overflow_repair_guidance_when_convergence_f
         def is_event_history_overflow_detail(self, detail):
             return "old_value" in detail
 
-        def repair_event_history_overflow(self, _issue_id):
-            return SimpleNamespace(issue_id="different-issue", verified_mutable=False)
+        def repair_event_history_overflow(self, issue_id):
+            return SimpleNamespace(issue_id=issue_id, verified_mutable=True)
 
         def update(self, _request):
             raise RuntimeError(


### PR DESCRIPTION
# Summary

- fail closed when Beads overflow repair cannot make oversized full-issue snapshots safe for real note/status mutations

# Changes

- gate `repair_issue_event_history_overflow` on full serialized issue snapshot size instead of trusting no-op lifecycle writes
- emit explicit notes/status mutation convergence evidence through the repair command and Beads client adapters
- add regression coverage and operator guidance for dependency-heavy snapshots that must report `repair unavailable for this mutation class`

# Testing

- `just format`
- `bash scripts/lint-gate.sh`
- `just test`

# Tickets

- None

# Risks / Rollout

- this only changes the overflow-repair path and its diagnostics, but it does make previously optimistic repair results fail closed when snapshots remain oversized

# Notes

- dependency-heavy changesets such as `at-xej3lf.3` now stop with explicit oversized-snapshot guidance instead of reporting a false `verified_mutable: true` result