### PR TITLE
Repair projected runtime rollouts for existing projects

### DIFF
--- a/src/atelier/agent_home.py
+++ b/src/atelier/agent_home.py
@@ -568,6 +568,24 @@ def _ensure_dir_link(dest: Path, target: Path) -> None:
             return
 
 
+def _looks_like_managed_skill_tree(path: Path) -> bool:
+    if not path.exists() or path.is_symlink() or not path.is_dir():
+        return False
+    shared_bootstrap = path / "shared" / "scripts" / "projected_bootstrap.py"
+    if shared_bootstrap.is_file():
+        return True
+    for child in path.iterdir():
+        if child.is_dir() and (child / "SKILL.md").is_file():
+            return True
+    return False
+
+
+def _ensure_managed_skill_link(dest: Path, target: Path) -> None:
+    if _looks_like_managed_skill_tree(dest):
+        shutil.rmtree(dest)
+    _ensure_dir_link(dest, target)
+
+
 def ensure_agent_links(
     agent: AgentHome,
     *,
@@ -581,14 +599,14 @@ def ensure_agent_links(
     if not root.exists():
         return
     _ensure_dir_link(root / "worktree", worktree_path)
-    _ensure_dir_link(root / "skills", skills_dir)
+    _ensure_managed_skill_link(root / "skills", skills_dir)
     for lookup in project_skill_lookup_paths:
         relative = str(lookup).strip().strip("/")
         if not relative or relative == "skills":
             continue
         alias_path = root / relative
         alias_path.parent.mkdir(parents=True, exist_ok=True)
-        _ensure_dir_link(alias_path, skills_dir)
+        _ensure_managed_skill_link(alias_path, skills_dir)
     _ensure_dir_link(root / "beads", beads_root)
 
 

--- a/src/atelier/cli.py
+++ b/src/atelier/cli.py
@@ -22,7 +22,7 @@ try:
 except ImportError:  # pragma: no cover - legacy Click fallback
     from click.parser import split_arg_string
 
-from . import __version__, bd_invocation, beads, config, git, lifecycle, paths
+from . import __version__, bd_invocation, beads, config, git, lifecycle, paths, skills
 from . import log as atelier_log
 from .commands import config as config_cmd
 from .commands import doctor as doctor_cmd
@@ -276,6 +276,8 @@ def app_callback(
         atelier_log.set_level(normalized)
     if color is not None:
         atelier_log.set_no_color(not color)
+    if _COMPLETE_ENV not in os.environ:
+        skills.repair_installed_project_skills_for_current_version()
 
 
 @app.command(

--- a/src/atelier/skills.py
+++ b/src/atelier/skills.py
@@ -31,6 +31,7 @@ _SKILLS_LOCAL_LOCKS: dict[str, threading.RLock] = {}
 _PACKAGED_SUPPORT_TREE_NAMES = frozenset({"shared"})
 _PROJECTED_RUNTIME_DIRNAME = ".atelier-runtime"
 _PROJECTED_RUNTIME_MANIFEST_FILENAME = "projected-runtime.json"
+_INSTALLED_RUNTIME_REPAIR_STATE_FILENAME = "projected-runtime-repair-state.json"
 
 
 @dataclass(frozen=True)
@@ -55,6 +56,14 @@ class ProjectSkillsSyncResult:
     skills_dir: Path
     action: str
     detail: str | None = None
+
+
+@dataclass(frozen=True)
+class InstalledProjectRuntimeRepairResult:
+    action: str
+    scanned_projects: tuple[Path, ...]
+    updated_projects: tuple[Path, ...]
+    failed_projects: tuple[tuple[Path, str], ...]
 
 
 def _skills_lock_path(workspace_dir: Path) -> Path:
@@ -430,6 +439,130 @@ def sync_project_skills(
         )
     install_workspace_skills(project_dir)
     return ProjectSkillsSyncResult(skills_dir=skills_dir, action="updated")
+
+
+def _installed_runtime_repair_state_path() -> Path:
+    return paths.atelier_data_dir() / _INSTALLED_RUNTIME_REPAIR_STATE_FILENAME
+
+
+def _load_installed_runtime_repair_state() -> dict[str, object] | None:
+    state_path = _installed_runtime_repair_state_path()
+    if not state_path.is_file():
+        return None
+    try:
+        payload = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    return payload
+
+
+def _installed_runtime_repair_state_is_current() -> bool:
+    payload = _load_installed_runtime_repair_state()
+    if payload is None:
+        return False
+    version = str(payload.get("atelier_version", "")).strip()
+    return payload.get("schema_version") == 1 and version == __version__
+
+
+def _write_installed_runtime_repair_state() -> None:
+    state_path = _installed_runtime_repair_state_path()
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    serialized = (
+        json.dumps(
+            {
+                "schema_version": 1,
+                "atelier_version": __version__,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=state_path.parent,
+            prefix=f".{state_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(serialized)
+            handle.flush()
+            tmp_path = Path(handle.name)
+        tmp_path.replace(state_path)
+    finally:
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
+
+
+def _installed_runtime_repair_candidates() -> tuple[Path, ...]:
+    project_dirs_root = paths.projects_root()
+    if not project_dirs_root.exists():
+        return ()
+    candidates: list[Path] = []
+    for candidate in sorted(project_dirs_root.iterdir()):
+        if not candidate.is_dir():
+            continue
+        if not (
+            paths.project_config_sys_path(candidate).exists()
+            or paths.project_config_legacy_path(candidate).exists()
+        ):
+            continue
+        if not (
+            paths.project_skills_dir(candidate).exists()
+            or _projected_runtime_manifest_path(candidate).exists()
+        ):
+            continue
+        candidates.append(candidate)
+    return tuple(candidates)
+
+
+def repair_installed_project_skills_for_current_version() -> InstalledProjectRuntimeRepairResult:
+    """Repair projected runtime state for already-installed project skill trees.
+
+    Returns:
+        Summary of the version-gated repair pass. ``action`` is ``"skipped"``
+        when the current Atelier version already scanned installed projects,
+        otherwise ``"repaired"`` after the repair pass runs.
+    """
+    if _installed_runtime_repair_state_is_current():
+        return InstalledProjectRuntimeRepairResult(
+            action="skipped",
+            scanned_projects=(),
+            updated_projects=(),
+            failed_projects=(),
+        )
+
+    scanned_projects = _installed_runtime_repair_candidates()
+    updated_projects: list[Path] = []
+    failed_projects: list[tuple[Path, str]] = []
+    for project_dir in scanned_projects:
+        try:
+            result = sync_project_skills(
+                project_dir,
+                upgrade_policy="always",
+                yes=True,
+                interactive=False,
+            )
+        except OSError as exc:
+            failed_projects.append((project_dir, str(exc)))
+            continue
+        if result.action != "up_to_date":
+            updated_projects.append(project_dir)
+
+    if not failed_projects:
+        _write_installed_runtime_repair_state()
+
+    return InstalledProjectRuntimeRepairResult(
+        action="repaired",
+        scanned_projects=scanned_projects,
+        updated_projects=tuple(updated_projects),
+        failed_projects=tuple(failed_projects),
+    )
 
 
 def _projected_runtime_manifest_path(workspace_dir: Path) -> Path:

--- a/src/atelier/skills.py
+++ b/src/atelier/skills.py
@@ -31,6 +31,7 @@ _SKILLS_LOCAL_LOCKS: dict[str, threading.RLock] = {}
 _PACKAGED_SUPPORT_TREE_NAMES = frozenset({"shared"})
 _PROJECTED_RUNTIME_DIRNAME = ".atelier-runtime"
 _PROJECTED_RUNTIME_MANIFEST_FILENAME = "projected-runtime.json"
+_PROJECTED_SUPPORT_MANIFEST_FILENAME = "support-manifest.json"
 _INSTALLED_RUNTIME_REPAIR_STATE_FILENAME = "projected-runtime-repair-state.json"
 
 
@@ -150,7 +151,13 @@ def _verify_skills_tree(
         skill_dir = skills_dir / name
         if "SKILL.md" in definition.files and not (skill_dir / "SKILL.md").is_file():
             return False
-        if _hash_dir(skill_dir) != definition.digest:
+        if (
+            _hash_dir(
+                skill_dir,
+                ignored_relpaths=_generated_skill_relpaths(name),
+            )
+            != definition.digest
+        ):
             return False
     return True
 
@@ -270,12 +277,20 @@ def packaged_skill_metadata() -> dict[str, dict[str, str]]:
     }
 
 
-def _hash_dir(root: Path) -> str:
+def _generated_skill_relpaths(skill_name: str) -> frozenset[str]:
+    if skill_name == "shared":
+        return frozenset({_PROJECTED_SUPPORT_MANIFEST_FILENAME})
+    return frozenset()
+
+
+def _hash_dir(root: Path, *, ignored_relpaths: frozenset[str] = frozenset()) -> str:
     files: dict[str, bytes] = {}
     for path in sorted(root.rglob("*")):
         if not path.is_file():
             continue
         rel_path = path.relative_to(root).as_posix()
+        if rel_path in ignored_relpaths:
+            continue
         files[rel_path] = path.read_bytes()
     return _hash_files(files)
 
@@ -330,7 +345,10 @@ def workspace_skill_state(
         if not skill_dir.exists():
             needs_install = True
             continue
-        actual_hash = _hash_dir(skill_dir)
+        actual_hash = _hash_dir(
+            skill_dir,
+            ignored_relpaths=_generated_skill_relpaths(name),
+        )
         packaged_hash = definition.digest
         stored_entry = stored.get(name)
         stored_hash = stored_entry.get("hash") if stored_entry else None
@@ -376,6 +394,7 @@ def install_workspace_skills(workspace_dir: Path) -> dict[str, dict[str, str]]:
             staging_dir,
             definitions,
         )
+        _write_projected_support_manifest(workspace_dir)
         _write_projected_runtime_manifest(workspace_dir)
     return {
         name: {"version": __version__, "hash": definition.digest}
@@ -419,17 +438,21 @@ def sync_project_skills(
 
     state = workspace_skill_state(project_dir, None)
     if not state.needs_install:
-        if dry_run and _projected_runtime_manifest_requires_backfill(project_dir):
+        if dry_run and (
+            _projected_support_manifest_requires_backfill(project_dir)
+            or _projected_runtime_manifest_requires_backfill(project_dir)
+        ):
             return ProjectSkillsSyncResult(
                 skills_dir=skills_dir,
                 action="would_update",
-                detail="projected runtime manifest missing or invalid",
+                detail="projected support manifest or runtime manifest missing or invalid",
             )
-        if _repair_projected_runtime_manifest(project_dir):
+        repaired_support, repaired_runtime = _repair_projected_runtime_manifests(project_dir)
+        if repaired_support or repaired_runtime:
             return ProjectSkillsSyncResult(
                 skills_dir=skills_dir,
                 action="updated",
-                detail="projected runtime manifest repaired",
+                detail="projected support manifest or runtime manifest repaired",
             )
         return ProjectSkillsSyncResult(skills_dir=skills_dir, action="up_to_date")
     if dry_run:
@@ -569,6 +592,10 @@ def _projected_runtime_manifest_path(workspace_dir: Path) -> Path:
     return workspace_dir / _PROJECTED_RUNTIME_DIRNAME / _PROJECTED_RUNTIME_MANIFEST_FILENAME
 
 
+def _projected_support_manifest_path(workspace_dir: Path) -> Path:
+    return workspace_dir / paths.SKILLS_DIRNAME / "shared" / _PROJECTED_SUPPORT_MANIFEST_FILENAME
+
+
 def _projected_runtime_helper_session_id() -> str:
     for env_key in ("ATELIER_AGENT_SESSION", "ATELIER_AGENT_ID"):
         value = str(os.environ.get(env_key, "")).strip()
@@ -701,6 +728,48 @@ def _write_projected_runtime_manifest(workspace_dir: Path) -> None:
         raise OSError(f"projected runtime manifest write failed: {exc}") from exc
 
 
+def _write_projected_support_manifest(workspace_dir: Path) -> None:
+    manifest_path = _projected_support_manifest_path(workspace_dir)
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = _projected_runtime_manifest_payload()
+    serialized = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    tmp_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            dir=manifest_path.parent,
+            prefix=f".{manifest_path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            handle.write(serialized)
+            handle.flush()
+            tmp_path = Path(handle.name)
+        tmp_path.replace(manifest_path)
+        readback = json.loads(manifest_path.read_text(encoding="utf-8"))
+        _validate_projected_runtime_manifest(readback)
+    except Exception as exc:
+        if tmp_path is not None:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
+        raise OSError(f"projected support manifest write failed: {exc}") from exc
+
+
+def _projected_support_manifest_requires_backfill(workspace_dir: Path) -> bool:
+    manifest_path = _projected_support_manifest_path(workspace_dir)
+    if not manifest_path.is_file():
+        return True
+    try:
+        readback = json.loads(manifest_path.read_text(encoding="utf-8"))
+        _validate_projected_runtime_manifest(readback)
+    except Exception:
+        return True
+    return False
+
+
 def _projected_runtime_manifest_requires_backfill(workspace_dir: Path) -> bool:
     manifest_path = _projected_runtime_manifest_path(workspace_dir)
     if not manifest_path.is_file():
@@ -713,9 +782,14 @@ def _projected_runtime_manifest_requires_backfill(workspace_dir: Path) -> bool:
     return False
 
 
-def _repair_projected_runtime_manifest(workspace_dir: Path) -> bool:
+def _repair_projected_runtime_manifests(workspace_dir: Path) -> tuple[bool, bool]:
     with _skills_write_lock(workspace_dir):
-        if not _projected_runtime_manifest_requires_backfill(workspace_dir):
-            return False
-        _write_projected_runtime_manifest(workspace_dir)
-        return True
+        repaired_support = False
+        repaired_runtime = False
+        if _projected_support_manifest_requires_backfill(workspace_dir):
+            _write_projected_support_manifest(workspace_dir)
+            repaired_support = True
+        if _projected_runtime_manifest_requires_backfill(workspace_dir):
+            _write_projected_runtime_manifest(workspace_dir)
+            repaired_runtime = True
+        return repaired_support, repaired_runtime

--- a/src/atelier/skills/shared/scripts/projected_bootstrap.py
+++ b/src/atelier/skills/shared/scripts/projected_bootstrap.py
@@ -18,6 +18,7 @@ _DEFAULT_REPO_DIR_ENV_VARS: tuple[str, ...] = (
 )
 _PROJECTED_RUNTIME_DIRNAME = ".atelier-runtime"
 _PROJECTED_RUNTIME_MANIFEST_FILENAME = "projected-runtime.json"
+_PROJECTED_SUPPORT_MANIFEST_FILENAME = "support-manifest.json"
 _PROJECTED_SUPPORT_RUNTIME_SELECTED_ENV = "ATELIER_PROJECTED_SUPPORT_RUNTIME_SELECTED"
 _PROJECTED_SUPPORT_RUNTIME_REPAIR_ATTEMPTED_ENV = (
     "ATELIER_PROJECTED_SUPPORT_RUNTIME_REPAIR_ATTEMPTED"
@@ -112,6 +113,14 @@ def _support_runtime_manifest_path(script_path: Path) -> Path | None:
     return None
 
 
+def _projected_support_manifest_path(script_path: Path) -> Path | None:
+    resolved_script = script_path.resolve()
+    for parent in resolved_script.parents:
+        if parent.name == "skills":
+            return parent / "shared" / _PROJECTED_SUPPORT_MANIFEST_FILENAME
+    return None
+
+
 def _same_executable(current_executable: str, selected_interpreter: str) -> bool:
     current = str(current_executable).strip()
     selected = str(selected_interpreter).strip()
@@ -161,43 +170,48 @@ def _activate_support_runtime_paths(entries: Sequence[str]) -> tuple[str, ...]:
     return ordered
 
 
-def _read_support_runtime_manifest(manifest_path: Path) -> tuple[object | None, str | None]:
+def _read_support_runtime_manifest(
+    manifest_path: Path,
+    *,
+    subject: str = "projected support runtime manifest",
+) -> tuple[object | None, str | None]:
     try:
         return json.loads(manifest_path.read_text(encoding="utf-8")), None
     except FileNotFoundError:
-        return None, f"projected support runtime manifest missing: {manifest_path}"
+        return None, f"{subject} missing: {manifest_path}"
     except (OSError, json.JSONDecodeError) as exc:
-        return None, f"projected support runtime manifest is malformed: {exc}"
+        return None, f"{subject} is malformed: {exc}"
 
 
 def _parse_support_runtime_manifest(
     payload: object,
+    *,
+    subject: str = "projected support runtime manifest",
 ) -> tuple[_ProjectedSupportRuntimeManifest | None, str | None]:
     if not isinstance(payload, dict):
-        return None, "projected support runtime manifest is not a JSON object."
+        return None, f"{subject} is not a JSON object."
     if payload.get("status") != "converged":
-        return None, "projected support runtime manifest did not prove convergence."
+        return None, f"{subject} did not prove convergence."
     helper_session_id = str(payload.get("helper_session_id", "")).strip()
     selected_interpreter = str(payload.get("selected_interpreter", "")).strip()
     import_root_raw = str(payload.get("atelier_import_root", "")).strip()
     pythonpath_entries_raw = payload.get("pythonpath_entries")
     if not helper_session_id:
-        return None, "projected support runtime manifest is missing helper_session_id."
+        return None, f"{subject} is missing helper_session_id."
     if not selected_interpreter:
-        return None, "projected support runtime manifest is missing selected_interpreter."
+        return None, f"{subject} is missing selected_interpreter."
     if not import_root_raw:
-        return None, "projected support runtime manifest is missing atelier_import_root."
+        return None, f"{subject} is missing atelier_import_root."
     if not isinstance(pythonpath_entries_raw, list) or not pythonpath_entries_raw:
-        return None, "projected support runtime manifest is missing pythonpath_entries."
+        return None, f"{subject} is missing pythonpath_entries."
     try:
         import_root = Path(import_root_raw).expanduser().resolve()
     except OSError as exc:
-        return None, f"projected support runtime manifest import root is invalid: {exc}"
+        return None, f"{subject} import root is invalid: {exc}"
     if not (import_root / "atelier" / "__init__.py").is_file():
         return (
             None,
-            "projected support runtime manifest does not point at an importable "
-            f"Atelier root: {import_root}",
+            f"{subject} does not point at an importable Atelier root: {import_root}",
         )
     pythonpath_entries = tuple(
         str(Path(str(entry).strip()).expanduser())
@@ -217,25 +231,57 @@ def _parse_support_runtime_manifest(
 
 def _repair_support_runtime_manifest(
     *,
+    script_path: Path,
     manifest_path: Path,
-    payload: object,
     env: Mapping[str, str],
 ) -> tuple[bool, str | None]:
     if env.get(_PROJECTED_SUPPORT_RUNTIME_REPAIR_ATTEMPTED_ENV) == "1":
         return False, None
-    if not isinstance(payload, dict):
-        return False, None
-    selected_interpreter = str(payload.get("selected_interpreter", "")).strip()
-    if not selected_interpreter:
-        return False, None
-    selected_path = Path(selected_interpreter).expanduser()
-    if not (selected_path.is_file() and os.access(selected_path, os.X_OK)):
-        return False, None
 
     workspace_dir = manifest_path.parent.parent.resolve()
+    support_manifest_path = _projected_support_manifest_path(script_path)
+    if support_manifest_path is None:
+        return (
+            False,
+            "projected support runtime self-heal is unavailable because the "
+            "projected support manifest path could not be derived from script path.",
+        )
+    support_payload, support_read_error = _read_support_runtime_manifest(
+        support_manifest_path,
+        subject="projected support manifest",
+    )
+    if support_read_error is not None:
+        return (
+            False,
+            f"projected support runtime self-heal is unavailable: {support_read_error}",
+        )
+    support_manifest, support_manifest_error = _parse_support_runtime_manifest(
+        support_payload,
+        subject="projected support manifest",
+    )
+    if support_manifest_error is not None:
+        return (
+            False,
+            f"projected support runtime self-heal is unavailable: {support_manifest_error}",
+        )
+    assert support_manifest is not None
+
+    support_path = Path(support_manifest.selected_interpreter).expanduser()
+    if not (support_path.is_file() and os.access(support_path, os.X_OK)):
+        return (
+            False,
+            "projected support runtime self-heal is unavailable because the "
+            "projected support manifest selected_interpreter is not executable: "
+            f"{support_manifest.selected_interpreter}",
+        )
+
     helper_env = dict(env)
     helper_env[_PROJECTED_SUPPORT_RUNTIME_REPAIR_ATTEMPTED_ENV] = "1"
     helper_env.pop(_PROJECTED_SUPPORT_RUNTIME_SELECTED_ENV, None)
+    if support_manifest.pythonpath_entries:
+        helper_env["PYTHONPATH"] = os.pathsep.join(support_manifest.pythonpath_entries)
+    else:
+        helper_env.pop("PYTHONPATH", None)
     repair_program = "\n".join(
         (
             "import json, sys",
@@ -268,7 +314,7 @@ def _repair_support_runtime_manifest(
     )
     try:
         completed = subprocess.run(
-            [selected_interpreter, "-c", repair_program, str(workspace_dir)],
+            [support_manifest.selected_interpreter, "-c", repair_program, str(workspace_dir)],
             check=False,
             capture_output=True,
             text=True,
@@ -324,7 +370,10 @@ def _repair_support_runtime_manifest(
             "projected support runtime self-heal convergence evidence referenced "
             f"the wrong manifest: {evidence_manifest or '(missing)'}",
         )
-    _manifest, manifest_error = _parse_support_runtime_manifest(evidence.get("manifest"))
+    _manifest, manifest_error = _parse_support_runtime_manifest(
+        evidence.get("manifest"),
+        subject="projected support runtime self-heal manifest evidence",
+    )
     if manifest_error is not None:
         return (
             True,
@@ -356,8 +405,8 @@ def _load_support_runtime_resolution(
     manifest, manifest_error = _parse_support_runtime_manifest(payload)
     if manifest_error is not None:
         attempted_repair, repair_error = _repair_support_runtime_manifest(
+            script_path=script_path,
             manifest_path=manifest_path,
-            payload=payload,
             env=env,
         )
         if repair_error is not None:

--- a/src/atelier/skills/shared/scripts/projected_bootstrap.py
+++ b/src/atelier/skills/shared/scripts/projected_bootstrap.py
@@ -19,6 +19,10 @@ _DEFAULT_REPO_DIR_ENV_VARS: tuple[str, ...] = (
 _PROJECTED_RUNTIME_DIRNAME = ".atelier-runtime"
 _PROJECTED_RUNTIME_MANIFEST_FILENAME = "projected-runtime.json"
 _PROJECTED_SUPPORT_MANIFEST_FILENAME = "support-manifest.json"
+_AGENT_METADATA_FILENAME = "agent.json"
+_PROJECT_CONFIG_SYS_FILENAME = "config.sys.json"
+_PROJECT_CONFIG_LEGACY_FILENAME = "config.json"
+_WORKTREES_DIRNAME = "worktrees"
 _PROJECTED_SUPPORT_RUNTIME_SELECTED_ENV = "ATELIER_PROJECTED_SUPPORT_RUNTIME_SELECTED"
 _PROJECTED_SUPPORT_RUNTIME_REPAIR_ATTEMPTED_ENV = (
     "ATELIER_PROJECTED_SUPPORT_RUNTIME_REPAIR_ATTEMPTED"
@@ -105,20 +109,77 @@ def _bootstrap_source_import(
     return None
 
 
-def _support_runtime_manifest_path(script_path: Path) -> Path | None:
+def _is_project_data_dir(path: Path) -> bool:
+    return (
+        (path / _PROJECT_CONFIG_SYS_FILENAME).exists()
+        or (path / _PROJECT_CONFIG_LEGACY_FILENAME).exists()
+        or (path / _WORKTREES_DIRNAME).exists()
+        or (path / "skills").is_dir()
+    )
+
+
+def _projected_skill_roots(script_path: Path) -> tuple[Path, ...]:
     resolved_script = script_path.resolve()
+    current_skill_root: Path | None = None
     for parent in resolved_script.parents:
         if parent.name == "skills":
-            return parent.parent / _PROJECTED_RUNTIME_DIRNAME / _PROJECTED_RUNTIME_MANIFEST_FILENAME
-    return None
+            current_skill_root = parent
+            break
+    if current_skill_root is None:
+        return ()
+
+    candidate_roots: list[Path] = []
+    agent_home_root = current_skill_root.parent
+    if (agent_home_root / _AGENT_METADATA_FILENAME).is_file():
+        for ancestor in agent_home_root.parents:
+            if ancestor.name != "agents":
+                continue
+            project_dir = ancestor.parent
+            if not _is_project_data_dir(project_dir):
+                continue
+            canonical_skills_root = project_dir / "skills"
+            if canonical_skills_root.is_dir():
+                candidate_roots.append(canonical_skills_root)
+            break
+    candidate_roots.append(current_skill_root)
+
+    ordered: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in candidate_roots:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        ordered.append(resolved)
+    return tuple(ordered)
+
+
+def _preferred_existing_path(candidates: Sequence[Path]) -> Path | None:
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    if not candidates:
+        return None
+    return candidates[0]
+
+
+def _support_runtime_manifest_path(script_path: Path) -> Path | None:
+    candidates = tuple(
+        skill_root.parent / _PROJECTED_RUNTIME_DIRNAME / _PROJECTED_RUNTIME_MANIFEST_FILENAME
+        for skill_root in _projected_skill_roots(script_path)
+    )
+    return _preferred_existing_path(candidates)
 
 
 def _projected_support_manifest_path(script_path: Path) -> Path | None:
-    resolved_script = script_path.resolve()
-    for parent in resolved_script.parents:
-        if parent.name == "skills":
-            return parent / "shared" / _PROJECTED_SUPPORT_MANIFEST_FILENAME
-    return None
+    candidates = tuple(
+        skill_root / "shared" / _PROJECTED_SUPPORT_MANIFEST_FILENAME
+        for skill_root in _projected_skill_roots(script_path)
+    )
+    return _preferred_existing_path(candidates)
 
 
 def _same_executable(current_executable: str, selected_interpreter: str) -> bool:

--- a/src/atelier/skills/shared/scripts/projected_bootstrap.py
+++ b/src/atelier/skills/shared/scripts/projected_bootstrap.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
@@ -18,6 +19,9 @@ _DEFAULT_REPO_DIR_ENV_VARS: tuple[str, ...] = (
 _PROJECTED_RUNTIME_DIRNAME = ".atelier-runtime"
 _PROJECTED_RUNTIME_MANIFEST_FILENAME = "projected-runtime.json"
 _PROJECTED_SUPPORT_RUNTIME_SELECTED_ENV = "ATELIER_PROJECTED_SUPPORT_RUNTIME_SELECTED"
+_PROJECTED_SUPPORT_RUNTIME_REPAIR_ATTEMPTED_ENV = (
+    "ATELIER_PROJECTED_SUPPORT_RUNTIME_REPAIR_ATTEMPTED"
+)
 _INSTALLED_TOOL_RUNTIME_MARKERS: tuple[str, ...] = (
     "/.local/share/uv/tools/atelier/",
     "/Library/Application Support/uv/tools/atelier/",
@@ -31,6 +35,14 @@ class _ProjectedSupportRuntimeResolution:
     detail: str
     command: tuple[str, ...] | None = None
     pythonpath_entries: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class _ProjectedSupportRuntimeManifest:
+    helper_session_id: str
+    selected_interpreter: str
+    import_root: Path
+    pythonpath_entries: tuple[str, ...]
 
 
 def _repo_dir_from_argv(argv: Sequence[str]) -> Path | None:
@@ -149,6 +161,179 @@ def _activate_support_runtime_paths(entries: Sequence[str]) -> tuple[str, ...]:
     return ordered
 
 
+def _read_support_runtime_manifest(manifest_path: Path) -> tuple[object | None, str | None]:
+    try:
+        return json.loads(manifest_path.read_text(encoding="utf-8")), None
+    except FileNotFoundError:
+        return None, f"projected support runtime manifest missing: {manifest_path}"
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"projected support runtime manifest is malformed: {exc}"
+
+
+def _parse_support_runtime_manifest(
+    payload: object,
+) -> tuple[_ProjectedSupportRuntimeManifest | None, str | None]:
+    if not isinstance(payload, dict):
+        return None, "projected support runtime manifest is not a JSON object."
+    if payload.get("status") != "converged":
+        return None, "projected support runtime manifest did not prove convergence."
+    helper_session_id = str(payload.get("helper_session_id", "")).strip()
+    selected_interpreter = str(payload.get("selected_interpreter", "")).strip()
+    import_root_raw = str(payload.get("atelier_import_root", "")).strip()
+    pythonpath_entries_raw = payload.get("pythonpath_entries")
+    if not helper_session_id:
+        return None, "projected support runtime manifest is missing helper_session_id."
+    if not selected_interpreter:
+        return None, "projected support runtime manifest is missing selected_interpreter."
+    if not import_root_raw:
+        return None, "projected support runtime manifest is missing atelier_import_root."
+    if not isinstance(pythonpath_entries_raw, list) or not pythonpath_entries_raw:
+        return None, "projected support runtime manifest is missing pythonpath_entries."
+    try:
+        import_root = Path(import_root_raw).expanduser().resolve()
+    except OSError as exc:
+        return None, f"projected support runtime manifest import root is invalid: {exc}"
+    if not (import_root / "atelier" / "__init__.py").is_file():
+        return (
+            None,
+            "projected support runtime manifest does not point at an importable "
+            f"Atelier root: {import_root}",
+        )
+    pythonpath_entries = tuple(
+        str(Path(str(entry).strip()).expanduser())
+        for entry in pythonpath_entries_raw
+        if str(entry).strip()
+    )
+    return (
+        _ProjectedSupportRuntimeManifest(
+            helper_session_id=helper_session_id,
+            selected_interpreter=selected_interpreter,
+            import_root=import_root,
+            pythonpath_entries=pythonpath_entries,
+        ),
+        None,
+    )
+
+
+def _repair_support_runtime_manifest(
+    *,
+    manifest_path: Path,
+    payload: object,
+    env: Mapping[str, str],
+) -> tuple[bool, str | None]:
+    if env.get(_PROJECTED_SUPPORT_RUNTIME_REPAIR_ATTEMPTED_ENV) == "1":
+        return False, None
+    if not isinstance(payload, dict):
+        return False, None
+    selected_interpreter = str(payload.get("selected_interpreter", "")).strip()
+    if not selected_interpreter:
+        return False, None
+    selected_path = Path(selected_interpreter).expanduser()
+    if not (selected_path.is_file() and os.access(selected_path, os.X_OK)):
+        return False, None
+
+    workspace_dir = manifest_path.parent.parent.resolve()
+    helper_env = dict(env)
+    helper_env[_PROJECTED_SUPPORT_RUNTIME_REPAIR_ATTEMPTED_ENV] = "1"
+    helper_env.pop(_PROJECTED_SUPPORT_RUNTIME_SELECTED_ENV, None)
+    repair_program = "\n".join(
+        (
+            "import json, sys",
+            "from pathlib import Path",
+            "from atelier import skills",
+            "",
+            "workspace_dir = Path(sys.argv[1]).expanduser().resolve()",
+            "result = skills.sync_project_skills(",
+            "    workspace_dir,",
+            "    upgrade_policy='always',",
+            "    yes=True,",
+            "    interactive=False,",
+            ")",
+            "manifest_path = workspace_dir / '.atelier-runtime' / 'projected-runtime.json'",
+            "payload = json.loads(manifest_path.read_text(encoding='utf-8'))",
+            "validated = skills._validate_projected_runtime_manifest(payload)",
+            "print(",
+            "    json.dumps(",
+            "        {",
+            "            'status': 'converged',",
+            "            'workspace_dir': str(workspace_dir),",
+            "            'manifest_path': str(manifest_path.resolve()),",
+            "            'sync_action': result.action,",
+            "            'manifest': validated,",
+            "        },",
+            "        sort_keys=True,",
+            "    )",
+            ")",
+        )
+    )
+    try:
+        completed = subprocess.run(
+            [selected_interpreter, "-c", repair_program, str(workspace_dir)],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=helper_env,
+            cwd=workspace_dir,
+        )
+    except OSError as exc:
+        return True, f"projected support runtime self-heal failed to start: {exc}"
+    if completed.returncode != 0:
+        detail = " ".join(
+            chunk.strip()
+            for chunk in (completed.stderr, completed.stdout)
+            if isinstance(chunk, str) and chunk.strip()
+        )
+        if not detail:
+            detail = f"exit status {completed.returncode}"
+        return True, f"projected support runtime self-heal failed: {detail}"
+
+    raw_evidence = (completed.stdout or "").strip()
+    if not raw_evidence:
+        return (
+            True,
+            "projected support runtime self-heal did not emit convergence evidence.",
+        )
+    try:
+        evidence = json.loads(raw_evidence)
+    except json.JSONDecodeError as exc:
+        return (
+            True,
+            f"projected support runtime self-heal emitted malformed convergence evidence: {exc}",
+        )
+    if not isinstance(evidence, dict):
+        return (
+            True,
+            "projected support runtime self-heal convergence evidence was not a JSON object.",
+        )
+    if evidence.get("status") != "converged":
+        return (
+            True,
+            "projected support runtime self-heal convergence evidence did not prove convergence.",
+        )
+    evidence_workspace = str(evidence.get("workspace_dir", "")).strip()
+    if evidence_workspace != str(workspace_dir):
+        return (
+            True,
+            "projected support runtime self-heal convergence evidence referenced "
+            f"the wrong workspace: {evidence_workspace or '(missing)'}",
+        )
+    evidence_manifest = str(evidence.get("manifest_path", "")).strip()
+    if evidence_manifest != str(manifest_path.resolve()):
+        return (
+            True,
+            "projected support runtime self-heal convergence evidence referenced "
+            f"the wrong manifest: {evidence_manifest or '(missing)'}",
+        )
+    _manifest, manifest_error = _parse_support_runtime_manifest(evidence.get("manifest"))
+    if manifest_error is not None:
+        return (
+            True,
+            "projected support runtime self-heal convergence evidence did not "
+            f"prove convergence: {manifest_error}",
+        )
+    return True, None
+
+
 def _load_support_runtime_resolution(
     *,
     script_path: Path,
@@ -161,79 +346,57 @@ def _load_support_runtime_resolution(
             status="unavailable",
             detail="projected support runtime manifest path could not be derived from script path.",
         )
-    try:
-        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
+    payload, manifest_read_error = _read_support_runtime_manifest(manifest_path)
+    if manifest_read_error is not None:
         return _ProjectedSupportRuntimeResolution(
             status="unavailable",
-            detail=f"projected support runtime manifest missing: {manifest_path}",
+            detail=manifest_read_error,
         )
-    except (OSError, json.JSONDecodeError) as exc:
-        return _ProjectedSupportRuntimeResolution(
-            status="unavailable",
-            detail=f"projected support runtime manifest is malformed: {exc}",
+
+    manifest, manifest_error = _parse_support_runtime_manifest(payload)
+    if manifest_error is not None:
+        attempted_repair, repair_error = _repair_support_runtime_manifest(
+            manifest_path=manifest_path,
+            payload=payload,
+            env=env,
         )
-    if not isinstance(payload, dict):
-        return _ProjectedSupportRuntimeResolution(
-            status="unavailable",
-            detail="projected support runtime manifest is not a JSON object.",
-        )
-    if payload.get("status") != "converged":
-        return _ProjectedSupportRuntimeResolution(
-            status="unavailable",
-            detail="projected support runtime manifest did not prove convergence.",
-        )
-    helper_session_id = str(payload.get("helper_session_id", "")).strip()
-    selected_interpreter = str(payload.get("selected_interpreter", "")).strip()
-    import_root_raw = str(payload.get("atelier_import_root", "")).strip()
-    pythonpath_entries_raw = payload.get("pythonpath_entries")
-    if not helper_session_id:
-        return _ProjectedSupportRuntimeResolution(
-            status="unavailable",
-            detail="projected support runtime manifest is missing helper_session_id.",
-        )
-    if not selected_interpreter:
-        return _ProjectedSupportRuntimeResolution(
-            status="unavailable",
-            detail="projected support runtime manifest is missing selected_interpreter.",
-        )
-    if not import_root_raw:
-        return _ProjectedSupportRuntimeResolution(
-            status="unavailable",
-            detail="projected support runtime manifest is missing atelier_import_root.",
-        )
-    if not isinstance(pythonpath_entries_raw, list) or not pythonpath_entries_raw:
-        return _ProjectedSupportRuntimeResolution(
-            status="unavailable",
-            detail="projected support runtime manifest is missing pythonpath_entries.",
-        )
-    try:
-        import_root = Path(import_root_raw).expanduser().resolve()
-    except OSError as exc:
-        return _ProjectedSupportRuntimeResolution(
-            status="unavailable",
-            detail=f"projected support runtime manifest import root is invalid: {exc}",
-        )
-    if not (import_root / "atelier" / "__init__.py").is_file():
-        return _ProjectedSupportRuntimeResolution(
-            status="unavailable",
-            detail=(
-                "projected support runtime manifest does not point at an "
-                f"importable Atelier root: {import_root}"
-            ),
-        )
-    pythonpath_entries = tuple(
-        str(Path(str(entry).strip()).expanduser())
-        for entry in pythonpath_entries_raw
-        if str(entry).strip()
-    )
-    if _same_executable(sys.executable, selected_interpreter):
-        activated = _activate_support_runtime_paths(pythonpath_entries)
+        if repair_error is not None:
+            return _ProjectedSupportRuntimeResolution(
+                status="unavailable",
+                detail=repair_error,
+            )
+        if not attempted_repair:
+            return _ProjectedSupportRuntimeResolution(
+                status="unavailable",
+                detail=manifest_error,
+            )
+        payload, manifest_read_error = _read_support_runtime_manifest(manifest_path)
+        if manifest_read_error is not None:
+            return _ProjectedSupportRuntimeResolution(
+                status="unavailable",
+                detail=(
+                    "projected support runtime self-heal completed without readable "
+                    f"manifest evidence: {manifest_read_error}"
+                ),
+            )
+        manifest, manifest_error = _parse_support_runtime_manifest(payload)
+        if manifest_error is not None:
+            return _ProjectedSupportRuntimeResolution(
+                status="unavailable",
+                detail=(
+                    "projected support runtime self-heal completed without "
+                    f"converged manifest evidence: {manifest_error}"
+                ),
+            )
+
+    assert manifest is not None
+    if _same_executable(sys.executable, manifest.selected_interpreter):
+        activated = _activate_support_runtime_paths(manifest.pythonpath_entries)
         return _ProjectedSupportRuntimeResolution(
             status="active",
             detail=(
                 "projected support runtime evidence converged in the current interpreter "
-                f"via helper session {helper_session_id}."
+                f"via helper session {manifest.helper_session_id}."
             ),
             command=None,
             pythonpath_entries=activated,
@@ -245,44 +408,44 @@ def _load_support_runtime_resolution(
                 "projected support runtime re-exec was already attempted, but the "
                 "selected interpreter still did not converge."
             ),
-            command=(selected_interpreter,),
-            pythonpath_entries=pythonpath_entries,
+            command=(manifest.selected_interpreter,),
+            pythonpath_entries=manifest.pythonpath_entries,
         )
-    selected_path = Path(selected_interpreter).expanduser()
+    selected_path = Path(manifest.selected_interpreter).expanduser()
     if not (selected_path.is_file() and os.access(selected_path, os.X_OK)):
         return _ProjectedSupportRuntimeResolution(
             status="unavailable",
             detail=(
                 "projected support runtime manifest selected_interpreter is not executable: "
-                f"{selected_interpreter}"
+                f"{manifest.selected_interpreter}"
             ),
-            command=(selected_interpreter,),
-            pythonpath_entries=pythonpath_entries,
+            command=(manifest.selected_interpreter,),
+            pythonpath_entries=manifest.pythonpath_entries,
         )
     exec_env = dict(env)
     exec_env[_PROJECTED_SUPPORT_RUNTIME_SELECTED_ENV] = "1"
-    if pythonpath_entries:
-        exec_env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+    if manifest.pythonpath_entries:
+        exec_env["PYTHONPATH"] = os.pathsep.join(manifest.pythonpath_entries)
     else:
         exec_env.pop("PYTHONPATH", None)
     try:
         os.execvpe(
-            selected_interpreter,
-            [selected_interpreter, str(script_path), *argv],
+            manifest.selected_interpreter,
+            [manifest.selected_interpreter, str(script_path), *argv],
             exec_env,
         )
     except OSError as exc:
         return _ProjectedSupportRuntimeResolution(
             status="unavailable",
             detail=f"projected support runtime re-exec failed: {exc}",
-            command=(selected_interpreter,),
-            pythonpath_entries=pythonpath_entries,
+            command=(manifest.selected_interpreter,),
+            pythonpath_entries=manifest.pythonpath_entries,
         )
     return _ProjectedSupportRuntimeResolution(
         status="available",
         detail="projected support runtime re-exec was requested.",
-        command=(selected_interpreter,),
-        pythonpath_entries=pythonpath_entries,
+        command=(manifest.selected_interpreter,),
+        pythonpath_entries=manifest.pythonpath_entries,
     )
 
 

--- a/src/atelier/skills/shared/scripts/projected_bootstrap.py
+++ b/src/atelier/skills/shared/scripts/projected_bootstrap.py
@@ -50,6 +50,12 @@ class _ProjectedSupportRuntimeManifest:
     pythonpath_entries: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class _ProjectedSupportRuntimeRepairLauncher:
+    selected_interpreter: str
+    pythonpath_entries: tuple[str, ...]
+
+
 def _repo_dir_from_argv(argv: Sequence[str]) -> Path | None:
     """Return an explicit ``--repo-dir`` argument when present.
 
@@ -290,6 +296,106 @@ def _parse_support_runtime_manifest(
     )
 
 
+def _validate_support_runtime_interpreter(
+    selected_interpreter: str,
+    *,
+    subject: str,
+) -> tuple[str | None, str | None]:
+    interpreter = str(selected_interpreter).strip()
+    if not interpreter:
+        return None, f"{subject} is missing selected_interpreter."
+    interpreter_path = Path(interpreter).expanduser()
+    if not (interpreter_path.is_file() and os.access(interpreter_path, os.X_OK)):
+        return (
+            None,
+            f"{subject} selected_interpreter is not executable: {interpreter}",
+        )
+    return interpreter, None
+
+
+def _support_runtime_repair_launcher(
+    *,
+    script_path: Path,
+    manifest_path: Path,
+) -> tuple[_ProjectedSupportRuntimeRepairLauncher | None, str | None]:
+    support_manifest_path = _projected_support_manifest_path(script_path)
+    support_manifest_error: str | None = None
+    if support_manifest_path is None:
+        support_manifest_error = (
+            "projected support manifest path could not be derived from script path."
+        )
+    else:
+        support_payload, support_read_error = _read_support_runtime_manifest(
+            support_manifest_path,
+            subject="projected support manifest",
+        )
+        if support_read_error is not None:
+            support_manifest_error = support_read_error
+        else:
+            support_manifest, parsed_support_error = _parse_support_runtime_manifest(
+                support_payload,
+                subject="projected support manifest",
+            )
+            if parsed_support_error is not None:
+                support_manifest_error = parsed_support_error
+            else:
+                assert support_manifest is not None
+                interpreter, interpreter_error = _validate_support_runtime_interpreter(
+                    support_manifest.selected_interpreter,
+                    subject="projected support manifest",
+                )
+                if interpreter_error is not None:
+                    support_manifest_error = interpreter_error
+                else:
+                    assert interpreter is not None
+                    return (
+                        _ProjectedSupportRuntimeRepairLauncher(
+                            selected_interpreter=interpreter,
+                            pythonpath_entries=support_manifest.pythonpath_entries,
+                        ),
+                        None,
+                    )
+
+    manifest_payload, manifest_read_error = _read_support_runtime_manifest(
+        manifest_path,
+        subject="projected support runtime manifest",
+    )
+    if manifest_read_error is not None:
+        if support_manifest_error is None:
+            return None, manifest_read_error
+        return (
+            None,
+            "projected support runtime self-heal is unavailable: "
+            f"{support_manifest_error}; fallback recorded runtime is unavailable: "
+            f"{manifest_read_error}",
+        )
+    if not isinstance(manifest_payload, dict):
+        recorded_manifest_error = "projected support runtime manifest is not a JSON object."
+    else:
+        interpreter, interpreter_error = _validate_support_runtime_interpreter(
+            str(manifest_payload.get("selected_interpreter", "")),
+            subject="projected support runtime manifest",
+        )
+        if interpreter_error is None:
+            assert interpreter is not None
+            return (
+                _ProjectedSupportRuntimeRepairLauncher(
+                    selected_interpreter=interpreter,
+                    pythonpath_entries=(),
+                ),
+                None,
+            )
+        recorded_manifest_error = interpreter_error
+    if support_manifest_error is None:
+        return None, recorded_manifest_error
+    return (
+        None,
+        "projected support runtime self-heal is unavailable: "
+        f"{support_manifest_error}; fallback recorded runtime is unavailable: "
+        f"{recorded_manifest_error}",
+    )
+
+
 def _repair_support_runtime_manifest(
     *,
     script_path: Path,
@@ -300,47 +406,19 @@ def _repair_support_runtime_manifest(
         return False, None
 
     workspace_dir = manifest_path.parent.parent.resolve()
-    support_manifest_path = _projected_support_manifest_path(script_path)
-    if support_manifest_path is None:
-        return (
-            False,
-            "projected support runtime self-heal is unavailable because the "
-            "projected support manifest path could not be derived from script path.",
-        )
-    support_payload, support_read_error = _read_support_runtime_manifest(
-        support_manifest_path,
-        subject="projected support manifest",
+    launcher, launcher_error = _support_runtime_repair_launcher(
+        script_path=script_path,
+        manifest_path=manifest_path,
     )
-    if support_read_error is not None:
-        return (
-            False,
-            f"projected support runtime self-heal is unavailable: {support_read_error}",
-        )
-    support_manifest, support_manifest_error = _parse_support_runtime_manifest(
-        support_payload,
-        subject="projected support manifest",
-    )
-    if support_manifest_error is not None:
-        return (
-            False,
-            f"projected support runtime self-heal is unavailable: {support_manifest_error}",
-        )
-    assert support_manifest is not None
-
-    support_path = Path(support_manifest.selected_interpreter).expanduser()
-    if not (support_path.is_file() and os.access(support_path, os.X_OK)):
-        return (
-            False,
-            "projected support runtime self-heal is unavailable because the "
-            "projected support manifest selected_interpreter is not executable: "
-            f"{support_manifest.selected_interpreter}",
-        )
+    if launcher_error is not None:
+        return False, launcher_error
+    assert launcher is not None
 
     helper_env = dict(env)
     helper_env[_PROJECTED_SUPPORT_RUNTIME_REPAIR_ATTEMPTED_ENV] = "1"
     helper_env.pop(_PROJECTED_SUPPORT_RUNTIME_SELECTED_ENV, None)
-    if support_manifest.pythonpath_entries:
-        helper_env["PYTHONPATH"] = os.pathsep.join(support_manifest.pythonpath_entries)
+    if launcher.pythonpath_entries:
+        helper_env["PYTHONPATH"] = os.pathsep.join(launcher.pythonpath_entries)
     else:
         helper_env.pop("PYTHONPATH", None)
     repair_program = "\n".join(
@@ -375,7 +453,7 @@ def _repair_support_runtime_manifest(
     )
     try:
         completed = subprocess.run(
-            [support_manifest.selected_interpreter, "-c", repair_program, str(workspace_dir)],
+            [launcher.selected_interpreter, "-c", repair_program, str(workspace_dir)],
             check=False,
             capture_output=True,
             text=True,

--- a/src/atelier/skills/shared/scripts/projected_bootstrap.py
+++ b/src/atelier/skills/shared/scripts/projected_bootstrap.py
@@ -296,6 +296,39 @@ def _parse_support_runtime_manifest(
     )
 
 
+def _parse_support_runtime_repair_launcher(
+    payload: object,
+    *,
+    subject: str,
+) -> tuple[_ProjectedSupportRuntimeRepairLauncher | None, str | None]:
+    if not isinstance(payload, dict):
+        return None, f"{subject} is not a JSON object."
+    interpreter, interpreter_error = _validate_support_runtime_interpreter(
+        str(payload.get("selected_interpreter", "")),
+        subject=subject,
+    )
+    if interpreter_error is not None:
+        return None, interpreter_error
+    pythonpath_entries_raw = payload.get("pythonpath_entries")
+    if not isinstance(pythonpath_entries_raw, list) or not pythonpath_entries_raw:
+        return None, f"{subject} is missing pythonpath_entries."
+    pythonpath_entries = tuple(
+        str(Path(str(entry).strip()).expanduser())
+        for entry in pythonpath_entries_raw
+        if str(entry).strip()
+    )
+    if not pythonpath_entries:
+        return None, f"{subject} is missing pythonpath_entries."
+    assert interpreter is not None
+    return (
+        _ProjectedSupportRuntimeRepairLauncher(
+            selected_interpreter=interpreter,
+            pythonpath_entries=pythonpath_entries,
+        ),
+        None,
+    )
+
+
 def _validate_support_runtime_interpreter(
     selected_interpreter: str,
     *,
@@ -369,23 +402,13 @@ def _support_runtime_repair_launcher(
             f"{support_manifest_error}; fallback recorded runtime is unavailable: "
             f"{manifest_read_error}",
         )
-    if not isinstance(manifest_payload, dict):
-        recorded_manifest_error = "projected support runtime manifest is not a JSON object."
-    else:
-        interpreter, interpreter_error = _validate_support_runtime_interpreter(
-            str(manifest_payload.get("selected_interpreter", "")),
-            subject="projected support runtime manifest",
-        )
-        if interpreter_error is None:
-            assert interpreter is not None
-            return (
-                _ProjectedSupportRuntimeRepairLauncher(
-                    selected_interpreter=interpreter,
-                    pythonpath_entries=(),
-                ),
-                None,
-            )
-        recorded_manifest_error = interpreter_error
+    launcher, recorded_manifest_error = _parse_support_runtime_repair_launcher(
+        manifest_payload,
+        subject="projected support runtime manifest",
+    )
+    if recorded_manifest_error is None:
+        assert launcher is not None
+        return launcher, None
     if support_manifest_error is None:
         return None, recorded_manifest_error
     return (

--- a/tests/atelier/commands/test_cli_logging_flags.py
+++ b/tests/atelier/commands/test_cli_logging_flags.py
@@ -44,3 +44,31 @@ def test_no_color_flag_disables_colorized_output() -> None:
 
     assert result.exit_code == 0
     mock_set_no_color.assert_called_once_with(True)
+
+
+def test_cli_repairs_installed_project_skills_before_dispatch() -> None:
+    runner = CliRunner()
+    with (
+        patch("atelier.cli.status_cmd", lambda _args: None),
+        patch("atelier.cli.skills.repair_installed_project_skills_for_current_version") as repair,
+    ):
+        result = runner.invoke(cli.app, ["status"])
+
+    assert result.exit_code == 0
+    repair.assert_called_once_with()
+
+
+def test_cli_skips_installed_project_repair_during_completion() -> None:
+    runner = CliRunner()
+    with (
+        patch("atelier.cli.status_cmd", lambda _args: None),
+        patch("atelier.cli.skills.repair_installed_project_skills_for_current_version") as repair,
+    ):
+        result = runner.invoke(
+            cli.app,
+            ["status"],
+            env={"_ATELIER_COMPLETE": "bash_complete"},
+        )
+
+    assert result.exit_code == 0
+    repair.assert_not_called()

--- a/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
+++ b/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
@@ -151,6 +151,42 @@ def _write_repo_python_without_site_packages(repo_root: Path) -> None:
     _write_python_without_site_packages(repo_python)
 
 
+def _write_python_with_pythonpath(
+    python_path: Path,
+    *,
+    pythonpath: Sequence[Path | str],
+) -> None:
+    python_path.parent.mkdir(parents=True, exist_ok=True)
+    joined_pythonpath = os.pathsep.join(str(entry) for entry in pythonpath)
+    python_path.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                f'export PYTHONPATH="{joined_pythonpath}"',
+                f'exec "{Path(sys.executable).resolve()}" "$@"',
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    python_path.chmod(python_path.stat().st_mode | 0o111)
+
+
+def _write_json_echo_python(python_path: Path, payload: str) -> None:
+    python_path.parent.mkdir(parents=True, exist_ok=True)
+    python_path.write_text(
+        "\n".join(
+            [
+                "#!/bin/sh",
+                f"printf '%s\\n' {payload!r}",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    python_path.chmod(python_path.stat().st_mode | 0o111)
+
+
 def _ambient_python_executable() -> str:
     current = Path(sys.executable).resolve()
     candidates = (
@@ -603,6 +639,58 @@ def test_projected_refresh_overview_uses_recorded_runtime_in_clean_non_atelier_r
     assert "usage:" in completed.stdout.lower()
 
 
+def test_projected_refresh_overview_repairs_stale_manifest_on_first_helper_invocation(
+    tmp_path: Path,
+) -> None:
+    agent_home, projected_script = _install_projected_script(
+        tmp_path,
+        skill_name="planner-startup-check",
+        script_name="refresh_overview.py",
+    )
+    repo_root = tmp_path / "non-atelier-repo"
+    repo_root.mkdir()
+    manifest_path = _projected_runtime_manifest_path(agent_home)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["helper_session_id"] = "stale-helper-session"
+    payload["atelier_import_root"] = str(tmp_path / "missing-import-root")
+    payload["pythonpath_entries"] = [str(tmp_path / "missing-pythonpath")]
+    payload["selected_interpreter"] = str(tmp_path / "bin" / "repair-python")
+    manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    helper_pythonpath = [str(_project_repo_root() / "src")]
+    helper_pythonpath.extend(
+        entry for entry in sys.path if isinstance(entry, str) and "site-packages" in entry
+    )
+    _write_python_with_pythonpath(
+        Path(payload["selected_interpreter"]),
+        pythonpath=helper_pythonpath,
+    )
+    isolated_python = tmp_path / "bin" / "python3"
+    _write_python_without_site_packages(isolated_python)
+
+    completed = subprocess.run(
+        [
+            str(isolated_python),
+            str(projected_script),
+            "--repo-dir",
+            str(repo_root),
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=agent_home,
+        env={},
+    )
+
+    assert completed.returncode == 0
+    assert "usage:" in completed.stdout.lower()
+    repaired = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert repaired["status"] == "converged"
+    assert repaired["helper_session_id"]
+    assert (Path(repaired["atelier_import_root"]) / "atelier" / "__init__.py").is_file()
+    assert repaired["pythonpath_entries"]
+
+
 def test_projected_create_epic_ignores_cross_project_env_hints_for_non_atelier_repo(
     tmp_path: Path,
 ) -> None:
@@ -682,6 +770,48 @@ def test_projected_refresh_overview_fails_closed_when_recorded_runtime_manifest_
     assert "repo_runtime_status: unavailable" in completed.stderr
     assert "projected support runtime manifest missing" in completed.stderr
     assert "dependency: atelier.runtime_env" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
+def test_projected_refresh_overview_fails_closed_when_self_heal_evidence_is_malformed(
+    tmp_path: Path,
+) -> None:
+    agent_home, projected_script = _install_projected_script(
+        tmp_path,
+        skill_name="planner-startup-check",
+        script_name="refresh_overview.py",
+    )
+    repo_root = tmp_path / "non-atelier-repo"
+    repo_root.mkdir()
+    manifest_path = _projected_runtime_manifest_path(agent_home)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["atelier_import_root"] = str(tmp_path / "missing-import-root")
+    payload["pythonpath_entries"] = [str(tmp_path / "missing-pythonpath")]
+    payload["selected_interpreter"] = str(tmp_path / "bin" / "repair-python")
+    manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    _write_json_echo_python(Path(payload["selected_interpreter"]), "not-json")
+    isolated_python = tmp_path / "bin" / "python3"
+    _write_python_without_site_packages(isolated_python)
+
+    completed = subprocess.run(
+        [
+            str(isolated_python),
+            str(projected_script),
+            "--repo-dir",
+            str(repo_root),
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=agent_home,
+        env={},
+    )
+
+    assert completed.returncode == 1
+    assert "planner helper runtime is unhealthy" in completed.stderr
+    assert "repo_runtime_status: unavailable" in completed.stderr
+    assert "self-heal emitted malformed convergence evidence" in completed.stderr
     assert "Traceback" not in completed.stderr
 
 

--- a/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
+++ b/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
@@ -709,13 +709,18 @@ def test_projected_refresh_overview_repairs_stale_manifest_without_support_manif
     payload["selected_interpreter"] = str(tmp_path / "bin" / "repair-python")
     payload["helper_session_id"] = "stale-helper-session"
     payload["atelier_import_root"] = str(tmp_path / "missing-import-root")
-    payload["pythonpath_entries"] = [str(tmp_path / "missing-pythonpath")]
+    payload["pythonpath_entries"] = list(recorded_pythonpath)
     manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
     _projected_support_manifest_path(agent_home).unlink(missing_ok=True)
-    _write_python_with_pythonpath(
-        Path(payload["selected_interpreter"]),
-        pythonpath=recorded_pythonpath,
+    _write_python_without_site_packages(Path(payload["selected_interpreter"]))
+    wrapper_probe = subprocess.run(
+        [str(payload["selected_interpreter"]), "-c", "import atelier"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={},
     )
+    assert wrapper_probe.returncode != 0
     isolated_python = tmp_path / "bin" / "python3"
     _write_python_without_site_packages(isolated_python)
 

--- a/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
+++ b/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
@@ -693,6 +693,56 @@ def test_projected_refresh_overview_repairs_stale_manifest_on_first_helper_invoc
     assert repaired["pythonpath_entries"]
 
 
+def test_projected_refresh_overview_repairs_stale_manifest_without_support_manifest(
+    tmp_path: Path,
+) -> None:
+    agent_home, projected_script = _install_projected_script(
+        tmp_path,
+        skill_name="planner-startup-check",
+        script_name="refresh_overview.py",
+    )
+    repo_root = tmp_path / "non-atelier-repo"
+    repo_root.mkdir()
+    manifest_path = _projected_runtime_manifest_path(agent_home)
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    recorded_pythonpath = tuple(payload["pythonpath_entries"])
+    payload["selected_interpreter"] = str(tmp_path / "bin" / "repair-python")
+    payload["helper_session_id"] = "stale-helper-session"
+    payload["atelier_import_root"] = str(tmp_path / "missing-import-root")
+    payload["pythonpath_entries"] = [str(tmp_path / "missing-pythonpath")]
+    manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    _projected_support_manifest_path(agent_home).unlink(missing_ok=True)
+    _write_python_with_pythonpath(
+        Path(payload["selected_interpreter"]),
+        pythonpath=recorded_pythonpath,
+    )
+    isolated_python = tmp_path / "bin" / "python3"
+    _write_python_without_site_packages(isolated_python)
+
+    completed = subprocess.run(
+        [
+            str(isolated_python),
+            str(projected_script),
+            "--repo-dir",
+            str(repo_root),
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=agent_home,
+        env={},
+    )
+
+    assert completed.returncode == 0
+    assert "usage:" in completed.stdout.lower()
+    repaired = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert repaired["status"] == "converged"
+    assert repaired["helper_session_id"]
+    assert (Path(repaired["atelier_import_root"]) / "atelier" / "__init__.py").is_file()
+    assert repaired["pythonpath_entries"]
+
+
 def test_projected_refresh_overview_prefers_canonical_project_runtime_from_stale_agent_home_copy(
     tmp_path: Path,
 ) -> None:

--- a/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
+++ b/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
@@ -693,6 +693,81 @@ def test_projected_refresh_overview_repairs_stale_manifest_on_first_helper_invoc
     assert repaired["pythonpath_entries"]
 
 
+def test_projected_refresh_overview_prefers_canonical_project_runtime_from_stale_agent_home_copy(
+    tmp_path: Path,
+) -> None:
+    project_dir = tmp_path / "project-data"
+    packaged_skills.install_workspace_skills(project_dir)
+    copied_agent_home = project_dir / "agents" / "worker" / "codex" / "p1-t2"
+    copied_agent_home.mkdir(parents=True)
+    (copied_agent_home / "agent.json").write_text(
+        json.dumps(
+            {
+                "id": "atelier/worker/codex/p1-t2",
+                "name": "codex",
+                "role": "worker",
+                "session_key": "p1-t2",
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    shutil.copytree(project_dir / "skills", copied_agent_home / "skills")
+    projected_script = (
+        copied_agent_home / "skills" / "planner-startup-check" / "scripts" / "refresh_overview.py"
+    )
+    copied_manifest = _projected_runtime_manifest_path(copied_agent_home)
+    assert not copied_manifest.exists()
+
+    copied_support_manifest_path = _projected_support_manifest_path(copied_agent_home)
+    copied_support_payload = json.loads(copied_support_manifest_path.read_text(encoding="utf-8"))
+    copied_support_payload["selected_interpreter"] = str(tmp_path / "bin" / "broken-repair-python")
+    copied_support_manifest_path.write_text(
+        json.dumps(copied_support_payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    canonical_manifest_path = project_dir / ".atelier-runtime" / "projected-runtime.json"
+    canonical_payload = json.loads(canonical_manifest_path.read_text(encoding="utf-8"))
+    canonical_payload["helper_session_id"] = "stale-project-runtime"
+    canonical_payload["atelier_import_root"] = str(tmp_path / "missing-import-root")
+    canonical_payload["pythonpath_entries"] = [str(tmp_path / "missing-pythonpath")]
+    canonical_payload["selected_interpreter"] = str(tmp_path / "bin" / "broken-project-python")
+    canonical_manifest_path.write_text(
+        json.dumps(canonical_payload, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    _write_python_without_site_packages(Path(canonical_payload["selected_interpreter"]))
+    isolated_python = tmp_path / "bin" / "python3"
+    _write_python_without_site_packages(isolated_python)
+    repo_root = tmp_path / "non-atelier-repo"
+    repo_root.mkdir()
+
+    completed = subprocess.run(
+        [
+            str(isolated_python),
+            str(projected_script),
+            "--repo-dir",
+            str(repo_root),
+            "--help",
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=copied_agent_home,
+        env={},
+    )
+
+    assert completed.returncode == 0
+    assert "usage:" in completed.stdout.lower()
+    repaired = json.loads(canonical_manifest_path.read_text(encoding="utf-8"))
+    assert repaired["status"] == "converged"
+    assert repaired["helper_session_id"]
+    assert (Path(repaired["atelier_import_root"]) / "atelier" / "__init__.py").is_file()
+    assert repaired["pythonpath_entries"]
+    assert not copied_manifest.exists()
+
+
 def test_projected_create_epic_ignores_cross_project_env_hints_for_non_atelier_repo(
     tmp_path: Path,
 ) -> None:

--- a/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
+++ b/tests/atelier/skills/test_projected_skill_runtime_bootstrap.py
@@ -38,6 +38,10 @@ def _projected_runtime_manifest_path(agent_home: Path) -> Path:
     return agent_home / ".atelier-runtime" / "projected-runtime.json"
 
 
+def _projected_support_manifest_path(agent_home: Path) -> Path:
+    return agent_home / "skills" / "shared" / "support-manifest.json"
+
+
 def _write_fake_module(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(content, encoding="utf-8")
@@ -300,12 +304,17 @@ def test_install_workspace_skills_writes_converged_projected_runtime_manifest(
 
     manifest_path = _projected_runtime_manifest_path(agent_home)
     payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    support_payload = json.loads(
+        _projected_support_manifest_path(agent_home).read_text(encoding="utf-8")
+    )
 
     assert payload["status"] == "converged"
     assert payload["helper_session_id"]
     assert Path(payload["selected_interpreter"]).exists()
     assert (Path(payload["atelier_import_root"]) / "atelier" / "__init__.py").is_file()
     assert payload["pythonpath_entries"]
+    assert support_payload["status"] == "converged"
+    assert support_payload["pythonpath_entries"]
 
 
 def test_sync_project_skills_backfills_missing_projected_runtime_manifest(
@@ -656,14 +665,7 @@ def test_projected_refresh_overview_repairs_stale_manifest_on_first_helper_invoc
     payload["pythonpath_entries"] = [str(tmp_path / "missing-pythonpath")]
     payload["selected_interpreter"] = str(tmp_path / "bin" / "repair-python")
     manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-    helper_pythonpath = [str(_project_repo_root() / "src")]
-    helper_pythonpath.extend(
-        entry for entry in sys.path if isinstance(entry, str) and "site-packages" in entry
-    )
-    _write_python_with_pythonpath(
-        Path(payload["selected_interpreter"]),
-        pythonpath=helper_pythonpath,
-    )
+    _write_python_without_site_packages(Path(payload["selected_interpreter"]))
     isolated_python = tmp_path / "bin" / "python3"
     _write_python_without_site_packages(isolated_python)
 
@@ -787,9 +789,12 @@ def test_projected_refresh_overview_fails_closed_when_self_heal_evidence_is_malf
     payload = json.loads(manifest_path.read_text(encoding="utf-8"))
     payload["atelier_import_root"] = str(tmp_path / "missing-import-root")
     payload["pythonpath_entries"] = [str(tmp_path / "missing-pythonpath")]
-    payload["selected_interpreter"] = str(tmp_path / "bin" / "repair-python")
     manifest_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-    _write_json_echo_python(Path(payload["selected_interpreter"]), "not-json")
+    support_manifest_path = _projected_support_manifest_path(agent_home)
+    support_payload = json.loads(support_manifest_path.read_text(encoding="utf-8"))
+    support_payload["selected_interpreter"] = str(tmp_path / "bin" / "repair-python")
+    support_manifest_path.write_text(json.dumps(support_payload, indent=2) + "\n", encoding="utf-8")
+    _write_json_echo_python(Path(support_payload["selected_interpreter"]), "not-json")
     isolated_python = tmp_path / "bin" / "python3"
     _write_python_without_site_packages(isolated_python)
 

--- a/tests/atelier/test_agent_home.py
+++ b/tests/atelier/test_agent_home.py
@@ -205,6 +205,33 @@ def test_ensure_agent_links_creates_project_skill_aliases() -> None:
         _assert_link_or_marker(home.path, ".claude/skills", skills)
 
 
+def test_ensure_agent_links_relinks_stale_copied_skill_tree() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        project_dir = root / "project"
+        project_dir.mkdir(parents=True)
+        home = agent_home.resolve_agent_home(project_dir, ProjectConfig(), role="worker")
+        worktree = root / "worktree"
+        beads = root / "beads"
+        skills = root / "skills"
+        worktree.mkdir()
+        beads.mkdir()
+        skills.mkdir()
+
+        stale_shared = home.path / "skills" / "shared" / "scripts"
+        stale_shared.mkdir(parents=True)
+        (stale_shared / "projected_bootstrap.py").write_text("", encoding="utf-8")
+
+        agent_home.ensure_agent_links(
+            home,
+            worktree_path=worktree,
+            beads_root=beads,
+            skills_dir=skills,
+        )
+
+        _assert_link_or_marker(home.path, "skills", skills)
+
+
 def test_cleanup_agent_home_removes_session_dir_and_prunes() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         project_dir = Path(tmp) / "project"

--- a/tests/atelier/test_skills.py
+++ b/tests/atelier/test_skills.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 import threading
 import time
+from collections.abc import Callable
 from importlib import resources
 from pathlib import Path
 
@@ -200,6 +201,72 @@ def test_ensure_project_skills_installs_if_missing() -> None:
         skills_dir = skills.ensure_project_skills(project_dir)
         assert skills_dir == project_dir / "skills"
         assert (skills_dir / "planner-startup-check" / "SKILL.md").exists()
+
+
+def _write_project_config(project_dir: Path) -> None:
+    skills.paths.project_config_sys_path(project_dir).write_text("{}", encoding="utf-8")
+
+
+def test_repair_installed_project_skills_repairs_existing_projects_once_per_version(
+    monkeypatch,
+) -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        atelier_data_dir = Path(tmp) / "atelier-data"
+        projects_root = atelier_data_dir / "projects"
+        project_alpha = projects_root / "alpha"
+        project_beta = projects_root / "beta"
+        for project_dir in (project_alpha, project_beta):
+            project_dir.mkdir(parents=True)
+            _write_project_config(project_dir)
+            skills.install_workspace_skills(project_dir)
+
+        shutil.rmtree(project_alpha / "skills" / "shared")
+        manifest_path = project_beta / ".atelier-runtime" / "projected-runtime.json"
+        manifest_path.write_text("{broken", encoding="utf-8")
+
+        monkeypatch.setattr(skills.paths, "atelier_data_dir", lambda: atelier_data_dir)
+
+        original_sync = skills.sync_project_skills
+        seen_projects: list[Path] = []
+
+        def wrapped_sync(
+            project_dir: Path,
+            *,
+            upgrade_policy: str = "ask",
+            yes: bool = False,
+            interactive: bool = False,
+            prompt_update: Callable[[str], bool] | None = None,
+            dry_run: bool = False,
+        ) -> skills.ProjectSkillsSyncResult:
+            seen_projects.append(project_dir)
+            return original_sync(
+                project_dir,
+                upgrade_policy=upgrade_policy,
+                yes=yes,
+                interactive=interactive,
+                prompt_update=prompt_update,
+                dry_run=dry_run,
+            )
+
+        monkeypatch.setattr(skills, "sync_project_skills", wrapped_sync)
+
+        result = skills.repair_installed_project_skills_for_current_version()
+
+        assert result.action == "repaired"
+        assert result.failed_projects == ()
+        assert set(result.scanned_projects) == {project_alpha, project_beta}
+        assert set(result.updated_projects) == {project_alpha, project_beta}
+        assert set(seen_projects) == {project_alpha, project_beta}
+        assert (
+            project_alpha / "skills" / "shared" / "scripts" / "projected_bootstrap.py"
+        ).is_file()
+        assert skills._projected_runtime_manifest_requires_backfill(project_beta) is False
+
+        seen_projects.clear()
+        second = skills.repair_installed_project_skills_for_current_version()
+
+        assert second.action == "skipped"
+        assert seen_projects == []
 
 
 def test_sync_project_skills_installs_when_missing() -> None:

--- a/tests/atelier/test_skills.py
+++ b/tests/atelier/test_skills.py
@@ -63,6 +63,7 @@ def test_install_workspace_skills_writes_skill_docs() -> None:
         assert (
             workspace_dir / "skills" / "shared" / "scripts" / "projected_bootstrap.py"
         ).is_file()
+        assert (workspace_dir / "skills" / "shared" / "support-manifest.json").is_file()
         for name in (
             "publish",
             "github",
@@ -302,6 +303,21 @@ def test_sync_project_skills_updates_when_shared_support_tree_missing() -> None:
 
         assert result.action == "updated"
         assert (support_tree / "scripts" / "projected_bootstrap.py").is_file()
+
+
+def test_sync_project_skills_updates_when_projected_support_manifest_missing() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        project_dir = Path(tmp)
+        skills.install_workspace_skills(project_dir)
+        support_manifest = project_dir / "skills" / "shared" / "support-manifest.json"
+        support_manifest.unlink()
+
+        result = skills.sync_project_skills(project_dir)
+
+        assert result.action == "updated"
+        assert support_manifest.is_file()
+        assert skills._projected_runtime_manifest_requires_backfill(project_dir) is False
+        assert skills._projected_support_manifest_requires_backfill(project_dir) is False
 
 
 def test_sync_project_skills_applies_upgrade_with_yes() -> None:


### PR DESCRIPTION
# Summary

- Repair projected runtime rollouts for already-installed Atelier projects so stale support manifests recover automatically after an update.
- Let the first helper invocation recover old projects even when `skills/shared/support-manifest.json` was never backfilled.
- Relink stale copied agent-home skill trees back to the managed project skills directory so helper sessions stop resolving old projected scripts.

# Changes

- Added a version-gated startup repair pass that scans known Atelier project data directories and runs managed skill sync once per installed version.
- Hooked the repair pass into normal CLI startup while skipping shell completion flows.
- Added projected-bootstrap self-heal from the synced shared support manifest when the recorded runtime manifest is stale.
- Added a projected-bootstrap fallback that reuses the stale manifest's recorded interpreter when the shared support manifest is missing or unusable, while keeping convergence evidence and manifest readback checks fail-closed.
- Added regression coverage for startup repair, stale copied agent-home skills, helper-first stale-manifest repair, and the missing-support-manifest rollout path.

# Testing

- `just format`
- `just lint`
- `just test`

# Tickets

- None

# Risks / Rollout

- The first normal `atelier` command after an update now scans managed project data dirs and may rewrite stale projected skill artifacts.
- Helper-first repair now has two launcher sources: the shared support manifest when present, and the previously recorded runtime interpreter when that support manifest is missing but the recorded interpreter is still executable.
- Stale copied agent-home skill directories are replaced with canonical links during agent-home preparation.

# Notes

- Projected bootstrap still fails closed when neither launcher path can prove a converged runtime.
