### PR TITLE
Repair blocked verification after worker startup failures

### DIFF
--- a/docs/beads-facade-contract.md
+++ b/docs/beads-facade-contract.md
@@ -22,17 +22,15 @@ boundary that blocks new public facade growth.
 
 ## Retired symbols in this slice
 
-- `IssuePrefixRenamePreview`, `ExternalTicketMetadataGap`, and
-  `run_bd_issues` were internal helpers that no longer needed public module
-  visibility.
+- `IssuePrefixRenamePreview`, `ExternalTicketMetadataGap`, and `run_bd_issues`
+  were internal helpers that no longer needed public module visibility.
 - `ensure_custom_types`, `external_label`, `policy_role_label`, and
   `list_epics_by_workspace_label` were dead public helpers with only internal
   call sites.
-- `EventHistoryOverflowRepairResult`,
-  `ExternalTicketMetadataRepairResult`,
-  `ExternalTicketReconcileResult`,
-  `EpicIdentityViolation`, and `EpicDiscoveryParityReport` were duplicate model
-  definitions that are now owned by `atelier.lib.beads` or `atelier.store`.
+- `EventHistoryOverflowRepairResult`, `ExternalTicketMetadataRepairResult`,
+  `ExternalTicketReconcileResult`, `EpicIdentityViolation`, and
+  `EpicDiscoveryParityReport` were duplicate model definitions that are now
+  owned by `atelier.lib.beads` or `atelier.store`.
 
 ## Remaining shim boundary
 

--- a/src/atelier/worker/store_adapter.py
+++ b/src/atelier/worker/store_adapter.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import datetime as dt
 import json
+import re
 import subprocess
 from dataclasses import dataclass
 from functools import lru_cache
@@ -55,6 +56,7 @@ _READY_JSON_ARGS = ("ready",)
 _LIST_JSON_PREFIX = ("list",)
 _EPIC_LABEL_SCAN_LIMIT = 10_000
 _AGENT_LABEL_SCAN_LIMIT = 10_000
+_BLOCKED_REASON_LINE_RE = re.compile(r"^blocked_at:\s+\S+\s+reason:\s*(?P<reason>.+?)\s*$")
 
 
 @dataclass(frozen=True)
@@ -692,6 +694,23 @@ def _description_ends_with_notes(description: str | None, *, notes: tuple[str, .
     return tuple(lines[-len(notes) :]) == notes
 
 
+def _blocked_reason_from_line(line: str) -> str | None:
+    match = _BLOCKED_REASON_LINE_RE.fullmatch(line.strip())
+    if match is None:
+        return None
+    return _normalize_text(match.group("reason"))
+
+
+def _description_contains_blocked_reason(description: str | None, *, reason: str) -> bool:
+    normalized_reason = _normalize_text(reason)
+    if normalized_reason is None:
+        return False
+    for line in (description or "").splitlines():
+        if _blocked_reason_from_line(line) == normalized_reason:
+            return True
+    return False
+
+
 def _labels_from_payload(value: object) -> set[str]:
     if not isinstance(value, list):
         return set()
@@ -866,22 +885,30 @@ def mark_issue_blocked(
     """Persist blocked lifecycle and audit note as one verified issue update."""
 
     bundle = _bundle(beads_root=beads_root, repo_root=repo_root)
+    normalized_reason = _normalize_text(reason)
+    if normalized_reason is None:
+        die("blocked reason must not be empty")
     timestamp = dt.datetime.now(tz=dt.timezone.utc).isoformat()
-    note = f"blocked_at: {timestamp} reason: {reason}"
+    note = f"blocked_at: {timestamp} reason: {normalized_reason}"
     for _attempt in range(5):
         current = _show_issue(issue_id=issue_id, beads_root=beads_root, repo_root=repo_root)
         if current is None:
             die(f"issue not found: {issue_id}")
         current_description = _normalize_text(current.get("description"))
-        desired_description = _append_issue_notes(
+        current_has_reason = _description_contains_blocked_reason(
             current_description,
-            notes=(note,),
+            reason=normalized_reason,
         )
+        desired_description = current_description or ""
+        if not current_has_reason:
+            desired_description = _append_issue_notes(
+                current_description,
+                notes=(note,),
+            )
 
-        if _normalize_status(
-            current.get("status")
-        ) == LifecycleStatus.BLOCKED.value and _description_ends_with_notes(
-            current_description, notes=(note,)
+        if (
+            _normalize_status(current.get("status")) == LifecycleStatus.BLOCKED.value
+            and current_has_reason
         ):
             return
 
@@ -898,8 +925,9 @@ def mark_issue_blocked(
         payload_description = _normalize_text(payload.get("description"))
         if _normalize_status(
             payload.get("status")
-        ) == LifecycleStatus.BLOCKED.value and _description_ends_with_notes(
-            payload_description, notes=(note,)
+        ) == LifecycleStatus.BLOCKED.value and _description_contains_blocked_reason(
+            payload_description,
+            reason=normalized_reason,
         ):
             return
         refreshed = _show_issue(issue_id=issue_id, beads_root=beads_root, repo_root=repo_root)
@@ -909,7 +937,10 @@ def mark_issue_blocked(
         if (
             refreshed is not None
             and _normalize_status(refreshed.get("status")) == LifecycleStatus.BLOCKED.value
-            and _description_ends_with_notes(refreshed_description, notes=(note,))
+            and _description_contains_blocked_reason(
+                refreshed_description,
+                reason=normalized_reason,
+            )
         ):
             return
     raise RuntimeError(f"blocked transition could not be verified for {issue_id}")

--- a/src/atelier/worker/store_adapter.py
+++ b/src/atelier/worker/store_adapter.py
@@ -701,14 +701,35 @@ def _blocked_reason_from_line(line: str) -> str | None:
     return _normalize_text(match.group("reason"))
 
 
-def _description_contains_blocked_reason(description: str | None, *, reason: str) -> bool:
+def _description_contains_line(description: str | None, *, line: str) -> bool:
+    target = line.strip()
+    if not target:
+        return False
+    return any(candidate.strip() == target for candidate in (description or "").splitlines())
+
+
+def _latest_blocked_reason(description: str | None) -> str | None:
+    latest_reason = None
+    for line in (description or "").splitlines():
+        blocked_reason = _blocked_reason_from_line(line)
+        if blocked_reason is not None:
+            latest_reason = blocked_reason
+    return latest_reason
+
+
+def _blocked_transition_has_convergence_evidence(
+    *,
+    status: object,
+    description: str | None,
+    reason: str,
+    note: str,
+) -> bool:
     normalized_reason = _normalize_text(reason)
     if normalized_reason is None:
         return False
-    for line in (description or "").splitlines():
-        if _blocked_reason_from_line(line) == normalized_reason:
-            return True
-    return False
+    if _normalize_status(status) == LifecycleStatus.BLOCKED.value:
+        return _latest_blocked_reason(description) == normalized_reason
+    return _description_contains_line(description, line=note)
 
 
 def _labels_from_payload(value: object) -> set[str]:
@@ -895,12 +916,14 @@ def mark_issue_blocked(
         if current is None:
             die(f"issue not found: {issue_id}")
         current_description = _normalize_text(current.get("description"))
-        current_has_reason = _description_contains_blocked_reason(
-            current_description,
+        current_has_convergence_evidence = _blocked_transition_has_convergence_evidence(
+            status=current.get("status"),
+            description=current_description,
             reason=normalized_reason,
+            note=note,
         )
         desired_description = current_description or ""
-        if not current_has_reason:
+        if not current_has_convergence_evidence:
             desired_description = _append_issue_notes(
                 current_description,
                 notes=(note,),
@@ -908,7 +931,7 @@ def mark_issue_blocked(
 
         if (
             _normalize_status(current.get("status")) == LifecycleStatus.BLOCKED.value
-            and current_has_reason
+            and current_has_convergence_evidence
         ):
             return
 
@@ -923,24 +946,22 @@ def mark_issue_blocked(
         )
         payload = _issue_payload(updated)
         payload_description = _normalize_text(payload.get("description"))
-        if _normalize_status(
-            payload.get("status")
-        ) == LifecycleStatus.BLOCKED.value and _description_contains_blocked_reason(
-            payload_description,
+        if _blocked_transition_has_convergence_evidence(
+            status=payload.get("status"),
+            description=payload_description,
             reason=normalized_reason,
+            note=note,
         ):
             return
         refreshed = _show_issue(issue_id=issue_id, beads_root=beads_root, repo_root=repo_root)
         refreshed_description = None
         if refreshed is not None:
             refreshed_description = _normalize_text(refreshed.get("description"))
-        if (
-            refreshed is not None
-            and _normalize_status(refreshed.get("status")) == LifecycleStatus.BLOCKED.value
-            and _description_contains_blocked_reason(
-                refreshed_description,
-                reason=normalized_reason,
-            )
+        if refreshed is not None and _blocked_transition_has_convergence_evidence(
+            status=refreshed.get("status"),
+            description=refreshed_description,
+            reason=normalized_reason,
+            note=note,
         ):
             return
     raise RuntimeError(f"blocked transition could not be verified for {issue_id}")

--- a/tests/atelier/worker/test_session_runner_flow.py
+++ b/tests/atelier/worker/test_session_runner_flow.py
@@ -11,6 +11,10 @@ import pytest
 
 from atelier import config
 from atelier.agent_home import AgentHome
+from atelier.lib.beads import IssueRecord
+from atelier.store import build_atelier_store
+from atelier.testing.beads.client import build_in_memory_beads_client
+from atelier.worker import store_adapter as worker_store
 from atelier.worker.context import WorkerRunContext
 from atelier.worker.models import (
     FinalizeResult,
@@ -178,6 +182,91 @@ def test_changeset_block_handler_marks_and_notifies() -> None:
     assert call["thread_id"] == "at-epic.1"
     assert "Stage: start agent session" in call["body"]
     assert "Diagnostics: missing required command: codex" in call["body"]
+
+
+def test_changeset_block_handler_accepts_verified_blocked_reason_after_startup_failure(
+    monkeypatch,
+) -> None:
+    requests = []
+    real_datetime = dt.datetime
+    descriptions = iter(
+        (
+            {"id": "at-epic.1", "status": "open", "description": ""},
+            {
+                "id": "at-epic.1",
+                "status": "blocked",
+                "description": (
+                    "blocked_at: 2026-03-15T18:28:04+00:00 reason: command failed: codex exec "
+                    "hello\nplanner_note: captured startup diagnostics\n"
+                ),
+            },
+        )
+    )
+
+    class _FakeSyncClient:
+        def is_event_history_overflow_detail(self, _detail):
+            return False
+
+        def update(self, request):
+            requests.append(request)
+            return IssueRecord(
+                id=request.issue_id,
+                title="Stale",
+                status="open",
+                description="stale update payload",
+            )
+
+    monkeypatch.setattr(
+        worker_store,
+        "_build_store_bundle",
+        lambda **_kwargs: worker_store._StoreBundle(  # pyright: ignore[reportPrivateUsage]
+            store=build_atelier_store(beads=build_in_memory_beads_client()[0]),
+            sync_client=_FakeSyncClient(),
+        ),
+    )
+    monkeypatch.setattr(worker_store, "_show_issue", lambda **_kwargs: next(descriptions))
+    monkeypatch.setattr(
+        worker_store.dt,
+        "datetime",
+        type(
+            "_FixedDateTime",
+            (),
+            {
+                "now": staticmethod(
+                    lambda tz=None: real_datetime.fromisoformat("2026-03-15T18:28:04+00:00")
+                )
+            },
+        ),
+    )
+    worker_store.clear_bundle_cache()
+    lifecycle = SimpleNamespace(
+        mark_changeset_blocked=lambda changeset_id, *, beads_root, repo_root, reason: (
+            worker_store.mark_issue_blocked(
+                changeset_id,
+                beads_root=beads_root,
+                repo_root=repo_root,
+                reason=reason,
+            )
+        ),
+        send_planner_notification=Mock(),
+    )
+    handler = runner._ChangesetBlockHandler(  # pyright: ignore[reportPrivateUsage]
+        lifecycle=lifecycle,
+        agent_id="atelier/worker/codex/p9",
+        changeset_id="at-epic.1",
+        beads_root=Path("/beads"),
+        repo_root=Path("/repo"),
+    )
+
+    try:
+        handler.mark_changeset_blocked("command failed: codex exec hello")
+    finally:
+        worker_store.clear_bundle_cache()
+
+    assert len(requests) == 1
+    assert requests[0].description is not None
+    assert requests[0].description.count("blocked_at:") == 1
+    lifecycle.send_planner_notification.assert_called_once()
 
 
 def test_run_worker_once_returns_startup_exit_summary() -> None:

--- a/tests/atelier/worker/test_store_adapter.py
+++ b/tests/atelier/worker/test_store_adapter.py
@@ -550,6 +550,104 @@ def test_mark_issue_blocked_reuses_same_note_when_retry_reads_partial_state(
     assert requests[1].description.count("blocked_at:") == 1
 
 
+def test_mark_issue_blocked_reuses_matching_reason_when_retry_has_trailing_notes(
+    monkeypatch,
+) -> None:
+    requests = []
+
+    class _FakeSyncClient:
+        def update(self, request):
+            requests.append(request)
+            return IssueRecord(
+                id=request.issue_id,
+                title="Blocked",
+                status="blocked",
+                description=request.description,
+            )
+
+    monkeypatch.setattr(
+        worker_store,
+        "_build_store_bundle",
+        lambda **_kwargs: worker_store._StoreBundle(  # pyright: ignore[reportPrivateUsage]
+            store=build_atelier_store(beads=build_in_memory_beads_client()[0]),
+            sync_client=_FakeSyncClient(),
+        ),
+    )
+    monkeypatch.setattr(
+        worker_store,
+        "_show_issue",
+        lambda **_kwargs: {
+            "id": "at-epic.1",
+            "status": "open",
+            "description": (
+                "blocked_at: 2026-03-15T18:28:04+00:00 reason: missing integration\n"
+                "north_star_review.2026-03-15T18:29:00+00:00: checklist pending\n"
+            ),
+        },
+    )
+    worker_store.clear_bundle_cache()
+
+    try:
+        worker_store.mark_issue_blocked(
+            "at-epic.1",
+            reason="missing integration",
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+        )
+    finally:
+        worker_store.clear_bundle_cache()
+
+    assert len(requests) == 1
+    assert requests[0].description is not None
+    assert requests[0].description.count("blocked_at:") == 1
+    assert "north_star_review" in requests[0].description
+
+
+def test_mark_issue_blocked_noops_when_matching_reason_exists_with_trailing_notes(
+    monkeypatch,
+) -> None:
+    requests = []
+
+    class _FakeSyncClient:
+        def update(self, request):
+            requests.append(request)
+            return IssueRecord(id=request.issue_id, title="Blocked", status="blocked")
+
+    monkeypatch.setattr(
+        worker_store,
+        "_build_store_bundle",
+        lambda **_kwargs: worker_store._StoreBundle(  # pyright: ignore[reportPrivateUsage]
+            store=build_atelier_store(beads=build_in_memory_beads_client()[0]),
+            sync_client=_FakeSyncClient(),
+        ),
+    )
+    monkeypatch.setattr(
+        worker_store,
+        "_show_issue",
+        lambda **_kwargs: {
+            "id": "at-epic.1",
+            "status": "blocked",
+            "description": (
+                "blocked_at: 2026-03-15T18:28:04+00:00 reason: missing integration\n"
+                "planner_note: waiting on dependency metadata\n"
+            ),
+        },
+    )
+    worker_store.clear_bundle_cache()
+
+    try:
+        worker_store.mark_issue_blocked(
+            "at-epic.1",
+            reason="missing integration",
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+        )
+    finally:
+        worker_store.clear_bundle_cache()
+
+    assert requests == []
+
+
 def test_mark_issue_blocked_repairs_event_history_overflow_and_retries(monkeypatch) -> None:
     attempts = 0
     repairs: list[str] = []

--- a/tests/atelier/worker/test_store_adapter.py
+++ b/tests/atelier/worker/test_store_adapter.py
@@ -554,6 +554,7 @@ def test_mark_issue_blocked_reuses_matching_reason_when_retry_has_trailing_notes
     monkeypatch,
 ) -> None:
     requests = []
+    real_datetime = dt.datetime
 
     class _FakeSyncClient:
         def update(self, request):
@@ -585,6 +586,19 @@ def test_mark_issue_blocked_reuses_matching_reason_when_retry_has_trailing_notes
             ),
         },
     )
+    monkeypatch.setattr(
+        worker_store.dt,
+        "datetime",
+        type(
+            "_FixedDateTime",
+            (),
+            {
+                "now": staticmethod(
+                    lambda tz=None: real_datetime.fromisoformat("2026-03-15T18:28:04+00:00")
+                )
+            },
+        ),
+    )
     worker_store.clear_bundle_cache()
 
     try:
@@ -601,6 +615,75 @@ def test_mark_issue_blocked_reuses_matching_reason_when_retry_has_trailing_notes
     assert requests[0].description is not None
     assert requests[0].description.count("blocked_at:") == 1
     assert "north_star_review" in requests[0].description
+
+
+def test_mark_issue_blocked_appends_new_note_for_reopened_issue_with_old_matching_reason(
+    monkeypatch,
+) -> None:
+    requests = []
+    real_datetime = dt.datetime
+
+    class _FakeSyncClient:
+        def update(self, request):
+            requests.append(request)
+            return IssueRecord(
+                id=request.issue_id,
+                title="Blocked",
+                status="blocked",
+                description=request.description,
+            )
+
+    monkeypatch.setattr(
+        worker_store,
+        "_build_store_bundle",
+        lambda **_kwargs: worker_store._StoreBundle(  # pyright: ignore[reportPrivateUsage]
+            store=build_atelier_store(beads=build_in_memory_beads_client()[0]),
+            sync_client=_FakeSyncClient(),
+        ),
+    )
+    monkeypatch.setattr(
+        worker_store,
+        "_show_issue",
+        lambda **_kwargs: {
+            "id": "at-epic.1",
+            "status": "open",
+            "description": (
+                "blocked_at: 2026-03-15T18:28:04+00:00 reason: missing integration\n"
+                "planner_note: reopened after dependency refresh\n"
+            ),
+        },
+    )
+    monkeypatch.setattr(
+        worker_store.dt,
+        "datetime",
+        type(
+            "_FixedDateTime",
+            (),
+            {
+                "now": staticmethod(
+                    lambda tz=None: real_datetime.fromisoformat("2026-03-16T09:10:11+00:00")
+                )
+            },
+        ),
+    )
+    worker_store.clear_bundle_cache()
+
+    try:
+        worker_store.mark_issue_blocked(
+            "at-epic.1",
+            reason="missing integration",
+            beads_root=Path("/beads"),
+            repo_root=Path("/repo"),
+        )
+    finally:
+        worker_store.clear_bundle_cache()
+
+    assert len(requests) == 1
+    assert requests[0].description is not None
+    assert requests[0].description.count("blocked_at:") == 2
+    assert requests[0].description.endswith(
+        "blocked_at: 2026-03-16T09:10:11+00:00 reason: missing integration"
+    )
 
 
 def test_mark_issue_blocked_noops_when_matching_reason_exists_with_trailing_notes(


### PR DESCRIPTION
# Summary

- Make worker blocked-transition verification idempotent when the same startup failure is retried or concurrent notes land after the blocked audit line.

# Changes

- Parse persisted `blocked_at ... reason:` lines and treat a matching reason as converged even when it is no longer the final line in the description.
- Reuse existing blocked reason lines on retry so blocked writes do not append duplicate audit notes.
- Add regression coverage for store-adapter retry behavior and the worker blocked-handler path triggered by startup command failure.

# Testing

- `just format`
- `just lint`
- `just test`

## Tickets
- Fixes #721

# Risks / Rollout

- Low risk: the path still fails closed when convergence is unproven; this only broadens successful verification to already-persisted matching blocked reasons.

# Notes

- Includes the formatter's markdown wrap update in `docs/beads-facade-contract.md` from the required `just format` pass.
