### PR TITLE
fix(beads): verify Dolt overflow compaction persistence

### DIFF
--- a/docs/beads-facade-inventory.json
+++ b/docs/beads-facade-inventory.json
@@ -55,7 +55,7 @@
               "module": "atelier.beads"
             }
           ],
-          "dotted_refs": 332
+          "dotted_refs": 335
         }
       ]
     }

--- a/src/atelier/beads.py
+++ b/src/atelier/beads.py
@@ -5075,6 +5075,7 @@ def _verify_overflow_repair_backend_readback(
     backend: str | None,
     beads_root: Path,
     cwd: Path,
+    expected_notes: str | None = None,
 ) -> _OverflowRepairBackendReadback:
     last_readback: _OverflowRepairBackendReadback | None = None
     for _attempt in range(3):
@@ -5087,7 +5088,11 @@ def _verify_overflow_repair_backend_readback(
         if (
             last_readback is not None
             and isinstance(last_readback.notes, str)
-            and last_readback.notes.startswith(_EVENT_HISTORY_REPAIR_MARKER)
+            and (
+                last_readback.notes == expected_notes
+                if expected_notes is not None
+                else last_readback.notes.startswith(_EVENT_HISTORY_REPAIR_MARKER)
+            )
         ):
             return last_readback
         if _attempt < 2:
@@ -5096,6 +5101,8 @@ def _verify_overflow_repair_backend_readback(
     if last_readback is not None:
         if last_readback.notes is None:
             detail = "backend notes readback returned no string value"
+        elif expected_notes is not None:
+            detail = "backend notes readback did not preserve the repaired notes payload"
         else:
             detail = "backend notes readback did not return the repaired marker"
     raise RuntimeError(f"overflow repair could not be verified for {issue_id}: {detail}")
@@ -5200,7 +5207,7 @@ def repair_issue_event_history_overflow(
                 "dependencies or other serialized fields still dominate the "
                 "snapshot. Repair unavailable for this mutation class."
             )
-        repaired_notes, estimated_snapshot_bytes_after, retained_notes_chars = repair_notes
+        repaired_notes, _estimated_snapshot_bytes_after, retained_notes_chars = repair_notes
         _repair_overflowed_issue_notes_sql(
             issue_id=cleaned_issue_id,
             repaired_notes=repaired_notes,
@@ -5213,6 +5220,7 @@ def repair_issue_event_history_overflow(
             backend=backend,
             beads_root=beads_root,
             cwd=cwd,
+            expected_notes=repaired_notes,
         )
         refreshed = run_bd_json(["show", cleaned_issue_id], beads_root=beads_root, cwd=cwd)
         if refreshed:
@@ -5249,17 +5257,32 @@ def repair_issue_event_history_overflow(
                 f"overflow repair did not restore mutability for {cleaned_issue_id}: "
                 f"{verify_detail or 'verification write failed'}"
             )
+        verified_readback = _verify_overflow_repair_backend_readback(
+            issue_id=cleaned_issue_id,
+            backend=backend,
+            beads_root=beads_root,
+            cwd=cwd,
+            expected_notes=repaired_notes,
+        )
+        repaired_issue["notes"] = verified_readback.notes
+        snapshot_bytes_after = _issue_snapshot_bytes(repaired_issue)
+        if not _snapshot_within_event_history_repair_target(snapshot_bytes_after):
+            raise RuntimeError(
+                f"overflow repair for {cleaned_issue_id} passed the verification write, "
+                "but the persisted issue snapshot remained above the safe mutation size "
+                f"({snapshot_bytes_after} > {_EVENT_HISTORY_REPAIR_TARGET_BYTES})"
+            )
         return EventHistoryOverflowRepairResult(
             issue_id=cleaned_issue_id,
             repaired=True,
             verified_mutable=True,
             snapshot_bytes_before=snapshot_bytes_before,
-            snapshot_bytes_after=min(snapshot_bytes_after, estimated_snapshot_bytes_after),
+            snapshot_bytes_after=snapshot_bytes_after,
             retained_notes_chars=retained_notes_chars,
             verified_mutation_classes=verified_mutation_classes,
             convergence_evidence=_event_history_repair_convergence_evidence(
                 snapshot_bytes_before=snapshot_bytes_before,
-                snapshot_bytes_after=min(snapshot_bytes_after, estimated_snapshot_bytes_after),
+                snapshot_bytes_after=snapshot_bytes_after,
                 verified_mutation_classes=verified_mutation_classes,
             ),
         )

--- a/tests/atelier/test_beads.py
+++ b/tests/atelier/test_beads.py
@@ -7034,13 +7034,95 @@ def test_repair_issue_event_history_overflow_fails_closed_for_backend_readback_m
     ):
         with pytest.raises(
             RuntimeError,
-            match=r"backend notes readback did not return the repaired marker",
+            match=r"backend notes readback did not preserve the repaired notes payload",
         ):
             beads.repair_issue_event_history_overflow(
                 "at-overflow",
                 beads_root=Path("/beads"),
                 cwd=Path("/repo"),
             )
+
+
+def test_repair_issue_event_history_overflow_fails_closed_when_verification_write_loses_notes() -> (
+    None
+):
+    initial_notes = "old note line\n" * 5000
+    issue_state = {
+        "id": "at-overflow",
+        "title": "Overflowed issue",
+        "description": "scope: repair event overflow\n",
+        "acceptance_criteria": "restore issue mutability\n",
+        "notes": initial_notes,
+        "status": "in_progress",
+        "priority": 2,
+        "issue_type": "task",
+        "owner": "scott",
+        "created_at": "2026-03-26T00:00:00Z",
+        "created_by": "planner",
+        "updated_at": "2026-03-26T00:00:00Z",
+    }
+    repaired_notes = beads._render_overflow_repair_notes(
+        backend="dolt",
+        issue_id="at-overflow",
+        original_notes=initial_notes,
+        snapshot_bytes_before=beads._issue_snapshot_bytes(issue_state),
+        retained_notes_chars=beads._find_overflow_repair_notes(
+            "at-overflow",
+            issue_state,
+            backend="dolt",
+        )[2],
+    )
+    readback_notes = [repaired_notes, initial_notes]
+    status_attempts = 0
+
+    def fake_run_bd_json(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+    ) -> list[dict[str, object]]:
+        del beads_root, cwd
+        nonlocal readback_notes
+        if args[:2] == ["show", "at-overflow"]:
+            return [dict(issue_state)]
+        if args[0] == "sql":
+            current_notes = readback_notes.pop(0) if readback_notes else initial_notes
+            return [{"notes": current_notes}]
+        raise AssertionError(f"unexpected bd json command: {args}")
+
+    def fake_run_bd_command(
+        args: list[str],
+        *,
+        beads_root: Path,
+        cwd: Path,
+        allow_failure: bool = False,
+    ) -> CompletedProcess[str]:
+        del beads_root, cwd, allow_failure
+        nonlocal status_attempts
+        if args[:3] == ["update", "at-overflow", "--status"]:
+            status_attempts += 1
+            return CompletedProcess(args=["bd", *args], returncode=0, stdout="", stderr="")
+        if args[0] == "sql":
+            return CompletedProcess(args=["bd", *args], returncode=0, stdout="", stderr="")
+        raise AssertionError(f"unexpected bd command: {args}")
+
+    with (
+        patch("atelier.beads._configured_beads_backend", return_value="dolt"),
+        patch("atelier.beads.run_bd_json", side_effect=fake_run_bd_json),
+        patch("atelier.beads.run_bd_command", side_effect=fake_run_bd_command),
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match=r"backend notes readback did not preserve the repaired notes payload",
+        ):
+            beads.repair_issue_event_history_overflow(
+                "at-overflow",
+                beads_root=Path("/beads"),
+                cwd=Path("/repo"),
+            )
+
+    assert status_attempts == 1
+    assert not readback_notes
 
 
 def test_read_overflow_repair_backend_readback_uses_sqlite_when_metadata_is_invalid(


### PR DESCRIPTION
# Summary

- verify that Dolt overflow note compaction actually persists before finalize treats the repair as converged

# Changes

- require `repair_issue_event_history_overflow` to read back the exact repaired notes payload immediately after the direct compaction write
- re-read the backend after the bounded verification mutation and fail closed if the compacted notes payload is lost
- add a Dolt regression test for success-without-persistence behavior and refresh the checked-in beads facade inventory count

# Testing

- `just format`
- `just test`
- `just lint`

# Tickets

- Fixes #745

# Risks / Rollout

- this only changes the overflow repair verification path and its regression coverage
- if Dolt direct compaction still cannot be proven durable, the repair now remains explicitly blocked instead of allowing finalize to continue on false success

# Notes

- published as a draft PR under the project's sequential PR workflow
