### PR TITLE
Fix projected bootstrap runtime resolution in non-Atelier repos

### DIFF
--- a/docs/projected-skill-runtime-contract.md
+++ b/docs/projected-skill-runtime-contract.md
@@ -15,8 +15,14 @@ consumed by `src/atelier/skills/shared/scripts/projected_bootstrap.py`.
 
 ## Provenance selection rules
 
-1. Resolve repo provenance explicitly from `--repo-dir`, the local `./worktree`
-   link, projected repo env hints, then `cwd` and script ancestry.
+1. Resolve repo provenance explicitly from `--repo-dir` and the local
+   `./worktree` link before considering any ambient projected repo env hints.
+1. When an explicit `--repo-dir` does not prove a checkout with `src/atelier`,
+   projected bootstrap must ignore unrelated ambient `ATELIER_*` repo/worktree
+   hints instead of drifting into another project's source tree.
+1. If the selected repo is not itself an Atelier checkout, projected bootstrap
+   may fall back only to the projected skill runtime evidence recorded when the
+   skills were synced into that agent home.
 1. Use `repo-source` mode only after bootstrap proves a checkout with
    `src/atelier` is available to the projected script.
 1. Runtime health checks must prove transitive dependencies, not just partial
@@ -42,6 +48,7 @@ consumed by `src/atelier/skills/shared/scripts/projected_bootstrap.py`.
 ## `repo_root = None`
 
 When `repo_root` is `None`, projected bootstrap does not guess a repo runtime.
-It stays in `active-interpreter` mode, skips repo-runtime re-exec, and reports
+It stays in `active-interpreter` mode, may activate only the recorded projected
+support runtime for that agent home, skips repo-runtime re-exec, and reports
 that operators must pass `--repo-dir <repo-root>` or run from an agent home with
 a local `./worktree` link when repo-source behavior is required.

--- a/docs/runtime-env-subprocess-inventory.md
+++ b/docs/runtime-env-subprocess-inventory.md
@@ -49,6 +49,11 @@ when launching planner/worker/editor/shell subprocesses.
   fixture copies.
 - Runtime warnings about removed inherited keys are now immediate guidance for
   explicit launch context, not future deprecation notices.
+- Projected skill installs now emit a verified support-runtime manifest in the
+  agent home. When `--repo-dir` points at a non-Atelier repo, shared bootstrap
+  uses that recorded runtime evidence and ignores unrelated ambient
+  cross-project `ATELIER_*` repo/worktree hints instead of importing whichever
+  checkout happened to leak into the shell.
 
 ## Variable inventory
 

--- a/src/atelier/runtime_env.py
+++ b/src/atelier/runtime_env.py
@@ -168,9 +168,12 @@ def projected_runtime_contract(*, repo_root: Path | None) -> ProjectedRuntimeCon
         preferred_mode=preferred_mode,
         repo_root_behavior=repo_root_behavior,
         provenance_selection_rules=(
-            "Resolve repo provenance explicitly from --repo-dir, the local "
-            "./worktree link, projected repo env hints, then cwd/script "
-            "ancestry.",
+            "Resolve repo provenance explicitly from --repo-dir and the local "
+            "./worktree link before consulting projected repo env hints or "
+            "cwd/script ancestry.",
+            "When an explicit --repo-dir disagrees with ambient ATELIER_* "
+            "repo/worktree hints, ignore the ambient hints instead of "
+            "drifting into another project's source tree.",
             "Use repo-source mode only after bootstrap proves a checkout with "
             "src/atelier is available for the projected script.",
             "When repo_root is None, remain in active-interpreter mode and "

--- a/src/atelier/skills.py
+++ b/src/atelier/skills.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import shutil
+import sys
+import tempfile
 import threading
 import time
 from contextlib import contextmanager
@@ -26,6 +29,8 @@ _SKILLS_LOCK_FILENAME = "skills-sync.lock"
 _SKILLS_LOCK_GUARD = threading.Lock()
 _SKILLS_LOCAL_LOCKS: dict[str, threading.RLock] = {}
 _PACKAGED_SUPPORT_TREE_NAMES = frozenset({"shared"})
+_PROJECTED_RUNTIME_DIRNAME = ".atelier-runtime"
+_PROJECTED_RUNTIME_MANIFEST_FILENAME = "projected-runtime.json"
 
 
 @dataclass(frozen=True)
@@ -362,6 +367,7 @@ def install_workspace_skills(workspace_dir: Path) -> dict[str, dict[str, str]]:
             staging_dir,
             definitions,
         )
+        _write_projected_runtime_manifest(workspace_dir)
     return {
         name: {"version": __version__, "hash": definition.digest}
         for name, definition in definitions.items()
@@ -412,3 +418,139 @@ def sync_project_skills(
         )
     install_workspace_skills(project_dir)
     return ProjectSkillsSyncResult(skills_dir=skills_dir, action="updated")
+
+
+def _projected_runtime_manifest_path(workspace_dir: Path) -> Path:
+    return workspace_dir / _PROJECTED_RUNTIME_DIRNAME / _PROJECTED_RUNTIME_MANIFEST_FILENAME
+
+
+def _projected_runtime_helper_session_id() -> str:
+    for env_key in ("ATELIER_AGENT_SESSION", "ATELIER_AGENT_ID"):
+        value = str(os.environ.get(env_key, "")).strip()
+        if value:
+            return value
+    try:
+        resolved = Path(sys.executable).resolve()
+    except OSError:
+        resolved = Path(sys.executable)
+    return f"installer:{resolved}"
+
+
+def _projected_runtime_pythonpath_entries() -> tuple[str, ...]:
+    module_names = (
+        "atelier",
+        "atelier.runtime_env",
+        "pydantic",
+        "pydantic_core",
+        "pydantic_core._pydantic_core",
+        "platformdirs",
+        "questionary",
+        "rich",
+        "typer",
+    )
+    roots: list[str] = []
+    seen: set[str] = set()
+    for module_name in module_names:
+        module = __import__(module_name, fromlist=["*"])
+        raw_origin = getattr(module, "__file__", None)
+        if not isinstance(raw_origin, str) or not raw_origin.strip():
+            spec = getattr(module, "__spec__", None)
+            raw_origin = getattr(spec, "origin", None)
+        if not isinstance(raw_origin, str) or not raw_origin.strip():
+            continue
+        try:
+            module_path = Path(raw_origin).resolve()
+        except OSError:
+            module_path = Path(raw_origin)
+        import_root = module_path
+        if module_path.name == "__init__.py" or module_path.name.startswith("__init__."):
+            import_root = module_path.parent
+        for _ in module_name.split("."):
+            import_root = import_root.parent
+        normalized = str(import_root)
+        if normalized in seen:
+            continue
+        seen.add(normalized)
+        roots.append(normalized)
+    return tuple(roots)
+
+
+def _projected_runtime_manifest_payload() -> dict[str, object]:
+    atelier_import_root = Path(__file__).resolve().parent.parent
+    package_init = atelier_import_root / "atelier" / "__init__.py"
+    if not package_init.is_file():
+        raise OSError(
+            "projected runtime manifest could not prove the Atelier import root "
+            f"at {atelier_import_root}"
+        )
+    try:
+        selected_interpreter = str(Path(sys.executable).resolve())
+    except OSError:
+        selected_interpreter = str(sys.executable)
+    pythonpath_entries = _projected_runtime_pythonpath_entries()
+    if not pythonpath_entries:
+        pythonpath_entries = (str(atelier_import_root),)
+    return {
+        "schema_version": 1,
+        "status": "converged",
+        "helper_session_id": _projected_runtime_helper_session_id(),
+        "selected_interpreter": selected_interpreter,
+        "atelier_import_root": str(atelier_import_root),
+        "pythonpath_entries": list(pythonpath_entries),
+    }
+
+
+def _validate_projected_runtime_manifest(payload: object) -> dict[str, object]:
+    if not isinstance(payload, dict):
+        raise OSError("projected runtime manifest readback was not a JSON object")
+    if payload.get("status") != "converged":
+        raise OSError("projected runtime manifest readback did not prove convergence")
+    helper_session_id = str(payload.get("helper_session_id", "")).strip()
+    selected_interpreter = str(payload.get("selected_interpreter", "")).strip()
+    import_root = str(payload.get("atelier_import_root", "")).strip()
+    pythonpath_entries = payload.get("pythonpath_entries")
+    if not helper_session_id:
+        raise OSError("projected runtime manifest readback is missing helper_session_id")
+    if not selected_interpreter:
+        raise OSError("projected runtime manifest readback is missing selected_interpreter")
+    if not import_root:
+        raise OSError("projected runtime manifest readback is missing atelier_import_root")
+    if not isinstance(pythonpath_entries, list) or not pythonpath_entries:
+        raise OSError("projected runtime manifest readback is missing pythonpath_entries")
+    package_init = Path(import_root) / "atelier" / "__init__.py"
+    if not package_init.is_file():
+        raise OSError(
+            "projected runtime manifest readback does not point at an importable "
+            f"Atelier root: {import_root}"
+        )
+    return payload
+
+
+def _write_projected_runtime_manifest(workspace_dir: Path) -> None:
+    manifest_path = _projected_runtime_manifest_path(workspace_dir)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = _projected_runtime_manifest_payload()
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=manifest_path.parent,
+            prefix=f".{manifest_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(serialized)
+            handle.flush()
+            tmp_path = Path(handle.name)
+        tmp_path.replace(manifest_path)
+        readback = json.loads(manifest_path.read_text(encoding="utf-8"))
+        _validate_projected_runtime_manifest(readback)
+    except Exception as exc:
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+        raise OSError(f"projected runtime manifest write failed: {exc}") from exc

--- a/src/atelier/skills.py
+++ b/src/atelier/skills.py
@@ -410,6 +410,18 @@ def sync_project_skills(
 
     state = workspace_skill_state(project_dir, None)
     if not state.needs_install:
+        if dry_run and _projected_runtime_manifest_requires_backfill(project_dir):
+            return ProjectSkillsSyncResult(
+                skills_dir=skills_dir,
+                action="would_update",
+                detail="projected runtime manifest missing or invalid",
+            )
+        if _repair_projected_runtime_manifest(project_dir):
+            return ProjectSkillsSyncResult(
+                skills_dir=skills_dir,
+                action="updated",
+                detail="projected runtime manifest repaired",
+            )
         return ProjectSkillsSyncResult(skills_dir=skills_dir, action="up_to_date")
     if dry_run:
         return ProjectSkillsSyncResult(
@@ -554,3 +566,23 @@ def _write_projected_runtime_manifest(workspace_dir: Path) -> None:
             except OSError:
                 pass
         raise OSError(f"projected runtime manifest write failed: {exc}") from exc
+
+
+def _projected_runtime_manifest_requires_backfill(workspace_dir: Path) -> bool:
+    manifest_path = _projected_runtime_manifest_path(workspace_dir)
+    if not manifest_path.is_file():
+        return True
+    try:
+        readback = json.loads(manifest_path.read_text(encoding="utf-8"))
+        _validate_projected_runtime_manifest(readback)
+    except Exception:
+        return True
+    return False
+
+
+def _repair_projected_runtime_manifest(workspace_dir: Path) -> bool:
+    with _skills_write_lock(workspace_dir):
+        if not _projected_runtime_manifest_requires_backfill(workspace_dir):
+            return False
+        _write_projected_runtime_manifest(workspace_dir)
+        return True

--- a/src/atelier/skills/shared/scripts/projected_bootstrap.py
+++ b/src/atelier/skills/shared/scripts/projected_bootstrap.py
@@ -2,16 +2,35 @@
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from pathlib import Path
+from typing import NoReturn
 
 _DEFAULT_REPO_DIR_ENV_VARS: tuple[str, ...] = (
     "ATELIER_PLANNER_WORKTREE",
     "ATELIER_WORKSPACE_DIR",
     "ATELIER_PROJECT",
 )
+_PROJECTED_RUNTIME_DIRNAME = ".atelier-runtime"
+_PROJECTED_RUNTIME_MANIFEST_FILENAME = "projected-runtime.json"
+_PROJECTED_SUPPORT_RUNTIME_SELECTED_ENV = "ATELIER_PROJECTED_SUPPORT_RUNTIME_SELECTED"
+_INSTALLED_TOOL_RUNTIME_MARKERS: tuple[str, ...] = (
+    "/.local/share/uv/tools/atelier/",
+    "/Library/Application Support/uv/tools/atelier/",
+    "/site-packages/atelier/",
+)
+
+
+@dataclass(frozen=True)
+class _ProjectedSupportRuntimeResolution:
+    status: str
+    detail: str
+    command: tuple[str, ...] | None = None
+    pythonpath_entries: tuple[str, ...] = ()
 
 
 def _repo_dir_from_argv(argv: Sequence[str]) -> Path | None:
@@ -49,10 +68,11 @@ def _bootstrap_source_import(
 
     current_dir = Path.cwd()
     candidate_roots.append(current_dir / "worktree")
-    for env_var in repo_dir_env_vars:
-        env_repo_dir = str(env.get(env_var, "")).strip()
-        if env_repo_dir:
-            candidate_roots.append(Path(env_repo_dir).expanduser())
+    if argv_repo_dir is None:
+        for env_var in repo_dir_env_vars:
+            env_repo_dir = str(env.get(env_var, "")).strip()
+            if env_repo_dir:
+                candidate_roots.append(Path(env_repo_dir).expanduser())
     candidate_roots.append(current_dir)
     candidate_roots.extend(script_path.resolve().parents)
 
@@ -70,6 +90,249 @@ def _bootstrap_source_import(
         sys.path.insert(0, src_dir_entry)
         return resolved
     return None
+
+
+def _support_runtime_manifest_path(script_path: Path) -> Path | None:
+    resolved_script = script_path.resolve()
+    for parent in resolved_script.parents:
+        if parent.name == "skills":
+            return parent.parent / _PROJECTED_RUNTIME_DIRNAME / _PROJECTED_RUNTIME_MANIFEST_FILENAME
+    return None
+
+
+def _same_executable(current_executable: str, selected_interpreter: str) -> bool:
+    current = str(current_executable).strip()
+    selected = str(selected_interpreter).strip()
+    if not current or not selected:
+        return False
+    try:
+        return Path(current).resolve() == Path(selected).resolve()
+    except OSError:
+        return current == selected
+
+
+def _runtime_provenance_label(*, current_executable: str) -> str:
+    if any(marker in current_executable for marker in _INSTALLED_TOOL_RUNTIME_MARKERS):
+        return "installed-tool"
+    return "ambient"
+
+
+def _format_path_entries(entries: Sequence[str]) -> str:
+    values = [str(entry).strip() for entry in entries if str(entry).strip()]
+    if not values:
+        return "(none)"
+    return ", ".join(values)
+
+
+def _prepend_sys_path(entries: Sequence[str]) -> tuple[str, ...]:
+    ordered: list[str] = []
+    seen: set[str] = set()
+    for entry in entries:
+        normalized = str(entry).strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        ordered.append(normalized)
+    if not ordered:
+        return ()
+    sys.path[:] = [entry for entry in sys.path if entry not in seen]
+    sys.path[:0] = ordered
+    return tuple(ordered)
+
+
+def _activate_support_runtime_paths(entries: Sequence[str]) -> tuple[str, ...]:
+    ordered = _prepend_sys_path(entries)
+    if ordered:
+        os.environ["PYTHONPATH"] = os.pathsep.join(ordered)
+    else:
+        os.environ.pop("PYTHONPATH", None)
+    return ordered
+
+
+def _load_support_runtime_resolution(
+    *,
+    script_path: Path,
+    argv: Sequence[str],
+    env: Mapping[str, str],
+) -> _ProjectedSupportRuntimeResolution:
+    manifest_path = _support_runtime_manifest_path(script_path)
+    if manifest_path is None:
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail="projected support runtime manifest path could not be derived from script path.",
+        )
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail=f"projected support runtime manifest missing: {manifest_path}",
+        )
+    except (OSError, json.JSONDecodeError) as exc:
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail=f"projected support runtime manifest is malformed: {exc}",
+        )
+    if not isinstance(payload, dict):
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail="projected support runtime manifest is not a JSON object.",
+        )
+    if payload.get("status") != "converged":
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail="projected support runtime manifest did not prove convergence.",
+        )
+    helper_session_id = str(payload.get("helper_session_id", "")).strip()
+    selected_interpreter = str(payload.get("selected_interpreter", "")).strip()
+    import_root_raw = str(payload.get("atelier_import_root", "")).strip()
+    pythonpath_entries_raw = payload.get("pythonpath_entries")
+    if not helper_session_id:
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail="projected support runtime manifest is missing helper_session_id.",
+        )
+    if not selected_interpreter:
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail="projected support runtime manifest is missing selected_interpreter.",
+        )
+    if not import_root_raw:
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail="projected support runtime manifest is missing atelier_import_root.",
+        )
+    if not isinstance(pythonpath_entries_raw, list) or not pythonpath_entries_raw:
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail="projected support runtime manifest is missing pythonpath_entries.",
+        )
+    try:
+        import_root = Path(import_root_raw).expanduser().resolve()
+    except OSError as exc:
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail=f"projected support runtime manifest import root is invalid: {exc}",
+        )
+    if not (import_root / "atelier" / "__init__.py").is_file():
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail=(
+                "projected support runtime manifest does not point at an "
+                f"importable Atelier root: {import_root}"
+            ),
+        )
+    pythonpath_entries = tuple(
+        str(Path(str(entry).strip()).expanduser())
+        for entry in pythonpath_entries_raw
+        if str(entry).strip()
+    )
+    if _same_executable(sys.executable, selected_interpreter):
+        activated = _activate_support_runtime_paths(pythonpath_entries)
+        return _ProjectedSupportRuntimeResolution(
+            status="active",
+            detail=(
+                "projected support runtime evidence converged in the current interpreter "
+                f"via helper session {helper_session_id}."
+            ),
+            command=None,
+            pythonpath_entries=activated,
+        )
+    if env.get(_PROJECTED_SUPPORT_RUNTIME_SELECTED_ENV) == "1":
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail=(
+                "projected support runtime re-exec was already attempted, but the "
+                "selected interpreter still did not converge."
+            ),
+            command=(selected_interpreter,),
+            pythonpath_entries=pythonpath_entries,
+        )
+    selected_path = Path(selected_interpreter).expanduser()
+    if not (selected_path.is_file() and os.access(selected_path, os.X_OK)):
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail=(
+                "projected support runtime manifest selected_interpreter is not executable: "
+                f"{selected_interpreter}"
+            ),
+            command=(selected_interpreter,),
+            pythonpath_entries=pythonpath_entries,
+        )
+    exec_env = dict(env)
+    exec_env[_PROJECTED_SUPPORT_RUNTIME_SELECTED_ENV] = "1"
+    if pythonpath_entries:
+        exec_env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+    else:
+        exec_env.pop("PYTHONPATH", None)
+    try:
+        os.execvpe(
+            selected_interpreter,
+            [selected_interpreter, str(script_path), *argv],
+            exec_env,
+        )
+    except OSError as exc:
+        return _ProjectedSupportRuntimeResolution(
+            status="unavailable",
+            detail=f"projected support runtime re-exec failed: {exc}",
+            command=(selected_interpreter,),
+            pythonpath_entries=pythonpath_entries,
+        )
+    return _ProjectedSupportRuntimeResolution(
+        status="available",
+        detail="projected support runtime re-exec was requested.",
+        command=(selected_interpreter,),
+        pythonpath_entries=pythonpath_entries,
+    )
+
+
+def _fail_unresolved_runtime(
+    *,
+    script_path: Path,
+    repo_root: Path | None,
+    repo_dir: Path | None,
+    support_resolution: _ProjectedSupportRuntimeResolution,
+    error: Exception,
+) -> NoReturn:
+    selected_mode = "repo-source" if repo_root is not None else "active-interpreter"
+    selected_interpreter = str(sys.executable or "").strip() or "(unknown)"
+    repo_display = str(repo_root) if repo_root is not None else "(unresolved)"
+    print(
+        "error: planner helper runtime is unhealthy before importing atelier modules.",
+        file=sys.stderr,
+    )
+    print(
+        "boundary: projected bootstrap could not resolve an importable Atelier "
+        "runtime before loading atelier.runtime_env.",
+        file=sys.stderr,
+    )
+    print(f"script: {script_path}", file=sys.stderr)
+    print(f"selected_interpreter: {selected_interpreter}", file=sys.stderr)
+    print(f"selected_mode: {selected_mode}", file=sys.stderr)
+    print(
+        f"runtime_provenance: {_runtime_provenance_label(current_executable=selected_interpreter)}",
+        file=sys.stderr,
+    )
+    print(f"repo_root: {repo_display}", file=sys.stderr)
+    if repo_dir is not None:
+        print(f"repo_hint: {repo_dir}", file=sys.stderr)
+    print(f"repo_runtime_status: {support_resolution.status}", file=sys.stderr)
+    print(f"repo_runtime_detail: {support_resolution.detail}", file=sys.stderr)
+    if support_resolution.command is not None:
+        print("repo_runtime_command: " + " ".join(support_resolution.command), file=sys.stderr)
+    print("pythonpath_removed: (none)", file=sys.stderr)
+    print(
+        "pythonpath_preserved: " + _format_path_entries(support_resolution.pythonpath_entries),
+        file=sys.stderr,
+    )
+    print("dependency: atelier.runtime_env", file=sys.stderr)
+    print(f"detail: {type(error).__name__}: {error}", file=sys.stderr)
+    print(
+        "action: sync projected skills from a converged Atelier runtime or rerun "
+        "from an agent home that can prove the runtime explicitly.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1) from error
 
 
 def bootstrap_projected_atelier_script(
@@ -102,22 +365,46 @@ def bootstrap_projected_atelier_script(
     """
     resolved_env = dict(os.environ if env is None else env)
     resolved_argv = tuple(sys.argv[1:] if argv is None else argv)
+    explicit_repo_dir = _repo_dir_from_argv(resolved_argv)
     repo_root = _bootstrap_source_import(
         script_path=script_path,
         argv=resolved_argv,
         env=resolved_env,
         repo_dir_env_vars=repo_dir_env_vars,
     )
-
-    from atelier.runtime_env import (
-        ProjectedRuntimeMode,
-        collect_projected_bootstrap_diagnostics,
-        ensure_projected_runtime_dependency,
-        maybe_reexec_projected_repo_runtime,
-        projected_runtime_contract,
-        reset_current_process_pythonpath,
-        sanitize_pythonpath_environment,
+    support_resolution = _ProjectedSupportRuntimeResolution(
+        status="not-applicable",
+        detail="repo-source bootstrap resolved an importable atelier checkout.",
     )
+    if repo_root is None:
+        support_resolution = _load_support_runtime_resolution(
+            script_path=script_path,
+            argv=resolved_argv,
+            env=resolved_env,
+        )
+        if support_resolution.pythonpath_entries:
+            resolved_env["PYTHONPATH"] = os.pathsep.join(support_resolution.pythonpath_entries)
+        else:
+            resolved_env.pop("PYTHONPATH", None)
+
+    try:
+        from atelier.runtime_env import (
+            ProjectedRuntimeMode,
+            collect_projected_bootstrap_diagnostics,
+            ensure_projected_runtime_dependency,
+            maybe_reexec_projected_repo_runtime,
+            projected_runtime_contract,
+            reset_current_process_pythonpath,
+            sanitize_pythonpath_environment,
+        )
+    except Exception as exc:
+        _fail_unresolved_runtime(
+            script_path=script_path,
+            repo_root=repo_root,
+            repo_dir=explicit_repo_dir,
+            support_resolution=support_resolution,
+            error=exc,
+        )
 
     contract = projected_runtime_contract(repo_root=repo_root)
 

--- a/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
+++ b/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import subprocess
@@ -31,6 +32,10 @@ def _install_projected_script(
     assert projected_script.exists()
     assert (agent_home / "skills" / "shared" / "scripts" / "projected_bootstrap.py").is_file()
     return agent_home, projected_script
+
+
+def _projected_runtime_manifest_path(agent_home: Path) -> Path:
+    return agent_home / ".atelier-runtime" / "projected-runtime.json"
 
 
 def _write_fake_module(path: Path, content: str) -> None:
@@ -248,6 +253,25 @@ def test_synced_agent_home_includes_shared_bootstrap_dependency_path(
     assert shared_bootstrap.is_file()
 
 
+def test_install_workspace_skills_writes_converged_projected_runtime_manifest(
+    tmp_path: Path,
+) -> None:
+    agent_home, _projected_script = _install_projected_script(
+        tmp_path,
+        skill_name="planner-startup-check",
+        script_name="refresh_overview.py",
+    )
+
+    manifest_path = _projected_runtime_manifest_path(agent_home)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert payload["status"] == "converged"
+    assert payload["helper_session_id"]
+    assert Path(payload["selected_interpreter"]).exists()
+    assert (Path(payload["atelier_import_root"]) / "atelier" / "__init__.py").is_file()
+    assert payload["pythonpath_entries"]
+
+
 def test_projected_create_epic_prefers_agent_worktree_source(tmp_path: Path) -> None:
     agent_home, projected_script = _install_projected_script(
         tmp_path,
@@ -381,7 +405,7 @@ def test_projected_create_epic_ignores_inherited_pythonpath_when_repo_runtime_ma
     )
 
 
-def test_projected_create_epic_preserves_tool_runtime_when_repo_root_is_unresolved(
+def test_projected_create_epic_prefers_recorded_runtime_when_repo_root_is_unresolved(
     tmp_path: Path,
 ) -> None:
     agent_home, projected_script = _install_projected_script(
@@ -439,12 +463,10 @@ def test_projected_create_epic_preserves_tool_runtime_when_repo_root_is_unresolv
     )
 
     assert completed.returncode == 0
-    assert sentinel_path.read_text(encoding="utf-8") == str(
-        installed_root / "atelier" / "auto_export.py"
-    )
+    assert not sentinel_path.exists()
 
 
-def test_projected_create_epic_preserves_split_tool_runtime_roots_when_repo_root_is_unresolved(
+def test_projected_create_epic_ignores_ambient_split_runtime_roots_when_recorded_runtime_exists(
     tmp_path: Path,
 ) -> None:
     agent_home, projected_script = _install_projected_script(
@@ -525,9 +547,121 @@ def test_projected_create_epic_preserves_split_tool_runtime_roots_when_repo_root
     )
 
     assert completed.returncode == 0
-    assert sentinel_path.read_text(encoding="utf-8") == str(
-        rich_runtime_root / "rich" / "__init__.py"
+    assert not sentinel_path.exists()
+
+
+def test_projected_refresh_overview_uses_recorded_runtime_in_clean_non_atelier_repo(
+    tmp_path: Path,
+) -> None:
+    agent_home, projected_script = _install_projected_script(
+        tmp_path,
+        skill_name="planner-startup-check",
+        script_name="refresh_overview.py",
     )
+    repo_root = tmp_path / "non-atelier-repo"
+    repo_root.mkdir()
+    isolated_python = tmp_path / "bin" / "python3"
+    _write_python_without_site_packages(isolated_python)
+
+    completed = subprocess.run(
+        [
+            str(isolated_python),
+            str(projected_script),
+            "--repo-dir",
+            str(repo_root),
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=agent_home,
+        env={},
+    )
+
+    assert completed.returncode == 0
+    assert "usage:" in completed.stdout.lower()
+
+
+def test_projected_create_epic_ignores_cross_project_env_hints_for_non_atelier_repo(
+    tmp_path: Path,
+) -> None:
+    agent_home, projected_script = _install_projected_script(
+        tmp_path,
+        skill_name="plan-create-epic",
+        script_name="create_epic.py",
+    )
+    target_repo = tmp_path / "target-repo"
+    target_repo.mkdir()
+    contaminated_root = _fake_repo(
+        tmp_path / "foreign-runtime",
+        sentinel_import="auto_export",
+    )
+    isolated_python = tmp_path / "bin" / "python3"
+    _write_python_without_site_packages(isolated_python)
+    sentinel_path = tmp_path / "cross-project-env-leak-sentinel.txt"
+
+    completed = subprocess.run(
+        [
+            str(isolated_python),
+            str(projected_script),
+            "--repo-dir",
+            str(target_repo),
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=agent_home,
+        env={
+            "ATELIER_PROJECT": str(contaminated_root),
+            "ATELIER_WORKSPACE_DIR": str(contaminated_root),
+            "ATELIER_PLANNER_WORKTREE": str(contaminated_root),
+            "BOOTSTRAP_SENTINEL": str(sentinel_path),
+            "PYTHONPATH": str(contaminated_root / "src"),
+        },
+    )
+
+    assert completed.returncode == 0
+    assert not sentinel_path.exists()
+
+
+def test_projected_refresh_overview_fails_closed_when_recorded_runtime_manifest_is_missing(
+    tmp_path: Path,
+) -> None:
+    agent_home, projected_script = _install_projected_script(
+        tmp_path,
+        skill_name="planner-startup-check",
+        script_name="refresh_overview.py",
+    )
+    repo_root = tmp_path / "non-atelier-repo"
+    repo_root.mkdir()
+    manifest_path = _projected_runtime_manifest_path(agent_home)
+    manifest_path.unlink()
+    isolated_python = tmp_path / "bin" / "python3"
+    _write_python_without_site_packages(isolated_python)
+
+    completed = subprocess.run(
+        [
+            str(isolated_python),
+            str(projected_script),
+            "--repo-dir",
+            str(repo_root),
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=agent_home,
+        env={},
+    )
+
+    assert completed.returncode == 1
+    assert "planner helper runtime is unhealthy" in completed.stderr
+    assert "selected_mode: active-interpreter" in completed.stderr
+    assert "repo_runtime_status: unavailable" in completed.stderr
+    assert "projected support runtime manifest missing" in completed.stderr
+    assert "dependency: atelier.runtime_env" in completed.stderr
+    assert "Traceback" not in completed.stderr
 
 
 def test_projected_auto_export_prefers_explicit_repo_dir_source(tmp_path: Path) -> None:
@@ -1154,7 +1288,7 @@ def test_projected_close_epic_reorders_repo_src_ahead_of_installed_package(
     )
 
 
-def test_projected_close_epic_preserves_tool_runtime_when_repo_root_is_unresolved(
+def test_projected_close_epic_prefers_recorded_runtime_when_repo_root_is_unresolved(
     tmp_path: Path,
 ) -> None:
     agent_home, projected_script = _install_projected_script(
@@ -1202,10 +1336,10 @@ def test_projected_close_epic_preserves_tool_runtime_when_repo_root_is_unresolve
     )
 
     assert completed.returncode == 0
-    assert sentinel_path.read_text(encoding="utf-8") == str(installed_root / "rich" / "__init__.py")
+    assert not sentinel_path.exists()
 
 
-def test_projected_close_epic_preserves_split_tool_runtime_roots_when_repo_root_is_unresolved(
+def test_projected_close_epic_ignores_ambient_split_runtime_roots_when_recorded_runtime_exists(
     tmp_path: Path,
 ) -> None:
     agent_home, projected_script = _install_projected_script(
@@ -1272,9 +1406,7 @@ def test_projected_close_epic_preserves_split_tool_runtime_roots_when_repo_root_
     )
 
     assert completed.returncode == 0
-    assert sentinel_path.read_text(encoding="utf-8") == str(
-        rich_runtime_root / "rich" / "__init__.py"
-    )
+    assert not sentinel_path.exists()
 
 
 def test_projected_check_issue_ownership_fails_closed_when_repo_runtime_is_dependency_unhealthy(

--- a/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
+++ b/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
@@ -272,6 +272,27 @@ def test_install_workspace_skills_writes_converged_projected_runtime_manifest(
     assert payload["pythonpath_entries"]
 
 
+def test_sync_project_skills_backfills_missing_projected_runtime_manifest(
+    tmp_path: Path,
+) -> None:
+    agent_home, _projected_script = _install_projected_script(
+        tmp_path,
+        skill_name="planner-startup-check",
+        script_name="refresh_overview.py",
+    )
+
+    manifest_path = _projected_runtime_manifest_path(agent_home)
+    manifest_path.unlink()
+
+    result = packaged_skills.sync_project_skills(agent_home)
+
+    assert result.action == "updated"
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["status"] == "converged"
+    assert payload["helper_session_id"]
+    assert payload["pythonpath_entries"]
+
+
 def test_projected_create_epic_prefers_agent_worktree_source(tmp_path: Path) -> None:
     agent_home, projected_script = _install_projected_script(
         tmp_path,


### PR DESCRIPTION
## Summary
- record a verified projected runtime manifest when syncing skills into an agent home so projected helpers can bootstrap Atelier in non-Atelier repos
- prefer explicit `--repo-dir` provenance, ignore mismatched ambient `ATELIER_*` repo hints, and fail closed with deterministic diagnostics when no valid runtime can be resolved
- add regression coverage and contract docs for clean-environment, cross-project env-leak, and missing-manifest bootstrap paths

## Testing
- `env -u PYTHONPATH just format`
- `env -u PYTHONPATH just lint`
- `env -u PYTHONPATH just test`

## Tickets
- Fixes #760