### PR TITLE
Honor planner contract fields in epic promotion preview

### DIFF
--- a/src/atelier/planner_contract.py
+++ b/src/atelier/planner_contract.py
@@ -88,7 +88,10 @@ def validate_authoring_contract(
         executable path has the required context sections.
     """
 
-    combined_fields = _collect_fields([*inherited_context, issue])
+    combined_fields = collect_authoring_contract_fields(
+        issue,
+        inherited_context=inherited_context,
+    )
     missing: list[str] = []
     for field_name, aliases in _REQUIRED_FIELD_ALIASES.items():
         if any(_has_meaningful_value(combined_fields.get(alias, ())) for alias in aliases):
@@ -97,6 +100,62 @@ def validate_authoring_contract(
     if not _has_done_definition([*inherited_context, issue], combined_fields):
         missing.append("done_definition")
     return tuple(missing)
+
+
+def collect_authoring_contract_fields(
+    issue: Mapping[str, object],
+    *,
+    inherited_context: Sequence[Mapping[str, object]] = (),
+) -> dict[str, tuple[str, ...]]:
+    """Return parsed planner authoring contract fields for an executable path.
+
+    Args:
+        issue: Target executable work bead payload.
+        inherited_context: Additional issues that provide shared planner context,
+            typically the parent epic for a child changeset.
+
+    Returns:
+        Mapping of normalized planner authoring contract field names to the
+        parsed values gathered from `description`, `notes`, and `design`.
+    """
+
+    return _collect_fields([*inherited_context, issue])
+
+
+def get_authoring_contract_values(
+    issue: Mapping[str, object],
+    field_name: str,
+    *,
+    inherited_context: Sequence[Mapping[str, object]] = (),
+) -> tuple[str, ...]:
+    """Return parsed values for a canonical planner authoring contract field.
+
+    Args:
+        issue: Target executable work bead payload.
+        field_name: Canonical field name, such as `related_context` or
+            `rationale`.
+        inherited_context: Additional issues that provide shared planner
+            context.
+
+    Returns:
+        Tuple of parsed values for the requested field across all supported
+        aliases. Unknown field names fall back to a direct lookup.
+    """
+
+    combined_fields = collect_authoring_contract_fields(
+        issue,
+        inherited_context=inherited_context,
+    )
+    aliases = _REQUIRED_FIELD_ALIASES.get(field_name)
+    if field_name == "done_definition":
+        aliases = _DONE_DEFINITION_ALIASES
+    if aliases is None:
+        aliases = (field_name,)
+
+    values: list[str] = []
+    for alias in aliases:
+        values.extend(combined_fields.get(alias, ()))
+    return tuple(values)
 
 
 def _collect_fields(issues: Sequence[Mapping[str, object]]) -> dict[str, tuple[str, ...]]:

--- a/src/atelier/skills/plan-promote-epic/scripts/promote_epic.py
+++ b/src/atelier/skills/plan-promote-epic/scripts/promote_epic.py
@@ -27,6 +27,7 @@ from atelier.beads_context import (  # noqa: E402
     resolve_skill_beads_context,
 )
 from atelier.lib.beads import description_fields as bead_fields  # noqa: E402
+from atelier.planner_contract import get_authoring_contract_values  # noqa: E402
 
 
 def _build_store_and_client(*, beads_root: Path, repo_root: Path):
@@ -65,6 +66,24 @@ def _clean_text(value: object) -> str | None:
 
 def _issue_text(issue: object, field_name: str) -> str | None:
     return _clean_text(getattr(issue, field_name, None))
+
+
+def _issue_contract_mapping(issue: object) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    description = _issue_text(issue, "description")
+    if description is not None:
+        mapping["description"] = description
+    notes = _issue_notes_text(issue)
+    if notes is not None:
+        mapping["notes"] = notes
+    design = _issue_text(issue, "design")
+    if design is not None:
+        mapping["design"] = design
+    return mapping
+
+
+def _authoring_contract_values(issue: object, field_name: str) -> tuple[str, ...]:
+    return get_authoring_contract_values(_issue_contract_mapping(issue), field_name)
 
 
 def _split_field_values(value: str | None) -> tuple[str, ...]:
@@ -115,8 +134,11 @@ def _issue_notes_text(issue: object) -> str | None:
 
 
 def _related_context(issue: object) -> tuple[str, ...]:
+    related: list[str] = []
+    for value in _authoring_contract_values(issue, "related_context"):
+        related.extend(_split_field_values(value))
+
     fields = bead_fields.parse_description_fields(_issue_text(issue, "description") or "")
-    related = list(_split_field_values(fields.get("related_context")))
     related.extend(_split_field_values(fields.get("external_tickets")))
     deduped: list[str] = []
     seen: set[str] = set()
@@ -136,7 +158,7 @@ def _missing_detail_sections(issue: object) -> tuple[str, ...]:
         missing.append("notes")
     if _issue_text(issue, "acceptance_criteria") is None:
         missing.append("acceptance criteria")
-    if not _related_context(issue):
+    if not _authoring_contract_values(issue, "related_context"):
         missing.append("related-context references")
     return tuple(missing)
 
@@ -145,8 +167,21 @@ def _has_decomposition_rationale(
     epic_issue: object,
     child_issues: tuple[object, ...],
 ) -> bool:
-    haystacks = [_issue_text(epic_issue, "description") or ""]
-    haystacks.extend((_issue_text(child, "description") or "") for child in child_issues)
+    issues = (epic_issue, *child_issues)
+    if any(_authoring_contract_values(issue, "rationale") for issue in issues):
+        return True
+
+    haystacks: list[str] = []
+    for issue in issues:
+        haystacks.extend(
+            text
+            for text in (
+                _issue_text(issue, "description"),
+                _issue_notes_text(issue),
+                _issue_text(issue, "design"),
+            )
+            if text is not None
+        )
     for text in haystacks:
         lowered = text.lower()
         if "changeset_strategy:" in lowered or "decomposition" in lowered or "split " in lowered:

--- a/tests/atelier/skills/test_plan_promote_epic_script.py
+++ b/tests/atelier/skills/test_plan_promote_epic_script.py
@@ -282,6 +282,58 @@ def test_promote_epic_preview_reads_canonical_notes_for_epic_and_child(
     assert transitions == []
 
 
+def test_promote_epic_accepts_related_context_from_notes(
+    monkeypatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+
+    monkeypatch.setattr(
+        module,
+        "_resolve_context",
+        lambda **_kwargs: (tmp_path / ".beads", tmp_path / "repo", None),
+    )
+
+    epic_issue = _issue(
+        "at-epic",
+        title="Epic",
+        description="promotion_note: ready for confirmation\n",
+        notes="related_context: at-context\ncanonical epic note",
+    )
+
+    class FakeStore:
+        async def get_epic(self, epic_id):
+            assert epic_id == "at-epic"
+            from atelier.store import LifecycleStatus
+
+            return SimpleNamespace(id=epic_id, lifecycle=LifecycleStatus.DEFERRED)
+
+        async def list_changesets(self, query):
+            del query
+            return ()
+
+        async def transition_lifecycle(self, request):  # pragma: no cover - defensive
+            raise AssertionError(request)
+
+    class FakeClient:
+        async def show(self, request):
+            assert request.issue_id == "at-epic"
+            return epic_issue
+
+    monkeypatch.setattr(
+        module, "_build_store_and_client", lambda **_kwargs: (FakeStore(), FakeClient())
+    )
+    monkeypatch.setattr(sys, "argv", ["promote_epic.py", "--epic-id", "at-epic"])
+
+    module.main()
+
+    captured = capsys.readouterr()
+    assert "- at-context" in captured.out
+    assert "Missing detail sections: related-context references" not in captured.out
+    assert "confirmation_required" in captured.out
+
+
 def test_render_issue_preview_prefers_canonical_notes_over_description_markers() -> None:
     module = _load_script_module()
     issue = _issue(
@@ -300,6 +352,64 @@ def test_render_issue_preview_prefers_canonical_notes_over_description_markers()
 
     assert notes_section == "canonical notes field"
     assert "Missing detail sections: notes" not in preview
+
+
+def test_promote_epic_accepts_one_child_rationale_from_notes(
+    monkeypatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+
+    monkeypatch.setattr(
+        module,
+        "_resolve_context",
+        lambda **_kwargs: (tmp_path / ".beads", tmp_path / "repo", None),
+    )
+
+    epic_issue = _issue(
+        "at-epic",
+        title="Epic",
+        description="related_context: at-context\npromotion_note: ready for confirmation\n",
+        notes="rationale: Keep one child because the review slice stays cohesive.",
+    )
+    child_issue = _issue(
+        "at-epic.1",
+        title="Child",
+        description="related_context: at-context\n",
+        notes="canonical child note",
+    )
+
+    class FakeStore:
+        async def get_epic(self, epic_id):
+            assert epic_id == "at-epic"
+            from atelier.store import LifecycleStatus
+
+            return SimpleNamespace(id=epic_id, lifecycle=LifecycleStatus.DEFERRED)
+
+        async def list_changesets(self, query):
+            del query
+            from atelier.store import LifecycleStatus
+
+            return (SimpleNamespace(id="at-epic.1", lifecycle=LifecycleStatus.DEFERRED),)
+
+        async def transition_lifecycle(self, request):  # pragma: no cover - defensive
+            raise AssertionError(request)
+
+    class FakeClient:
+        async def show(self, request):
+            return {"at-epic": epic_issue, "at-epic.1": child_issue}[request.issue_id]
+
+    monkeypatch.setattr(
+        module, "_build_store_and_client", lambda **_kwargs: (FakeStore(), FakeClient())
+    )
+    monkeypatch.setattr(sys, "argv", ["promote_epic.py", "--epic-id", "at-epic"])
+
+    module.main()
+
+    captured = capsys.readouterr()
+    assert "confirmation_required" in captured.out
+    assert "one-child promotion requires explicit decomposition rationale" not in captured.err
 
 
 def test_promote_epic_fails_when_one_child_has_no_decomposition_rationale(
@@ -414,3 +524,58 @@ def test_promote_epic_still_fails_when_notes_are_actually_absent(
 
     assert excinfo.value.code == 1
     assert "epic missing detail sections: notes" in capsys.readouterr().err
+
+
+def test_promote_epic_does_not_treat_external_tickets_as_related_context(
+    monkeypatch,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    module = _load_script_module()
+
+    monkeypatch.setattr(
+        module,
+        "_resolve_context",
+        lambda **_kwargs: (tmp_path / ".beads", tmp_path / "repo", None),
+    )
+
+    epic_issue = _issue(
+        "at-epic",
+        title="Epic",
+        description=(
+            "changeset_strategy: Keep review scope small.\nexternal_tickets:\n- github#123\n"
+        ),
+        notes="canonical epic note",
+    )
+
+    class FakeStore:
+        async def get_epic(self, epic_id):
+            assert epic_id == "at-epic"
+            from atelier.store import LifecycleStatus
+
+            return SimpleNamespace(id=epic_id, lifecycle=LifecycleStatus.DEFERRED)
+
+        async def list_changesets(self, query):
+            del query
+            return ()
+
+        async def transition_lifecycle(self, request):  # pragma: no cover - defensive
+            raise AssertionError(request)
+
+    class FakeClient:
+        async def show(self, request):
+            assert request.issue_id == "at-epic"
+            return epic_issue
+
+    monkeypatch.setattr(
+        module, "_build_store_and_client", lambda **_kwargs: (FakeStore(), FakeClient())
+    )
+    monkeypatch.setattr(sys, "argv", ["promote_epic.py", "--epic-id", "at-epic"])
+
+    with pytest.raises(SystemExit) as excinfo:
+        module.main()
+
+    assert excinfo.value.code == 1
+    captured = capsys.readouterr()
+    assert "- github#123" in captured.out
+    assert "epic missing detail sections: related-context references" in captured.err


### PR DESCRIPTION
# Summary

- Make epic promotion preview and readiness checks honor `related_context` and one-child rationale from the same planner-contract-backed locations the planner guidance already allows.

# Changes

- Add reusable planner-contract field accessors so promotion preview code can read normalized authoring fields from description, notes, and design.
- Update `plan-promote-epic` preview/readiness logic to accept notes-backed related context and rationale while keeping `external_tickets` additive instead of satisfying the required related-context field.
- Add regression coverage for notes-backed related context, notes-backed one-child rationale, and the fail-closed external-tickets-only case.

# Testing

- `pytest -q tests/atelier/skills/test_plan_promote_epic_script.py tests/atelier/skills/test_plan_changeset_guardrails_script.py`
- `python -m compileall src/atelier/planner_contract.py src/atelier/skills/plan-promote-epic/scripts/promote_epic.py`
- Full pre-push suite via repo hook: `pytest` plus shell tests (`tests/shell/run.sh`)

# Tickets

- Fixes #763

# Risks / Rollout

- Low risk. The change is isolated to planner preview/readiness parsing and covered by focused regressions plus the repo's full pre-push test gate.

# Notes

- `external_tickets` still appear in preview output for context, but promotion now fails closed when explicit related-context links are still missing.
