### PR TITLE
Fix epic close when merged child PR metadata is stale

### DIFF
--- a/src/atelier/worker/epic_close.py
+++ b/src/atelier/worker/epic_close.py
@@ -43,7 +43,11 @@ def close_epic_if_complete(
     for candidate in changeset_candidates:
         if candidate.lifecycle.value != "closed":
             continue
-        if not worker_store.close_transition_has_active_pr_lifecycle(candidate):
+        if not worker_store.close_transition_has_active_pr_lifecycle(
+            candidate,
+            beads_root=beads_root,
+            repo_root=repo_root,
+        ):
             continue
         if not dry_run:
             worker_store.transition_lifecycle(

--- a/src/atelier/worker/store_adapter.py
+++ b/src/atelier/worker/store_adapter.py
@@ -11,7 +11,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import cast
 
-from .. import beads, changeset_fields, changesets, lifecycle, messages
+from .. import beads, changeset_fields, changesets, git, lifecycle, messages, prs
 from ..io import die
 from ..lib.beads import (
     CreateIssueRequest,
@@ -70,6 +70,7 @@ class EpicCloseCandidate:
     id: str
     lifecycle: LifecycleStatus
     review: StoreReviewMetadata
+    work_branch: str | None = None
 
 
 @dataclass(frozen=True)
@@ -187,6 +188,8 @@ def close_transition_has_active_pr_lifecycle(
         review_state = (
             candidate.review.pr_state.value if candidate.review.pr_state is not None else None
         )
+        integrated_sha = candidate.review.integrated_sha
+        work_branch = candidate.work_branch
     else:
         hydrated = candidate
         description = hydrated.get("description")
@@ -206,10 +209,56 @@ def close_transition_has_active_pr_lifecycle(
             description if isinstance(description, str) else ""
         )
         review_state = lifecycle.normalize_review_state(review.pr_state)
+        fields = changeset_fields.issue_fields(hydrated)
+        integrated_sha = changeset_fields.normalized_field(fields, "changeset.integrated_sha")
+        work_branch = changeset_fields.work_branch(hydrated)
+
+    terminal_proof = False
+    if lifecycle_status == LifecycleStatus.CLOSED.value and (
+        review_state == ReviewState.PUSHED.value
+        or lifecycle.is_active_pr_lifecycle_state(review_state)
+    ):
+        terminal_proof = _closed_candidate_has_terminal_proof(
+            integrated_sha=integrated_sha,
+            work_branch=work_branch,
+            repo_root=repo_root,
+        )
 
     if review_state == ReviewState.PUSHED.value:
-        return lifecycle_status == LifecycleStatus.CLOSED.value
+        return lifecycle_status == LifecycleStatus.CLOSED.value and not terminal_proof
+    if terminal_proof:
+        return False
     return lifecycle.is_active_pr_lifecycle_state(review_state)
+
+
+def _closed_candidate_has_terminal_proof(
+    *,
+    integrated_sha: str | None,
+    work_branch: str | None,
+    repo_root: Path | None,
+) -> bool:
+    """Return whether a closed candidate already has deterministic terminal proof."""
+
+    if integrated_sha:
+        return True
+    if repo_root is None or not work_branch:
+        return False
+    repo_slug = prs.github_repo_slug(git.git_origin_url(repo_root))
+    if not repo_slug:
+        return False
+    pushed = git.git_ref_exists(repo_root, f"refs/remotes/origin/{work_branch}")
+    lookup = prs.lookup_github_pr_status(repo_slug, work_branch)
+    if lookup.failed:
+        lookup = prs.lookup_github_pr_status(repo_slug, work_branch, refresh=True)
+    if not lookup.found or not isinstance(lookup.payload, dict):
+        return False
+    review_requested = prs.has_review_requests(lookup.payload)
+    live_pr_state = prs.lifecycle_state(
+        lookup.payload,
+        pushed=pushed,
+        review_requested=review_requested,
+    )
+    return live_pr_state in {ReviewState.MERGED.value, ReviewState.CLOSED.value}
 
 
 def _store_ids_to_payloads(
@@ -328,6 +377,7 @@ def _close_candidate_from_changeset(record: ChangesetRecord) -> EpicCloseCandida
         id=record.id,
         lifecycle=record.lifecycle,
         review=record.review,
+        work_branch=record.branches.work_branch if record.branches is not None else None,
     )
 
 

--- a/tests/atelier/worker/test_epic_close.py
+++ b/tests/atelier/worker/test_epic_close.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from atelier import prs
 from atelier.store import LifecycleStatus, ReviewMetadata, ReviewState
 from atelier.worker import epic_close
 from atelier.worker import store_adapter as worker_store
@@ -114,3 +115,86 @@ def test_close_epic_if_complete_reopens_active_pr_candidate(monkeypatch) -> None
 
     assert closed is False
     assert events == [("transition", "at-epic.1"), ("reconcile", "at-epic.1")]
+
+
+def test_close_epic_if_complete_keeps_closed_merged_child_terminal_when_review_state_is_stale(
+    monkeypatch,
+) -> None:
+    summary = worker_store.EpicChangesetSummary(
+        total=1,
+        ready=1,
+        merged=1,
+        abandoned=0,
+        remaining=0,
+    )
+    candidate = worker_store.EpicCloseCandidate(
+        id="at-epic.3",
+        lifecycle=LifecycleStatus.CLOSED,
+        review=ReviewMetadata(pr_state=ReviewState.DRAFT_PR),
+        work_branch="feat/at-epic.3",
+    )
+    events: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        worker_store,
+        "show_issue_lifecycle",
+        lambda issue_id, *, beads_root, repo_root: LifecycleStatus.IN_PROGRESS,
+    )
+    monkeypatch.setattr(
+        worker_store,
+        "has_work_children",
+        lambda epic_id, *, beads_root, repo_root, include_closed: True,
+    )
+    monkeypatch.setattr(
+        worker_store,
+        "list_epic_close_candidates",
+        lambda epic_id, *, beads_root, repo_root, include_closed: [candidate],
+    )
+    monkeypatch.setattr(
+        worker_store,
+        "epic_changeset_summary",
+        lambda epic_id, *, beads_root, repo_root: summary,
+    )
+    monkeypatch.setattr(
+        worker_store.git,
+        "git_origin_url",
+        lambda repo_root: "https://github.com/org/repo.git",
+    )
+    monkeypatch.setattr(worker_store.git, "git_ref_exists", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        worker_store.prs,
+        "lookup_github_pr_status",
+        lambda *args, **kwargs: prs.GithubPrLookup(
+            outcome="found",
+            payload={
+                "number": 737,
+                "state": "CLOSED",
+                "isDraft": False,
+                "reviewDecision": None,
+                "mergedAt": "2026-04-02T18:00:00Z",
+                "closedAt": "2026-04-02T18:00:00Z",
+            },
+        ),
+    )
+    monkeypatch.setattr(
+        worker_store,
+        "transition_lifecycle",
+        lambda issue_id, *, target_status, beads_root, repo_root: events.append(
+            ("transition", issue_id)
+        ),
+    )
+    monkeypatch.setattr(
+        worker_store,
+        "reconcile_reopened_external_tickets",
+        lambda issue_id, *, beads_root, repo_root: events.append(("reconcile", issue_id)),
+    )
+
+    closed = epic_close.close_epic_if_complete(
+        "at-epic",
+        None,
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    assert closed is True
+    assert events == [("transition", "at-epic")]

--- a/tests/atelier/worker/test_store_adapter.py
+++ b/tests/atelier/worker/test_store_adapter.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from atelier import prs
 from atelier.lib.beads import BeadsParseError, CloseIssueRequest, IssueRecord, SyncBeadsClient
 from atelier.messages import render_message
 from atelier.store import HookRecord, StartupMessageRecord, build_atelier_store
@@ -406,6 +407,47 @@ def test_close_transition_has_active_pr_lifecycle_treats_pushed_as_inactive_when
     assert (
         worker_store.close_transition_has_active_pr_lifecycle(
             {"status": "open", "description": "pr_state: pushed\n"}
+        )
+        is False
+    )
+
+
+def test_close_transition_has_active_pr_lifecycle_ignores_stale_active_state_with_live_merge(
+    monkeypatch,
+) -> None:
+    candidate = worker_store.EpicCloseCandidate(
+        id="at-epic.1",
+        lifecycle=worker_store.LifecycleStatus.CLOSED,
+        review=worker_store.StoreReviewMetadata(pr_state=worker_store.ReviewState.DRAFT_PR),
+        work_branch="feat/at-epic.1",
+    )
+
+    monkeypatch.setattr(
+        worker_store.git,
+        "git_origin_url",
+        lambda repo_root: "https://github.com/org/repo.git",
+    )
+    monkeypatch.setattr(worker_store.git, "git_ref_exists", lambda *args, **kwargs: True)
+    monkeypatch.setattr(
+        worker_store.prs,
+        "lookup_github_pr_status",
+        lambda *args, **kwargs: prs.GithubPrLookup(
+            outcome="found",
+            payload={
+                "number": 101,
+                "state": "CLOSED",
+                "isDraft": False,
+                "reviewDecision": None,
+                "mergedAt": "2026-04-02T18:00:00Z",
+                "closedAt": "2026-04-02T18:00:00Z",
+            },
+        ),
+    )
+
+    assert (
+        worker_store.close_transition_has_active_pr_lifecycle(
+            candidate,
+            repo_root=Path("/repo"),
         )
         is False
     )


### PR DESCRIPTION
# Summary

- Keep epic close from reopening already merged child changesets when stale stored PR metadata lags behind live terminal PR state.

# Changes

- Prefer deterministic terminal proof for closed epic-close candidates via `changeset.integrated_sha` or a live merged/closed GitHub PR lookup before treating stored review metadata as active.
- Pass repo context into the epic-close guard so typed changeset candidates can resolve live PR lifecycle before any reopen transition.
- Add regressions for the stale merged-child finalize-after-manual-close path and the typed store-adapter live-merge handling.

# Testing

- `just format`
- `just lint`
- `just test`

# Tickets

- None

# Risks / Rollout

- If live PR state cannot be determined safely and no integrated SHA is available, the close guard still fails closed instead of guessing.

# Notes

- Scoped to worker epic-close terminal-child handling; startup selection and broader overflow-repair behavior remain unchanged.
