### PR TITLE
docs(design): validate skill-based Atelier reset

### DIFF
--- a/docs/atelier-skill-design.md
+++ b/docs/atelier-skill-design.md
@@ -156,6 +156,18 @@ The agent host surrounds this system. It provides the active task, subagents,
 permissions, timers, worktrees, connectors, and user interface. Atelier does not
 persist or reproduce host task state.
 
+Codex is the reference host for v0. Its plugin, skill, subagent, connector, and
+permission surfaces define the first tested adapter. This is a delivery
+constraint, not a product claim that Atelier concepts belong to Codex.
+
+A future Claude Code adapter should preserve the same Atelier documents,
+transitions, authority vocabulary, Agent Scripts contract, and mailbox history.
+Only host integration may differ: command discovery, skill invocation, subagent
+launch, permission prompts, and connector access. If a supposedly portable
+Atelier rule must branch on host identity, the rule belongs above the host
+adapter or the contract is underspecified. Claude compatibility is deferred
+until the Codex reference path works; it must not distort v0.
+
 ## Distribution and dependency model
 
 Atelier should remain its own repository and plugin. It is an application built
@@ -620,11 +632,26 @@ implementation foundation.
 
 ## Transition from the current codebase
 
-The current CLI should receive a final archival tag or branch before the reset.
-The next implementation should then replace it rather than coexist with it.
+The current CLI receives the annotated archival tag `atelier-cli-v2-final`
+before the reset. The tag names the exact final legacy commit and explains that
+the skill-based product supersedes it. The next implementation then replaces the
+CLI rather than coexisting with it.
 
-There should be no dual-running period, data migration, compatibility adapter,
-or attempt to route new skill behavior through the existing store and worker
+The tag, legacy-ticket disposition, and implementation removal are a deliberate
+reset gate. Before crossing it, the composition spike must prove that an
+independently installed Agent Scripts capability can be discovered, validated,
+invoked with allowed and denied checkpoints, acknowledge a published candidate,
+and return a valid terminal result without Atelier copying its workflow. The
+operator reviews that evidence and explicitly confirms the reset a second time.
+
+Only after that confirmation should obsolete tickets be closed as `cancelled` or
+`superseded`, the archival tag be pushed, and the legacy implementation be
+removed. A ticket is not `completed` merely because its architecture was
+abandoned. The disposition record must map retained product obligations to the
+new implementation graph before deletion begins.
+
+There is no dual-running period, data migration, compatibility adapter, or
+attempt to route new skill behavior through the existing store and worker
 runtime. Existing documents and skills are source material; selected behavioral
 tests may become forward-evaluation cases. Legacy Python modules and their
 implementation-specific tests are not the scaffold for the new product.
@@ -634,9 +661,13 @@ the infrastructure burden that the reset is meant to remove.
 
 ## Validation strategy
 
-The next version should be validated outside Atelier itself.
+Atelier itself is the first low-risk live dogfood repository. It should exercise
+planning, delegated implementation, review, delivery, operator acceptance, and
+the reset changes while the legacy implementation remains recoverable by tag.
+This proves that the workflow can govern real work, not that it generalizes.
 
-At minimum, forward evaluations should cover:
+External validation must follow before claiming broader product success. At
+minimum, forward evaluations should cover:
 
 1. A personal GitHub project with human approval and merge.
 1. A cross-project initiative spanning Tuber and Peeler.
@@ -662,7 +693,7 @@ Evaluations should measure:
 
 Lines of code and raw ticket throughput are not success measures.
 
-The backing protocol has separately passed the 15-scenario
+The backing protocol has separately passed the 16-scenario
 [Mailbox Protocol Validation]. That result validates the Git mechanics, not the
 future skill prompts, host integration, or live provider adapters.
 
@@ -681,7 +712,9 @@ The first usable version should contain only:
 
 It should support one Git mailbox realm and one native ticket provider first.
 Additional providers should be expressed through host connectors and
-project-policy references rather than a new Atelier provider framework.
+project-policy references rather than a new Atelier provider framework. The
+ordered changesets and reset gate are defined in the
+[Atelier Skill Implementation Plan].
 
 ## Decisions intentionally deferred
 
@@ -699,6 +732,7 @@ These decisions do not require a storage abstraction or server design.
 [agent scripts]: https://github.com/shaug/agent-scripts
 [atelier north star]: ./north-star.md
 [atelier project policy contract]: ./project-policy-contract.md
+[atelier skill implementation plan]: ./implementation-plan.md
 [git mailbox contract]: ./git-mailbox-contract.md
 [mailbox protocol validation]: ./mailbox-protocol-validation.md
 [why atelier?]: ./atelier-name.md

--- a/docs/atelier-skill-design.md
+++ b/docs/atelier-skill-design.md
@@ -1,0 +1,704 @@
+# Atelier as a Skill
+
+## Next-Version Design
+
+**Status:** Proposed direction, revised after initial adversarial review
+
+This document defines the high-level direction for the next version of Atelier.
+It is a strategic reset, not an incremental revision of the current CLI.
+
+The [Git Mailbox Contract] defines the backing repository and the minimal
+planner-worker interactions that this design relies on. The
+[Atelier Project Policy Contract] defines the project-owned authority,
+validation, and acceptance predicates applied to those interactions. The
+[Mailbox Protocol Validation] records the disposable two-clone experiment used
+to test the backing mechanism.
+
+## Summary
+
+Atelier will become an opinionated, host-native skill for accountable
+agent-assisted development.
+
+It will run inside capable agent hosts such as Codex and Claude Code rather than
+launching, supervising, or replacing them. It will use those hosts for agent
+execution, subagents, timers, permissions, worktrees, and task continuity.
+
+Atelier will own:
+
+- shaping intent before implementation,
+- separating planning authority from implementation authority,
+- promoting work through explicit human decisions,
+- coordinating work across projects,
+- keeping changesets cognitively reviewable,
+- recording durable planner-worker communication,
+- applying project-specific authority and review policy,
+- separating worker delivery from accountable acceptance,
+- and producing evidence that an accountable operator can accept.
+
+Atelier will delegate implementation, review, and pull-request handling to the
+independently useful [Agent Scripts] skills. The initial version does not
+delegate merge, deployment, or ticket-state mutation.
+
+A dedicated Git repository will serve as Atelier's passive planning record and
+mailbox. Its human-readable documents are authoritative. Git history records
+their evolution. Atelier will not require Beads, SQLite, Dolt, a background
+daemon, or an Atelier server.
+
+## Motivation
+
+Agent hosts have absorbed most of the execution capabilities that justified the
+standalone Atelier CLI:
+
+- launching and resuming agents,
+- creating isolated worktrees,
+- orchestrating subagents,
+- scheduling or repeating work,
+- enforcing local permissions,
+- loading reusable skills,
+- connecting to ticket systems,
+- and operating Git and pull-request workflows.
+
+Competing with those capabilities makes Atelier responsible for a large and
+rapidly changing execution surface without strengthening its central idea.
+
+Atelier's remaining value is the idea expressed in the [Atelier North Star]:
+implementation has become cheap, but trust has not. The system should optimize
+for work that humans can understand, review, and take responsibility for.
+
+The next version therefore moves Atelier up one level. It becomes a way of
+thinking about and governing agentic work, not another environment in which
+agents run.
+
+## Product thesis
+
+> Atelier enables development at the speed of accountability.
+
+Atelier treats accountability as an engineering constraint:
+
+- Intent exists before implementation.
+- Work is approved explicitly.
+- Authority is bounded and visible.
+- Dependencies and sequencing are legible.
+- Implementation is divided at human review boundaries.
+- Scope growth becomes a decision rather than silent diff growth.
+- Current-head validation and review are evidence, not implication.
+- Interrupting or replacing an agent does not lose the work's context.
+
+The workshop metaphor remains important. As [Why Atelier?] explains, a workshop
+is not a factory. It values craft over automation, explicit intent over
+invisible orchestration, and tools that can change without changing the work's
+meaning.
+
+## Goals
+
+The next version should:
+
+1. Support a general planner that can shape and coordinate work across projects.
+1. Support project-specific planners when local context or governance requires
+   them.
+1. Support project-specific workers that claim only approved work for their
+   project.
+1. Preserve planner-worker communication independently of any agent task or
+   native ticket system.
+1. Model cross-project initiatives and dependencies.
+1. Allow each project to declare its own approval, review, ticket, and
+   automation policy.
+1. Use native project tickets where useful or required without making them the
+   only possible Atelier coordination channel.
+1. Delegate implementation mechanics to Agent Scripts rather than rebuilding
+   them.
+1. Make every shared transition inspectable through ordinary Git and text tools.
+1. Fail closed when authority, persistence, or current state cannot be
+   established.
+
+## Non-goals
+
+The next version will not:
+
+- launch or supervise agent processes,
+- implement a general-purpose agent runtime,
+- provide its own scheduler or watch loop,
+- manage project worktrees,
+- parse agent transcripts to recover sessions,
+- replace GitHub, Linear, or another native delivery tracker,
+- mirror native tickets into an Atelier issue database,
+- synchronize mutable fields between ticket providers,
+- own pull-request or merge mechanics,
+- optimize for maximum agent utilization or code throughput,
+- require every assignment to reach a solution in one agent session,
+- provide multiple storage backends,
+- maintain compatibility with the current Atelier CLI or data,
+- or provide a hosted Atelier service.
+
+Atelier is allowed to remain a personal, strongly opinionated workflow. General
+adoption and compatibility are not design constraints.
+
+## System boundary
+
+```text
+Operator
+   |
+   v
+Atelier skill
+   |-- planning, promotion, policy, coordination, audit
+   |
+   +--> Git mailbox repository
+   |      durable intent, assignments, messages, claims, receipts
+   |
+   +--> Agent Scripts
+   |      implementation, review, changeset carving, PR lifecycle
+   |
+   +--> Native project systems
+          tickets, repositories, CI, pull requests, deployments
+```
+
+The agent host surrounds this system. It provides the active task, subagents,
+permissions, timers, worktrees, connectors, and user interface. Atelier does not
+persist or reproduce host task state.
+
+## Distribution and dependency model
+
+Atelier should remain its own repository and plugin. It is an application built
+on Agent Scripts, not a peer skill collection inside Agent Scripts.
+
+Agent Scripts remains independently installable and useful. It must not depend
+on or contain Atelier-specific behavior.
+
+The initial worker mode depends directly on one named Agent Scripts capability:
+`implement-ticket`. That capability owns its own implementation, changeset
+carving, review, pull-request, and babysitting workflow. Atelier must not
+re-orchestrate its transitive skills.
+
+Audit mode may invoke `review-code-change` directly when an independent review
+of one exact candidate is itself the audit operation. The initial version does
+not invoke `implement-epic`: Atelier owns its cross-project assignment graph,
+while `implement-epic` owns a native ticket graph.
+
+Where a host supports plugin dependencies, Atelier should declare an explicit,
+versioned dependency. Where it does not, Atelier should perform a startup
+capability check and fail with exact installation guidance. It must not silently
+fall back to a bespoke implementation workflow.
+
+The initial version will not vendor Agent Scripts. A copied dependency would
+create release lag and pressure for Atelier-specific patches. Explicit
+prerequisites preserve the platform/application boundary more honestly.
+
+### Agent Scripts capability contract
+
+Before claiming work, Atelier must establish that the host can invoke a
+compatible `agent-scripts.implement-ticket/delegated-execution/v1` capability
+and validate its `capability.json` discovery manifest plus versioned invocation,
+checkpoint, and result schemas. Finding a skill with the expected name is not
+sufficient.
+
+The invocation contract supplies:
+
+- the eligible native ticket and owning tracker,
+- the project repository and exact base,
+- the approved Atelier work identifier, revision, and opaque approval evidence
+  containing the mailbox approval commit,
+- intent, scope, non-goals, constraints, and done definition,
+- validation and review expectations,
+- the durable authority ceiling and governing project-policy identity,
+- the operator-only acceptance policy,
+- the current claim and worker-run identifiers,
+- the claim's last consumed checkpoint sequence and opaque continuation token,
+- and a caller-provided checkpoint command.
+
+The initial accepted outcomes are:
+
+- `ready_pr`,
+- `blocked`,
+- and `requires_epic`.
+
+`ready_pr` moves work to `delivered` only after Atelier independently verifies
+the current claim, approved revision, policy, native ticket, repository, exact
+remotely reachable candidate, validation, review, and pull-request state.
+`blocked` produces a blocked attempt receipt. `requires_epic` returns to
+planning; it does not authorize Atelier to invoke `implement-epic`
+automatically. A PR stack, merge, deployment, branch deletion, or native-ticket
+mutation is outside the initial Atelier authority vocabulary.
+
+The capability must invoke the checkpoint command before every consequential
+external mutation. It must also report `candidate_published` immediately after
+publishing or advancing a remote candidate and receive an acknowledgement before
+continuing. A denied, malformed, unknown, or unavailable checkpoint blocks
+execution. If implementation state exists at a blocked terminal result, the
+result must identify a durable handoff ref or state explicitly that no
+transferable candidate exists. A published blocked result may have no pull
+request when acknowledgement failed before PR creation; its verified candidate
+is recoverable project state but becomes shared Atelier state only after a later
+mailbox transition records it.
+
+Atelier's checkpoint helper atomically compares and advances the expected
+sequence and opaque continuation token in its authoritative Git transition. On
+allowance, the same transition appends the invocation, phase, action, proposed
+effect, candidate, and acknowledgement to the claim's authorization ledger. A
+denial preserves the prior sequence and token. Before consuming any terminal
+result, Atelier uses the Agent Scripts validator to require the reported
+terminal sequence and token to equal the current claim-ledger tail. It then
+requires the terminal `authority_used` set to equal the allowed pre-mutation
+actions in that ledger; missing or extra actions block the result. A consumed
+request cannot be replayed. Agent Scripts validates each exchange, but Atelier
+owns durable compare-and-swap semantics and the ledger.
+
+If capability compatibility is missing before claim, the work remains approved.
+If it becomes unavailable after a claim, the worker blocks or releases the work
+with an attempt receipt whenever implementation state exists. Atelier never
+substitutes an inline implementation workflow.
+
+## Skill shape
+
+Atelier should present one entry skill with explicit modes. The host-specific
+invocation may differ, but the conceptual interface is:
+
+- `atelier plan`
+- `atelier work`
+- `atelier audit`
+
+Like Trycycle, the entry skill may route to focused internal phases and
+references. Unlike the current Atelier CLI, those phases orchestrate host-native
+capabilities rather than implementing an agent runtime.
+
+### What "Trycycle-like" means
+
+Atelier should follow Trycycle's useful structural pattern:
+
+- one explicit entry skill,
+- phase-specific instructions and artifacts,
+- host-native subagents rather than a proprietary worker process,
+- fresh planning or review perspectives where independence matters,
+- bounded refinement loops with explicit stop conditions,
+- user decisions at authority boundaries,
+- and deterministic helpers only where persistence or validation requires them.
+
+The resemblance ends at the session boundary.
+
+Trycycle is designed to drive one given effort to a solution in one agentic
+session. After the initial design interaction, the operator can delegate most
+implementation judgment to the agent, subject to authority overrides when its
+review loops do not converge. Completion of the requested solution is the
+organizing objective.
+
+Atelier is designed for durable software work. Authority may be delegated, but
+accountability remains distributed across the operator, project policy,
+reviewers, maintainers, and the evidence accumulated over time. Completion is
+subordinate to preserving that accountability.
+
+An Atelier session may validly end with work blocked, released, deferred,
+replanned, rejected, or waiting for a human decision. A later session or a
+different worker must be able to continue from durable artifacts without
+inheriting the original agent's hidden context. The Git mailbox carries that
+continuity; no orchestrator process remains alive between sessions.
+
+### Accountability chain
+
+Atelier distinguishes the decisions that a throughput-oriented workflow can
+collapse:
+
+```text
+approved contract
+  -> authorized claim
+  -> execution attempt
+  -> exact candidate
+  -> delivery with current evidence
+  -> accountable acceptance
+  -> accepted work
+```
+
+Approval authorizes an attempt within a durable ceiling. A claim assigns
+cooperative mutation ownership. Execution produces a candidate. Delivery makes
+that candidate reviewable and records evidence. Acceptance is a separate
+decision that the evidence satisfies the approved contract and project policy.
+Only an authorized operator may record acceptance. A worker cannot infer it from
+having produced a pull request, merge, deployment, or receipt.
+
+### Plan mode
+
+Plan mode works with the operator to turn incomplete intent into approved,
+worker-ready assignments.
+
+It should:
+
+1. Check unresolved planner messages and delivered work awaiting acceptance.
+1. Present each delivered candidate, approved contract, and live evidence for an
+   operator acceptance or rework decision.
+1. Record acceptance only when the invoking operator is authorized to accept it.
+1. Capture a concrete idea as draft work without requiring approval.
+1. Record intent, rationale, non-goals, constraints, edge cases, related
+   context, and a done definition.
+1. Identify affected projects and cross-project dependencies.
+1. Decompose work only where sequencing, independence, or reviewability
+   benefits.
+1. Challenge ambiguous scope and missing negative requirements.
+1. Preview the complete proposed initiative and its assignments.
+1. Ask the operator to approve promotion.
+1. Record the exact approved revision, durable authority ceiling, acceptance
+   policy, and governing project-policy revision.
+1. Link one existing eligible native ticket. Initial plan mode never creates or
+   mutates native tickets.
+
+Drafting and approval are distinct. Agents may create and improve drafts freely.
+Approval is an authority transition.
+
+### Work mode
+
+Work mode runs in the context of one project.
+
+It should:
+
+1. Resolve the current project and its policy.
+1. Fetch the Git mailbox and check work-threaded messages.
+1. Identify approved work whose dependencies and project-specific gates are
+   satisfied.
+1. Verify that the required Agent Scripts capability and native ticket are
+   available.
+1. Refuse a claim while another assignment for the project is active.
+1. Claim exactly one assignment through a verified Git transition.
+1. Confirm the approved assignment revision, policy identity, current claim, and
+   effective authority.
+1. Delegate implementation to `implement-ticket`.
+1. Register the exact candidate when durable implementation state first exists.
+1. Post questions, blockers, discoveries, and scope-change requests to the
+   assignment's durable thread.
+1. Reject material unapproved scope growth.
+1. Revalidate the claim before every consequential external mutation.
+1. Record an attempt receipt for blocked, released, or delivered work using
+   exact candidate, validation, review, and pull-request evidence.
+1. Deliver accountable work into `delivered`, or leave the assignment blocked or
+   released through another verified Git transition.
+
+Initial work mode is serial: a project may have only one active assignment.
+Parallel assignment execution is outside v0.
+
+Finishing the assignment in the invoking session is not a success condition. A
+worker succeeds when it either produces accountable evidence for the approved
+outcome or leaves the work in an explicit, truthful, recoverable state.
+
+### Audit mode
+
+Audit mode is read-only. It reconstructs accountability from the Git mailbox and
+live project systems.
+
+Each audited promise receives one explicit verdict:
+
+- `satisfied`,
+- `violated`,
+- `unknown` because required evidence is unavailable,
+- `stale` because the candidate or governing state changed,
+- `needs-decision`,
+- or `authority-unreconstructable`.
+
+Audit should identify:
+
+- approved work with no implementation,
+- active work whose claim or approved revision is unclear,
+- implementation that exceeds its approved scope,
+- unresolved planner-worker decisions,
+- stale pull-request or review evidence,
+- missing validation or required review,
+- delivered work awaiting acceptance,
+- accepted work whose evidence has since become stale or unavailable,
+- and actions that exceed project policy or task-specific authority.
+
+Audit reads live native state when that state is part of the evidence. Cached or
+historical success is not sufficient.
+
+## Planning model
+
+The initial model should remain deliberately small.
+
+### Initiative
+
+An initiative is an optional, non-authoritative grouping document for a coherent
+outcome that may span projects. It explains cross-project intent. Children are
+derived only from each assignment's `initiative_id`; executable authority,
+dependencies, readiness, and acceptance belong to assignments. Initiative
+progress is derived from those children.
+
+### Assignment
+
+An assignment is one project-scoped unit of approved work that a worker may
+claim. It should be independently understandable and reviewable.
+
+An initiative whose scope already fits one project and one reviewable changeset
+may consist of a single assignment. Atelier should not require ceremonial
+one-child decomposition.
+
+### Message
+
+A message is durable communication attached to an assignment. The work, not the
+agent task, is its address.
+
+### Receipt
+
+A receipt records the evidence produced by one execution attempt. It should
+identify:
+
+- whether the attempt blocked, released, or delivered,
+- the approved assignment revision,
+- the worker claim,
+- the project and exact candidate revision,
+- the candidate branch and pull request when durable implementation exists,
+- validation performed and its outcome,
+- independent review performed and its outcome,
+- the native ticket and pull request when present,
+- unresolved obligations,
+- and whether mutation ownership was retained or relinquished.
+
+Receipts summarize evidence; they do not replace live verification.
+
+## Human-shaped changesets
+
+Atelier retains the existing planning doctrine but not its fixed implementation
+or all of its numeric heuristics.
+
+Planning should continue to:
+
+- keep an initiative executable as one assignment when it is already reviewable,
+- avoid one-child decomposition without a real reason,
+- separate unrelated concern domains,
+- prefer additive foundations before disruptive transitions,
+- separate mechanical restructuring from behavioral changes when that helps
+  review,
+- keep validation with the behavior it proves,
+- identify re-split triggers before implementation,
+- and create follow-up work when implementation or review reveals new scope.
+
+Line counts may inform judgment but are not universal correctness gates. The
+test is whether a reviewer can construct an accurate mental model of the change
+and evaluate it independently.
+
+## Project policy and authority
+
+Each project carries the strict, human-readable policy defined by the
+[Atelier Project Policy Contract]. Unknown fields, unsupported values, and
+unreadable policy revisions fail closed.
+
+The effective authority is the intersection of:
+
+1. project policy,
+1. the approved assignment,
+1. the operator's task-specific grant,
+1. and host or native-system enforcement.
+
+A promoted assignment records its inheritable authority ceiling and the exact
+repository, commit, and path of the project policy used for approval. A
+task-specific operator grant is inheritable only when it is recorded in that
+approved contract.
+
+Before claim, every consequential external mutation, delivery, and acceptance,
+Atelier reads the approved policy revision and current project policy. Current
+policy may tighten approved authority and block an action. A later, looser
+policy does not widen an existing approval; widening authority requires a new
+work revision and approval. If either policy identity cannot be read or
+reconciled, Atelier stops.
+
+A skill is not a security boundary. Atelier records and checks authority, while
+host permissions, protected branches, hooks, and native access controls enforce
+what they can.
+
+At approval, Atelier resolves the policy to an exact repository commit and
+stores that identity and the granted subset of its authority in the work
+contract. Host-local credentials and checkout paths are not policy. Work mode
+verifies that the current repository matches the stable project record before it
+reads or claims work.
+
+## Relationship to native tickets
+
+Atelier work and native project tickets have different responsibilities.
+
+Atelier owns:
+
+- cross-project intent,
+- approval,
+- assignment,
+- planner-worker communication,
+- and accountability receipts.
+
+Native systems own their normal delivery and governance records.
+
+Planning may begin privately in Atelier before a native ticket exists. The
+initial worker contract, however, requires one linked and eligible native ticket
+before claim because `implement-ticket` is the only direct implementation
+capability.
+
+An operator or the project's external triage process must supply that ticket;
+initial plan mode never publishes one. Atelier-only execution and read-only
+external-ticket execution remain unsupported until Agent Scripts offers a
+generally useful ticket-independent implementation contract.
+
+Atelier links these records; it does not synchronize mutable ticket fields or
+pretend that they are the same object.
+
+Native ticket state is checked again before repository, pull-request, or review
+mutations, delivery, and acceptance. If an external edit, closure, or rejection
+invalidates eligibility or the approved contract, the worker stops and records a
+blocked attempt with the conflict. Atelier never resolves the disagreement by
+silently copying one record over the other.
+
+## Git mailbox
+
+The Git mailbox is the only Atelier coordination store. It is:
+
+- passive,
+- document-based,
+- human-readable,
+- historically inspectable,
+- independent of any managed project,
+- and accessible to general and project-specific planners and workers.
+
+It is not a task queue or notification service. Participants discover new state
+when they explicitly fetch and inspect it.
+
+The [Git Mailbox Contract] defines its repository layout, document conventions,
+write protocol, claim behavior, failure semantics, and minimal interactions.
+
+## Reliability model
+
+Atelier deliberately accepts Git's passive availability model.
+
+- Local drafts may exist before publication.
+- Shared authority exists only after a successful, verified push.
+- A remote failure blocks claims, approval, delivery, acceptance, and other
+  authoritative shared transitions.
+- Ambiguous push results must be read back before they are retried or reported.
+- Non-fast-forward rejection requires fresh state and precondition evaluation.
+- Claims do not expire automatically.
+- No background service repairs or reconciles the repository.
+
+Atelier should prefer an explicit unknown outcome over inferred success.
+
+## What is retained
+
+Very little current implementation should survive unchanged.
+
+### Retain as product doctrine
+
+- The [Atelier North Star].
+- The workshop metaphor in [Why Atelier?].
+- Intent before execution.
+- Draft work before explicit promotion.
+- Full-plan preview before approval.
+- Human-shaped changeset planning.
+- Visible dependencies and deliberate sequencing.
+- Work-threaded rather than agent-threaded communication.
+- Project-specific authority and review posture.
+- Fail-closed persistence and current-state verification.
+
+### Re-author as skills, schemas, or evaluations
+
+- Draft creation and refinement behavior.
+- Promotion and clarification behavior.
+- Changeset shaping and re-split judgment.
+- Planner and worker startup checks.
+- Work-threaded message behavior.
+- Read-only accountability status and audit behavior.
+- Representative current test scenarios that express these product rules.
+
+The existing skill text may be useful source material, but new skills should be
+written for the new product boundary rather than mechanically ported.
+
+### Abandon
+
+- The Typer CLI as the primary product.
+- Beads and Dolt integration.
+- The Atelier store abstraction and migration layers.
+- Agent launch, session discovery, and transcript resumption.
+- Worktree creation and mapping.
+- Worker runtime, hooks, watch loops, and reconciliation.
+- Projected skill homes and bootstrap repair.
+- GitHub and external-provider client abstractions.
+- Native-ticket import, export, and mutable synchronization.
+- Pull-request publication, restacking, and merge implementation.
+- System/user configuration compatibility.
+- Data migration and backward compatibility.
+- Tests whose only purpose is preserving abandoned machinery.
+
+The current codebase should be treated as research evidence, not as an
+implementation foundation.
+
+## Transition from the current codebase
+
+The current CLI should receive a final archival tag or branch before the reset.
+The next implementation should then replace it rather than coexist with it.
+
+There should be no dual-running period, data migration, compatibility adapter,
+or attempt to route new skill behavior through the existing store and worker
+runtime. Existing documents and skills are source material; selected behavioral
+tests may become forward-evaluation cases. Legacy Python modules and their
+implementation-specific tests are not the scaffold for the new product.
+
+This clean break is intentional. Maintaining both architectures would preserve
+the infrastructure burden that the reset is meant to remove.
+
+## Validation strategy
+
+The next version should be validated outside Atelier itself.
+
+At minimum, forward evaluations should cover:
+
+1. A personal GitHub project with human approval and merge.
+1. A cross-project initiative spanning Tuber and Peeler.
+1. A corporate project where Atelier cannot create or modify native tickets.
+1. Two workers racing to claim the same assignment.
+1. Planner and worker messages crossing while both are active.
+1. A worker discovering scope that invalidates the approved plan.
+1. An interrupted worker being replaced without losing durable context.
+1. Git remote failure before, during, and after a push.
+1. A pull request whose previously reviewed head becomes stale.
+1. Acceptance where some evidence is missing or cannot be verified.
+1. Project policy changing after approval.
+1. A native ticket changing or closing during execution.
+
+Evaluations should measure:
+
+- whether promoted assignments are self-contained,
+- whether changes remain cognitively reviewable,
+- whether authority boundaries are respected,
+- whether interruption and resumption use durable artifacts,
+- whether current evidence supports every delivery and acceptance claim,
+- and how much operator effort is required to understand and accept the work.
+
+Lines of code and raw ticket throughput are not success measures.
+
+The backing protocol has separately passed the 15-scenario
+[Mailbox Protocol Validation]. That result validates the Git mechanics, not the
+future skill prompts, host integration, or live provider adapters.
+
+## Initial delivery boundary
+
+The first usable version should contain only:
+
+- the Atelier entry skill,
+- plan, work, and audit mode instructions,
+- deterministic local Git mailbox helpers,
+- the mailbox document schemas,
+- the normative lifecycle and transition contracts,
+- the strict project policy and evidence contract,
+- the `implement-ticket` capability and result contract,
+- and forward evaluations for the core planner-worker interactions.
+
+It should support one Git mailbox realm and one native ticket provider first.
+Additional providers should be expressed through host connectors and
+project-policy references rather than a new Atelier provider framework.
+
+## Decisions intentionally deferred
+
+- Exact cross-host plugin dependency packaging.
+- Ticket-independent execution.
+- How a planner aggregates multiple mailbox realms across trust boundaries.
+- Automatic policy acceptance.
+- PR stacks, integration, merge, deployment, and ticket-state mutation.
+- Whether accepted work ever needs an explicit archival convention.
+
+These decisions do not require a storage abstraction or server design.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[agent scripts]: https://github.com/shaug/agent-scripts
+[atelier north star]: ./north-star.md
+[atelier project policy contract]: ./project-policy-contract.md
+[git mailbox contract]: ./git-mailbox-contract.md
+[mailbox protocol validation]: ./mailbox-protocol-validation.md
+[why atelier?]: ./atelier-name.md

--- a/docs/git-mailbox-contract.md
+++ b/docs/git-mailbox-contract.md
@@ -1,0 +1,996 @@
+# Git Mailbox Contract
+
+## Purpose
+
+The Git mailbox is Atelier's durable planning record and communication
+mechanism.
+
+It supports a general planner, project-specific planners, and project-specific
+workers without requiring a database, daemon, hosted service, or a project's
+native ticket system.
+
+The mailbox is intentionally passive. Participants publish durable documents and
+discover them when they next fetch and inspect the repository.
+
+This document defines the initial repository conventions and the minimal
+planner-worker interactions required by [Atelier as a Skill].
+
+## Core properties
+
+The mailbox is:
+
+- a dedicated Git repository,
+- scoped to one trust realm,
+- authoritative on one canonical branch,
+- composed of human-readable Markdown and YAML,
+- historically explained by ordinary Git commits,
+- written through fast-forward-only transitions,
+- usable without an Atelier server,
+- and durable across the end, failure, or replacement of any agent session.
+
+The mailbox is not:
+
+- a message bus,
+- a task queue,
+- a notification service,
+- a scheduler,
+- a projection of native project tickets,
+- or one implementation behind a generic storage interface.
+
+It is a small document record store with structured authoritative state. Its
+boundary is concrete: it has no event projection, query service, persistent
+index, alternate backend, or server process.
+
+## Trust realms
+
+One mailbox repository represents one trust realm.
+
+Projects may share a mailbox only when its operators and workers may see the
+names, intent, dependencies, messages, native links, and timing of all included
+work.
+
+Personal, employer, and client work should normally use separate mailbox
+repositories. Atelier must not copy content between realms implicitly.
+
+A planner may read more than one realm only when it is independently authorized
+to access each repository. Cross-realm planning is outside the initial contract.
+
+## Canonical state
+
+The remote canonical branch, normally `main`, is the shared source of truth.
+
+Local documents that have not been pushed are drafts. They do not establish a
+shared approval, claim, decision, delivery, or acceptance.
+
+The current tree describes current state. Git history explains how that state
+changed. Consumers should not need a separate event database to understand the
+mailbox.
+
+No agent session owns a work item's lifecycle. A session may leave work active,
+blocked, released, awaiting a decision, or delivered. The durable documents,
+rather than the originating transcript, define what another planner or worker
+inherits.
+
+Force pushes and history rewrites are prohibited. Where the Git host supports
+it, the canonical branch should reject force pushes and deletion.
+
+## Repository layout
+
+The initial repository layout is:
+
+```text
+atelier.yaml
+projects/
+  <project-id>/
+    project.md
+initiatives/
+  <initiative-id>/
+    initiative.md
+work/
+  <work-id>/
+    work.md
+    messages/
+      <message-id>.md
+    receipts/
+      <receipt-id>.md
+```
+
+All identifiers are stable and treated as opaque by consumers. Create
+identifiers use a type prefix and lowercase UUIDv7, such as `wrk_019f9a9e-...`.
+The initial prefixes are `prj`, `ini`, `wrk`, `msg`, `clm`, `run`, and `rcp`. A
+generated identifier that already exists with different content is a collision
+and fails closed; it is never regenerated during an ambiguous retry. Renaming a
+title or moving a project checkout must not change an identifier.
+
+The initial contract does not use long-lived branches for message classes,
+projects, or lifecycle states. The canonical branch is the serialization point
+for shared writes. Local implementation branches are not mailbox branches, but
+their remote candidate identities may appear in claims and receipts.
+
+The initial contract neither creates nor reads Atelier tags. Commits and
+documents are the only authoritative Git objects.
+
+## Root manifest
+
+`atelier.yaml` identifies the repository as an Atelier mailbox.
+
+Its complete initial schema is:
+
+```yaml
+schema: atelier.mailbox/v1
+realm_id: personal
+canonical_branch: main
+```
+
+Unknown fields are invalid in every v1 structured document. This keeps authority
+and lifecycle interpretation identical across independently evolving clients.
+
+The manifest must not contain credentials or provider tokens.
+
+## Project document
+
+`projects/<project-id>/project.md` identifies a project known to the mailbox.
+
+Its normative frontmatter is:
+
+```yaml
+---
+schema: atelier.project/v1
+id: prj_019f9a9e-0000-7000-8000-000000000001
+name: Example Project
+repository: github:example/project
+policy:
+  repository: github:example/project
+  path: .atelier/policy.yaml
+native_ticket:
+  provider: github
+  required_before_claim: true
+status: active
+---
+```
+
+The body may explain project-specific context that a general planner needs.
+
+Machine-local checkout paths do not belong in shared mailbox documents. The host
+resolves its current checkout independently. Repository identity and the stable
+project identifier survive worktrees, clones, and path changes.
+
+For work mode, project policy supplies the mailbox remote, realm identifier,
+canonical branch, and stable project identifier. The worker fetches that remote
+and verifies that this project document names the current repository and policy
+path. Credentials remain host-local. A general planner starts from an explicitly
+selected mailbox remote rather than searching for mailboxes.
+
+## Initiative document
+
+`initiatives/<initiative-id>/initiative.md` optionally describes a coherent
+outcome that may span projects. It is non-authoritative: it grants no execution
+authority and has no independent lifecycle or approval.
+
+Its normative frontmatter is:
+
+```yaml
+---
+schema: atelier.initiative/v1
+id: ini_019f9a9e-0000-7000-8000-000000000001
+title: Example cross-project outcome
+---
+```
+
+Its body should record:
+
+- intent,
+- rationale,
+- non-goals,
+- constraints,
+- edge cases,
+- related context,
+- and the initiative-level outcome.
+
+Initiative children and progress are derived from each work document's
+`initiative_id`. The initiative does not duplicate a mutable child list. A
+single-assignment effort does not require a ceremonial initiative.
+
+## Work document
+
+`work/<work-id>/work.md` describes one project-scoped assignment.
+
+Its normative frontmatter shape is:
+
+```yaml
+---
+schema: atelier.work/v1
+id: wrk_019f9a9e-0000-7000-8000-000000000001
+title: Add the example behavior
+project_id: prj_019f9a9e-0000-7000-8000-000000000001
+initiative_id: null
+status: draft
+revision: 1
+dependencies: []
+replaces: []
+native_ticket:
+  provider: github
+  id: "123"
+  url: https://github.com/example/project/issues/123
+approval: null
+claim: null
+blocking_message_id: null
+attempt_receipt_id: null
+delivery_receipt_id: null
+acceptance: null
+---
+```
+
+An approved work document replaces `approval: null` with:
+
+```yaml
+approval:
+  approved_by: operator
+  approved_at: 2026-07-25T12:00:00Z
+  revision: 1
+  policy:
+    repository: github:example/project
+    commit: 0123456789abcdef0123456789abcdef01234567
+    path: .atelier/policy.yaml
+  authority_ceiling:
+    - repository.candidate.create
+    - repository.candidate.push
+    - pull_request.create
+    - pull_request.update
+  acceptance:
+    mode: operator
+    required_evidence:
+      - candidate-remote-reachable
+      - pull-request-head-current
+      - pull-request-open
+      - pull-request-mergeable
+      - required-checks-pass
+      - required-validation-reported
+      - independent-review-current
+      - unresolved-feedback-zero
+```
+
+`acceptance.mode` is always `operator` in v1. The approval commit is the
+canonical commit that first contains this approved document; it is recorded by
+the later claim rather than self-referenced here.
+
+Its body should contain the worker-ready contract:
+
+- intent,
+- rationale,
+- scope,
+- non-goals,
+- constraints,
+- edge cases,
+- related context,
+- done definition,
+- verification expectations,
+- changeset or review-shape guidance,
+- and explicit re-split triggers when relevant.
+
+Shared initiative context may be referenced rather than duplicated, but an
+assignment and its referenced context must be sufficient for a new worker to
+understand the work without a planner transcript.
+
+Every field shown above is required, including fields whose value is `null` or
+an empty list. This makes document shape independent of lifecycle state.
+`native_ticket` may remain `null` while private planning or external triage is
+underway, but claim requires the complete eligible native-ticket shape.
+
+## Lifecycle
+
+The initial work lifecycle is deliberately small:
+
+```text
+draft -> approved -> active -> delivered -> accepted
+  |          ^          |  ^       |
+  |          |          |  +-------+ rework
+  |          |          +-> blocked -> active
+  |          +------------- release
+  +-> deferred
+  +-> cancelled
+```
+
+The allowed states are:
+
+- `draft`: editable planning material with no execution authority.
+- `approved`: explicitly promoted and available when its gates are satisfied.
+- `active`: claimed by one worker run.
+- `blocked`: claimed work that cannot continue without a recorded decision or
+  dependency.
+- `delivered`: an exact remotely reachable candidate and delivery receipt are
+  ready for an authorized operator acceptance decision.
+- `accepted`: terminal Atelier work whose delivery an authorized operator
+  accepted against current evidence.
+- `deferred`: intentionally unavailable until a later planning decision.
+- `cancelled`: terminal work that should not be executed.
+
+Claiming moves work from `approved` to `active`. Blocking retains the claim;
+resolving the blocker returns the work to `active`. Explicit release clears the
+claim and returns the work to `approved`. Delivery retains the claim, records
+the exact receipt, and moves `active` work to `delivered`. Acceptance verifies
+live evidence, records the accepting operator, clears the claim, and moves work
+to `accepted`.
+
+Requested rework returns `delivered` work to `active` only when the current
+claim will continue. Otherwise the operator takes over or releases the claim
+first. Deferring or cancelling claimed work requires release or takeover.
+Replanning or splitting claimed work also requires an attempt receipt whenever
+candidate state exists, then release or takeover, cancellation of the old work
+with replacement links, and separately approved replacement work. `release`,
+`rework`, `replanned`, and `superseded` are recorded transition or decision
+outcomes rather than additional lifecycle states.
+
+Lifecycle fields obey these invariants:
+
+- `draft` has no approval, claim, blocker, attempt receipt, delivery, or
+  acceptance;
+- `approved` has approval but no claim, blocker, delivery, or acceptance; it may
+  point to the latest released attempt receipt;
+- `active` has approval and claim but no blocker, delivery, or acceptance; it
+  may retain the latest attempt receipt while continuing a transferred
+  candidate;
+- `blocked` has approval, claim, one blocking message, and its blocked attempt
+  receipt but no delivery or acceptance;
+- `delivered` has approval, claim, exact remotely reachable candidate, and one
+  receipt referenced as both the current attempt and delivery, but no
+  acceptance;
+- `accepted` has approval, the same attempt and delivery receipt, and
+  acceptance, and no current claim or blocker;
+- `deferred` and `cancelled` have no current claim or blocker, while retaining
+  any prior approval, attempt receipt, and replacement links for explanation.
+
+`attempt_receipt_id` is the canonical pointer to the latest execution outcome
+that a fresh worker should inspect. Release clears the current claim, blocker,
+delivery pointer, and acceptance pointer, but atomically sets
+`attempt_receipt_id` to the released receipt when an attempt or candidate
+exists. It never deletes messages or receipts. Returning a rejected delivery to
+active clears its delivery pointer but preserves the rejected receipt as the
+current attempt and preserves the decision message.
+
+Readiness is derived, not stored. Work is ready when:
+
+- its status is `approved`,
+- its dependencies are `accepted`,
+- its project policy gates are satisfied,
+- its linked native ticket is live and eligible,
+- a compatible `implement-ticket` capability is available,
+- and it has no active claim.
+
+## Revisions and approval
+
+Substantive planning changes increment the work revision. Initiative edits are
+ordinary explanatory commits and cannot alter approved child work implicitly.
+
+Approval records:
+
+- approving operator,
+- approved revision,
+- approval timestamp,
+- exact project-policy repository, commit, and path,
+- inheritable authority ceiling,
+- operator-only acceptance mode,
+- and evidence required for acceptance.
+
+The canonical commit containing that transition is the exact approved artifact;
+it does not need to be duplicated inside its own document.
+
+Editing the intent, scope, non-goals, constraints, done definition,
+dependencies, project assignment, or required verification of approved work
+invalidates that approval. The document returns to `draft` until it is previewed
+and approved again. Active, blocked, or delivered work must first be released or
+explicitly taken over; a planner cannot revise the contract beneath its current
+worker or accepter.
+
+Typographical or non-semantic corrections may retain approval only when the
+commit records why the approved contract did not change.
+
+A worker claim records the exact approved revision and canonical commit that the
+worker intends to execute.
+
+The approved policy revision remains the authority ceiling for that work. Before
+claim, each consequential external mutation, delivery, and acceptance, the actor
+also reads current project policy:
+
+- a stricter current policy narrows effective authority and may block the
+  operation;
+- a looser current policy does not widen the approved authority ceiling;
+- widening authority requires a substantive revision and new approval;
+- and an unavailable or incompatible policy revision stops the operation.
+
+An operator instruction delivered only in a host transcript may narrow the
+current invocation. It cannot widen authority inherited by a later session
+unless it becomes part of a newly approved work revision.
+
+## Claims
+
+A claim coordinates cooperative mutation ownership; it is not a security lock.
+
+Its normative shape inside `work.md` is:
+
+```yaml
+claim:
+  id: clm_019f9a9e-0000-7000-8000-000000000001
+  worker_run_id: run_019f9a9e-0000-7000-8000-000000000001
+  work_revision: 1
+  approved_commit: 0123456789abcdef0123456789abcdef01234567
+  policy_commit: 0123456789abcdef0123456789abcdef01234567
+  ticket_observation_digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+  claimed_at: 2026-07-25T12:05:00Z
+  host: codex
+  checkpoint:
+    sequence: 0
+    continuation_token: opaque-token-0
+    authorizations: []
+  candidate: null
+```
+
+Every entry in `checkpoint.authorizations` has this complete shape:
+
+```yaml
+sequence: 1
+invocation_id: run_019f9a9e-0000-7000-8000-000000000001
+phase: pre_external_mutation
+action: repository.candidate.create
+proposed_effect_digest: sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+candidate_head: null
+acknowledged_candidate_head: null
+recorded_at: 2026-07-25T12:06:00Z
+```
+
+`phase` is `pre_external_mutation` or `candidate_published`; `action` uses the
+Agent Scripts v1 vocabulary. SHA fields are exact candidate revisions or `null`
+when the action has no candidate. All other fields are required. Entries are in
+strictly increasing sequence order and are append-only. When transferable
+implementation state first exists, the worker updates the claim only after
+publishing and verifying it:
+
+```yaml
+candidate:
+  repository: github:example/project
+  remote: origin
+  remote_url: git@github.com:example/project.git
+  remote_ref: refs/heads/scott/example-work
+  base_revision: 1111111111111111111111111111111111111111
+  head_revision: 2222222222222222222222222222222222222222
+  pull_request: null
+  workspace_id: null
+  published_at: 2026-07-25T12:20:00Z
+```
+
+`workspace_id` may name a durable host workspace or task but must not contain a
+machine-local path. The candidate is valid only when `head_revision` is
+reachable from `remote_ref` on the verified declared remote. A local-only SHA,
+an unverified push, or a mutable branch name without the exact remote ref and
+head is not a candidate.
+
+After every candidate push, the worker verifies remote reachability, publishes
+the new exact head in the claim, and verifies that mailbox transition before
+relying on that candidate for review, delivery, or another external mutation.
+
+Claims do not expire automatically.
+
+Each delegated-execution checkpoint is a verified mailbox transition. A
+pre-mutation request must name the current claim, sequence, and continuation
+token. Atelier fetches and reevaluates current claim, revision, policy, ticket,
+candidate, and authority. On allowance, one atomic commit increments `sequence`,
+rotates `continuation_token`, and appends an authorization entry containing the
+invocation ID, phase, action, proposed-effect digest, exact candidate head,
+acknowledged candidate head, and recorded time. Atelier pushes and reads that
+exact checkpoint back before returning `allow`. Denial echoes the prior token
+and does not advance the checkpoint or ledger. A consumed sequence or token
+cannot be replayed, and the ledger is never truncated or rewritten.
+
+`candidate_published` uses the same compare-and-swap transition while also
+recording the exact remotely reachable candidate. An unavailable or ambiguous
+mailbox outcome does not acknowledge the candidate. Before accepting any
+terminal result, Atelier requires its sequence and continuation token to equal
+the current claim-ledger tail. It also requires the terminal `authority_used`
+set to equal the allowed `pre_external_mutation` actions in that ledger; either
+under-reporting or an unrecorded action blocks the result.
+
+A worker releases a claim explicitly when it stops without delivering the work.
+An operator or planner may perform an explicit takeover when the prior worker
+cannot release it. Release atomically publishes and points to the authoritative
+attempt receipt. A later claim reads that pointer and adopts its verified
+transferable candidate when one exists. The takeover commit must identify the
+replaced claim, record a reason, and copy the exact verified candidate into the
+new claim when the replaced claim has one. A takeover never silently discards a
+candidate: when no transferable handoff exists it preserves and references the
+current attempt receipt explaining that fact. A takeover creates a new claim
+identifier and worker-run identifier; it never edits the old identifiers in
+history.
+
+Two workers may race to claim the same approved work locally. Only the worker
+whose commit first advances the canonical remote branch owns the claim. Every
+other worker must fetch, observe the winning claim, and stop.
+
+A worker must fetch and verify its exact claim identifier, approved revision,
+approval commit, policy identity, and effective authority immediately before:
+
+- the first implementation mutation,
+- every candidate branch push,
+- pull-request creation or update,
+- review reply or resolution,
+- and delivery.
+
+Unavailable or mismatched verification stops the external action. This is
+cooperative fencing; host, repository, and native-system controls remain the
+enforcement boundary. A takeover therefore revokes the old worker's cooperative
+authority at its next mandatory fence.
+
+Operator acceptance performs the same fresh verification independently.
+Native-ticket mutation, merge, deployment, and branch deletion are unsupported
+in v0 rather than merely unchecked.
+
+## Messages
+
+Durable messages attach to the work item they concern and live at
+`work/<work-id>/messages/<message-id>.md`. Initiative-level discussion becomes
+work guidance or remains planning prose; v0 does not create a second message
+address.
+
+Their normative frontmatter is:
+
+```yaml
+---
+schema: atelier.message/v1
+id: msg_019f9a9e-0000-7000-8000-000000000001
+work_id: wrk_019f9a9e-0000-7000-8000-000000000001
+kind: needs-decision
+author_role: worker
+worker_run_id: run_019f9a9e-0000-7000-8000-000000000001
+audience: planner
+in_reply_to: null
+resolves: null
+blocks: worker
+created_at: 2026-07-25T12:30:00Z
+subject: Choose the compatibility boundary
+---
+```
+
+The initial message kinds are:
+
+- `instruction`,
+- `needs-decision`,
+- and `notification`.
+
+More specific meaning belongs in the subject and body until repeated use proves
+that another machine-readable kind is necessary.
+
+Messages are appended rather than edited. Corrections, answers, acknowledgments,
+and resolutions are new messages that reference the earlier message.
+
+Blocking and resolution are atomic operations:
+
+- `block` creates exactly one unresolved `needs-decision` or `notification`
+  message with `blocks: worker`, changes work to `blocked`, and stores that
+  message identifier in `blocking_message_id` in one commit;
+- blocked work is valid only when that referenced message exists, belongs to the
+  work, blocks the worker, and has no resolving message;
+- `resolve` appends one message whose `resolves` field names the blocker, clears
+  `blocking_message_id`, and moves work to `active` in the same commit;
+- resolving an already resolved message, or a message other than the work's
+  current blocker, fails its precondition.
+
+A non-blocking decision message does not change work status. An unresolved
+message is one for which no valid later message has a matching `resolves`
+reference.
+
+Release, defer, cancel, takeover, and replacement are separate transitions with
+their own authority, receipt, and claim preconditions. They cannot be smuggled
+through blocker resolution.
+
+Agent identifiers may help explain authorship but are not durable addresses. The
+owning work thread and intended role are the coordination path.
+
+## Receipts
+
+`work/<work-id>/receipts/<receipt-id>.md` records one execution outcome.
+
+Its normative frontmatter is:
+
+```yaml
+---
+schema: atelier.receipt/v1
+id: rcp_019f9a9e-0000-7000-8000-000000000001
+work_id: wrk_019f9a9e-0000-7000-8000-000000000001
+outcome: delivered
+approved_revision: 1
+approved_commit: 0123456789abcdef0123456789abcdef01234567
+policy_commit: 0123456789abcdef0123456789abcdef01234567
+claim_id: clm_019f9a9e-0000-7000-8000-000000000001
+worker_run_id: run_019f9a9e-0000-7000-8000-000000000001
+candidate:
+  repository: github:example/project
+  remote: origin
+  remote_url: git@github.com:example/project.git
+  remote_ref: refs/heads/scott/example-work
+  base_revision: 1111111111111111111111111111111111111111
+  head_revision: 2222222222222222222222222222222222222222
+  pull_request: https://github.com/example/project/pull/456
+  workspace_id: null
+  published_at: 2026-07-25T12:20:00Z
+handoff: transferable
+native_ticket:
+  provider: github
+  id: "123"
+validation:
+  - command: just test
+    outcome: passed
+    candidate_revision: 2222222222222222222222222222222222222222
+    observed_at: 2026-07-25T12:45:00Z
+reviews:
+  - mechanism: review-code-change
+    verdict: approved
+    candidate_revision: 2222222222222222222222222222222222222222
+    unresolved_material_findings: []
+    observed_at: 2026-07-25T12:55:00Z
+unresolved_obligations: []
+mutation_ownership: retained
+ended_at: 2026-07-25T13:00:00Z
+---
+```
+
+`outcome` is `blocked`, `released`, or `delivered`. `mutation_ownership` is
+`retained` or `relinquished`. A worker session ending after durable
+implementation state exists must append a receipt even when it does not deliver.
+The work document atomically sets `attempt_receipt_id` to that receipt so a
+fresh worker never has to infer the current handoff from timestamps or
+filenames. A released receipt relinquishes mutation ownership. A blocked receipt
+normally retains it until release or takeover.
+
+`handoff` is `transferable` or `none`. `candidate` is non-null exactly when the
+handoff is transferable. When implementation exists but could not be published
+under effective authority, a blocked receipt uses `handoff: none` and explains
+why. A delivered receipt requires a remotely reachable candidate, evidence
+satisfying the approved delivery policy, exactly one open pull request for that
+candidate, and `mutation_ownership: retained` until acceptance, release, or
+takeover. V1 cannot encode a PR stack or merged result.
+
+Validation entries identify the command, outcome, exact candidate revision, and
+observation time. Review entries identify the reviewer or review mechanism,
+verdict, exact candidate revision, unresolved material findings, and observation
+time. The body explains discoveries, unresolved obligations, handoff
+instructions, and the next required decision.
+
+Receipts are concise evidence indexes. Audit mode must read live native state
+when current state matters.
+
+Acceptance is stored in `work.md` and references one delivered receipt:
+
+```yaml
+acceptance:
+  receipt_id: rcp_019f9a9e-0000-7000-8000-000000000001
+  accepted_by: operator
+  accepted_at: 2026-07-25T13:15:00Z
+  policy_commit: 0123456789abcdef0123456789abcdef01234567
+  candidate_revision: 2222222222222222222222222222222222222222
+  evidence:
+    candidate-remote-reachable: satisfied
+    pull-request-head-current: satisfied
+    pull-request-open: satisfied
+    pull-request-mergeable: satisfied
+    required-checks-pass: satisfied
+    required-validation-reported: satisfied
+    independent-review-current: satisfied
+    unresolved-feedback-zero: satisfied
+```
+
+Acceptance records what was verified at that commit. If evidence later becomes
+unavailable, stale, or contradictory, history is not rewritten. Audit reports
+the current promise as `unknown`, `stale`, or `violated` and cites the earlier
+acceptance.
+
+## Minimal planner-worker interactions
+
+The mailbox initially supports only these durable interactions:
+
+- A planner creates or revises a draft work document.
+- An operator approves a revision and authority envelope.
+- A worker claims approved work and registers its exact candidate.
+- A planner sends work-threaded guidance.
+- A worker requests a decision or reports a discovery.
+- A planner or operator resolves a decision with a lifecycle transition.
+- A worker blocks with a message and attempt receipt.
+- A worker releases with a receipt and returns work to approved.
+- An operator or planner takes over with a replacement claim and rationale.
+- A worker delivers with a receipt into `delivered`.
+- An authorized operator accepts the delivery into `accepted`.
+- A planner defers, cancels, or replaces work explicitly.
+
+There is no durable agent-to-agent message that lacks an owning work item. A
+transient host task may report that no eligible work exists, but that fact does
+not create mailbox content.
+
+## Normative transition contract
+
+Every transition uses the common write protocol plus these semantic
+preconditions:
+
+- **Create draft.** A planner requires the identifier to be absent and publishes
+  one draft document. Ambiguous retry reuses the identifier; different existing
+  content is a collision.
+- **Revise draft.** A planner requires the expected draft revision and publishes
+  an incremented revision. After conflict, intent must be reapplied to the
+  current draft.
+- **Approve.** An operator requires the exact previewed draft and readable
+  policy. The commit publishes the approved authority envelope. Changed work or
+  policy stops the operation.
+- **Claim.** A worker requires approved work whose readiness and capability
+  gates pass. The commit publishes active work and its claim. If
+  `attempt_receipt_id` identifies a verified transferable handoff, the new claim
+  adopts that exact candidate. A losing claim stops.
+- **Register or update candidate.** The claiming worker requires its exact
+  active claim and unconsumed checkpoint and publishes the exact candidate while
+  advancing the checkpoint. Retry is valid only for the same candidate
+  transition.
+- **Authorize external mutation.** The claiming worker requires its exact active
+  claim and unconsumed checkpoint. The commit advances the checkpoint only after
+  current revision, policy, ticket, candidate, and authority pass. The returned
+  allowance applies to one named action.
+- **Block.** The claiming worker requires its exact active claim and atomically
+  publishes blocked work, its blocking message, and an attempt receipt
+  referenced by `attempt_receipt_id`. Retry is valid only while that same claim
+  remains active.
+- **Resolve.** A planner or operator requires the exact unresolved current
+  blocker and atomically publishes the resolution and active state. A changed
+  blocker stops the operation.
+- **Release.** The claiming worker or takeover actor requires a current claim on
+  active, blocked, or delivered work. It publishes a receipt when attempt or
+  candidate state exists, sets `attempt_receipt_id` to that exact receipt, and
+  returns the work to approved with no claim. A changed claim stops the
+  operation.
+- **Take over.** An operator or planner requires the exact replaced claim on
+  active, blocked, or delivered work. It publishes a new claim and rationale,
+  copying the replaced claim's verified candidate. If no transferable candidate
+  exists, it retains `attempt_receipt_id` as the explicit no-handoff record. A
+  changed claim stops the operation.
+- **Deliver.** The claiming worker requires current claim, candidate, policy,
+  ticket, and evidence. It atomically publishes the receipt and delivered state.
+  Every identity must remain current on retry.
+- **Request rework.** An authorized operator requires the current delivery and
+  claim. It publishes active work with the same claim and a decision message. A
+  changed delivery or claim stops the operation.
+- **Accept.** An authorized operator requires every approved live-evidence
+  predicate to be satisfied. It publishes acceptance and accepted work. A
+  changed candidate, policy, ticket, or evidence stops the operation.
+- **Defer or cancel.** A planner requires draft or approved work with no claim
+  and publishes the selected state. Conflict requires full reevaluation.
+- **Replace or split.** A planner and operator require draft or approved work
+  whose prior candidate disposition is recorded. One commit cancels the old work
+  and publishes replacement drafts whose `replaces` fields name the old work.
+  The inverse relationship is derived. Replacement work requires separate
+  approval.
+
+The actor named above is a protocol role. Project policy determines which actor
+may perform it, except acceptance, which is operator-only in v1. Each
+operation's durable result is one Git commit even when several documents change.
+
+## Native links
+
+Native tickets, pull requests, documents, and deployments are stored as typed
+links.
+
+Links should record:
+
+- relation,
+- provider or system,
+- stable external identifier,
+- URL when useful,
+- optional provider-native revision or version,
+- and observation timestamp when the linked state is time-sensitive.
+
+Atelier does not copy mutable native ticket status, title, body, comments, or
+review state into the mailbox as synchronized fields. Workers and audits read
+live state when project policy depends on it.
+
+The worker rechecks native-ticket identity, eligibility, and the approved
+material-field digest before claim, every consequential repository or
+pull-request mutation, and delivery. The operator repeats that check before
+acceptance. If the ticket was materially edited, closed, or rejected outside
+Atelier, the [Atelier Project Policy Contract] determines whether the approved
+contract remains eligible. An invalidating conflict stops execution and produces
+a blocked attempt receipt and work-threaded decision message. Neither record
+silently overwrites the other.
+
+Truth ownership remains non-synchronizing:
+
+- Atelier owns approved intent, non-goals, authority, assignment, and acceptance
+  policy;
+- the native tracker owns externally governed delivery state and dependencies;
+- the project repository owns code and project policy;
+- and the pull-request system owns candidate, CI, review, and merge state.
+
+Any material contradiction is reported and blocks the dependent transition.
+
+## Derived views and audit outcomes
+
+A fresh clone derives operational views directly from validated documents:
+
+- ready work is approved work whose derived gates pass;
+- active work is `active` or `blocked` work with a valid claim;
+- decision-needed work has an unresolved `needs-decision` message;
+- blocked work additionally references its one current blocking message;
+- delivered work is `delivered` and references a valid delivered receipt;
+- and accepted work contains an acceptance record bound to that receipt and
+  candidate.
+
+Live audit evaluates each required promise as `satisfied`, `violated`,
+`unknown`, `stale`, `needs-decision`, or `authority-unreconstructable`.
+Historical acceptance is never rewritten when evidence changes. The current
+audit verdict cites both the acceptance commit and the live fact that changes
+its present interpretation.
+
+## Write protocol
+
+The canonical remote must:
+
+- permit the authorized actor to fetch and directly update the canonical branch,
+- accept atomic fast-forward ref updates,
+- expose the resulting commit for read-back,
+- reject force pushes and branch deletion where the host supports those rules,
+- and retain reachable history.
+
+A repository that permits updates only through pull requests is not a compatible
+mailbox remote. Mailbox commits are the coordination primitive; they are not
+software changes awaiting code review.
+
+Every shared mutation follows the same protocol:
+
+1. Fetch the canonical remote branch.
+1. Verify the operation's preconditions against the fetched commit.
+1. Apply one logical transition in an isolated local checkout.
+1. Create one commit that contains every document change required by the
+   transition.
+1. Push as a fast-forward update without force.
+1. If rejected, fetch current state and reevaluate the operation.
+1. Retry only when the operation remains valid and idempotent.
+1. Read the remote branch back and verify the expected commit is reachable and
+   contains the exact expected durable content.
+
+A transition that updates several mailbox documents must update them in one
+commit. Consumers never treat an unpushed commit as shared state.
+
+Each create operation uses a stable identifier generated before the first push.
+An ambiguous retry reuses that identifier so it cannot create a duplicate
+message, receipt, initiative, or work item.
+
+Retries are bounded. Conflict, uncertainty, or a changed precondition is
+reported rather than hidden.
+
+Operation-specific retry rules override a generic retry:
+
+- a losing claim never retries;
+- any independent append-only message may be replayed on a new head when its
+  exact content, references, and meaning remain unchanged;
+- a resolution retries only while its target remains the unresolved current
+  blocker;
+- approval retries only while the exact previewed revision and policy remain
+  unchanged;
+- candidate registration retries only for the identical candidate;
+- and a receipt or acceptance retries only while claim, candidate, policy,
+  native ticket, and evidence remain current.
+
+## Failure semantics
+
+### Remote unavailable
+
+Participants may read previously fetched state with an explicit staleness
+warning or continue private draft work.
+
+They may not report a shared approval, claim, release, decision, delivery, or
+acceptance until the remote accepts and exposes the transition.
+
+### Push result unknown
+
+The writer fetches the remote branch and verifies both:
+
+1. the expected commit is reachable from the current remote head, even if later
+   mailbox commits have advanced it; and
+1. the expected commit's tree contains the exact document content the operation
+   intended to publish.
+
+- If both are true, the operation succeeded historically. The caller must still
+  revalidate current state before any dependent action.
+- If absent, the operation may be retried after fresh precondition evaluation.
+- If verification is impossible, the outcome remains unknown and the writer
+  stops.
+
+### Non-fast-forward rejection
+
+The writer fetches current state and reevaluates the semantic precondition.
+
+It must not mechanically force, merge, or rebase a transition whose meaning may
+have changed. A losing claim attempt, superseded approval, or resolved question
+ends rather than retries.
+
+### Malformed or unsupported document
+
+Consumers fail closed for any operation that depends on the document. They
+identify the path, schema, and validation problem without rewriting it
+automatically.
+
+## Schema evolution
+
+Every structured document declares a schema name and version. V1 schemas reject
+all unknown fields.
+
+A consumer must reject an unsupported version when interpreting approval, claim,
+dependency, policy, delivery, or acceptance state.
+
+There is no general migration framework. If a future schema requires replacement
+documents, the change is performed as an explicit, reviewable Git commit with
+its own verification.
+
+## No projections or server
+
+The canonical implementation reads repository paths and documents directly.
+
+It may build transient in-memory views during one invocation. Those views are
+discarded afterward and never become shared or authoritative.
+
+The initial design explicitly excludes:
+
+- SQLite or another persistent index,
+- generated current-state manifests,
+- a background indexer,
+- a webhook receiver,
+- an Atelier API service,
+- a synchronization daemon,
+- and alternative storage backends.
+
+If direct reads become inconvenient, the first remedies are narrower path
+conventions, smaller active documents, and explicit archival organization.
+SQLite is not a planned scaling stage, and a server implementation is not a
+supported future backend. Atelier is allowed to stop scaling before it is
+allowed to add either.
+
+## Security and privacy
+
+The mailbox must not contain:
+
+- credentials,
+- provider tokens,
+- secrets copied from managed projects,
+- private artifacts that belong in their source system,
+- or information that violates the realm's trust boundary.
+
+Repository access controls determine who may read or write mailbox content.
+Branch protection and backups reduce accidental history loss but do not make Git
+a tamper-proof ledger.
+
+Document author fields, timestamps, commit authorship, and host labels are
+attribution metadata, not cryptographic proof of identity. Authorization derives
+from repository access, approved project policy, the work's durable authority
+ceiling, and native enforcement. The initial trust-realm model does not attempt
+non-repudiation among authorized writers.
+
+## Contract tests
+
+The first implementation should prove:
+
+1. Concurrent claim attempts produce exactly one winner.
+1. Concurrent append-only messages are both preserved exactly once.
+1. A timeout-after-success is verified after later commits advance the branch.
+1. An unavailable remote never produces a reported claim.
+1. A blocked attempt survives the worker session and is visible to a fresh
+   planner.
+1. Takeover fences the prior claimant at its next mandatory checkpoint.
+1. Release or takeover preserves a remotely reachable candidate handoff.
+1. A local-only candidate SHA is rejected.
+1. A substantive revision beneath an active claim is rejected.
+1. Policy tightening blocks newly forbidden actions, while loosening never
+   widens an approved authority ceiling.
+1. Material native-ticket drift blocks the next consequential mutation.
+1. Pull-request head drift invalidates candidate evidence and acceptance.
+1. An unsupported or malformed schema fails closed.
+1. A fresh clone reconstructs ready, active, blocked, delivered, and accepted
+   state without a local cache.
+1. No authoritative transition reports success until exact remote read-back
+   verifies its commit and durable content.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[atelier as a skill]: ./atelier-skill-design.md
+[atelier project policy contract]: ./project-policy-contract.md

--- a/docs/git-mailbox-contract.md
+++ b/docs/git-mailbox-contract.md
@@ -625,7 +625,6 @@ reviews:
     verdict: clean
     candidate_revision: 2222222222222222222222222222222222222222
     comparison_base_revision: 1111111111111111111111111111111111111111
-    unresolved_material_findings: []
     observed_at: 2026-07-25T12:55:00Z
 unresolved_obligations: []
 mutation_ownership: retained
@@ -652,12 +651,13 @@ takeover. V1 cannot encode a PR stack or merged result.
 Validation entries identify the command, outcome, exact candidate revision, and
 observation time. Review entries identify the reviewer or review mechanism,
 shared review verdict (`clean`, `changes_required`, or `blocked`), exact
-candidate and comparison-base revisions, unresolved material findings, and
-observation time. A review can satisfy `independent-review-current` only when
-its verdict is `clean`, its candidate and comparison-base revisions match the
-current delivery, and it reports no unresolved material findings. The body
-explains discoveries, unresolved obligations, handoff instructions, and the next
-required decision.
+candidate and comparison-base revisions, and observation time. A review can
+satisfy `independent-review-current` only when its verdict is `clean` and its
+candidate and comparison-base revisions match the current delivery. Findings
+retained by a clean shared review keep their recorded dispositions; Atelier does
+not reinterpret an explicit deferral as a gating failure. The body explains
+discoveries, unresolved obligations, handoff instructions, and the next required
+decision.
 
 Receipts are concise evidence indexes. Audit mode must read live native state
 when current state matters.

--- a/docs/git-mailbox-contract.md
+++ b/docs/git-mailbox-contract.md
@@ -622,8 +622,9 @@ validation:
     observed_at: 2026-07-25T12:45:00Z
 reviews:
   - mechanism: review-code-change
-    verdict: approved
+    verdict: clean
     candidate_revision: 2222222222222222222222222222222222222222
+    comparison_base_revision: 1111111111111111111111111111111111111111
     unresolved_material_findings: []
     observed_at: 2026-07-25T12:55:00Z
 unresolved_obligations: []
@@ -650,9 +651,13 @@ takeover. V1 cannot encode a PR stack or merged result.
 
 Validation entries identify the command, outcome, exact candidate revision, and
 observation time. Review entries identify the reviewer or review mechanism,
-verdict, exact candidate revision, unresolved material findings, and observation
-time. The body explains discoveries, unresolved obligations, handoff
-instructions, and the next required decision.
+shared review verdict (`clean`, `changes_required`, or `blocked`), exact
+candidate and comparison-base revisions, unresolved material findings, and
+observation time. A review can satisfy `independent-review-current` only when
+its verdict is `clean`, its candidate and comparison-base revisions match the
+current delivery, and it reports no unresolved material findings. The body
+explains discoveries, unresolved obligations, handoff instructions, and the next
+required decision.
 
 Receipts are concise evidence indexes. Audit mode must read live native state
 when current state matters.

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,0 +1,257 @@
+# Atelier Skill Implementation Plan
+
+## Purpose
+
+This plan turns the [Atelier as a Skill] design into a sequence of reviewable
+decisions and vertical slices. It does not preserve the current CLI as an
+implementation foundation.
+
+The plan optimizes for one question:
+
+> Can Atelier make agentic software development faster without allowing
+> implementation activity to outrun durable intent, bounded authority, current
+> evidence, and human acceptance?
+
+Codex is the v0 reference host. Atelier is the first live dogfood project.
+Neither choice is evidence of generality; external validation remains a separate
+gate.
+
+## Governing constraints
+
+- Atelier remains its own repository and installable plugin.
+- Agent Scripts remains an independently installed platform dependency.
+- The Git mailbox is the only shared Atelier state.
+- There is no database, daemon, server, background lease, or persistent
+  projection.
+- Native tickets describe project work. The mailbox carries Atelier planning,
+  approval, claim, coordination, receipt, and acceptance state.
+- Agent Scripts owns ticket implementation and its transitive workflow. Atelier
+  supplies policy, authority fences, and terminal validation; it does not copy
+  or re-orchestrate that workflow.
+- The v0 delivery outcome is one ready pull request. Merge, deployment, native
+  ticket mutation, stack carving, and branch deletion remain outside Atelier
+  authority.
+- Operator acceptance is distinct from delivery, merge, push, or native-ticket
+  completion.
+- Backward compatibility, data migration, and dual operation are not goals.
+
+## Phase 0: Freeze the contracts
+
+### Work
+
+1. Land the coordinator-neutral delegated-execution capability in Agent Scripts.
+1. Record Codex as the v0 reference host and define the portable host-adapter
+   boundary.
+1. Reconcile the design with the 16-scenario [Mailbox Protocol Validation].
+1. Approve this implementation sequence and its reset gate.
+
+### Exit criteria
+
+- Agent Scripts publishes and validates
+  `agent-scripts.implement-ticket/delegated-execution/v1`.
+- The design, [Git Mailbox Contract], [Atelier Project Policy Contract], and
+  implementation plan agree on lifecycle, authority, delivery, and acceptance.
+- No legacy ticket, tag, or implementation has been mutated as part of this
+  phase.
+
+## Phase 1: Prove host-native composition
+
+Build a disposable Atelier Codex plugin with the smallest possible `work`
+vertical slice. It is a composition experiment, not the new production
+implementation.
+
+### Required proof
+
+The experiment must:
+
+1. install Agent Scripts independently from its published repository state;
+1. discover the delegated `implement-ticket` capability by its manifest;
+1. validate the manifest and a structured invocation with Agent Scripts' own
+   validator;
+1. let a fresh Codex worker task invoke the installed skill by stable name;
+1. exercise an allowed pre-mutation checkpoint;
+1. exercise a denied pre-mutation checkpoint and prove that the proposed action
+   did not occur;
+1. exercise exact candidate-publication acknowledgement;
+1. validate a terminal result against the invocation and durable checkpoint
+   tail; and
+1. demonstrate by inspection that the experiment contains no copied
+   `implement-ticket`, review, changeset, or pull-request workflow.
+
+Fixtures may replace live GitHub mutation in this phase, but the process must
+use real Codex skill discovery and a separately installed Agent Scripts skill. A
+Python-only simulation does not satisfy the proof.
+
+### Evaluation
+
+Run forward evaluations in fresh tasks that receive only the installed plugin,
+the disposable repository, and the invocation artifacts they would have in
+normal operation. Include at least:
+
+- a successful delegated handoff;
+- authority denial;
+- stale sequence or continuation token;
+- malformed or incompatible capability;
+- candidate acknowledgement mismatch; and
+- a terminal result that exceeds granted authority.
+
+### Exit criteria
+
+- Every required proof is reproducible from a documented command.
+- Raw inputs, outputs, checkpoint ledger, and result validation are inspectable.
+- An independent adversarial review finds no material composition, authority,
+  durability, or evaluation-validity gap.
+- Any material finding is fixed and the exact revised experiment is reviewed
+  again.
+
+## Reset gate
+
+After Phase 1, stop and present the operator with:
+
+- the merged Agent Scripts prerequisite and exact version;
+- composition and forward-evaluation evidence;
+- adversarial-review findings and dispositions;
+- the proposed new implementation issue graph;
+- a mapping from every open legacy issue to `superseded`, `cancelled`, retained
+  doctrine, or newly represented work;
+- the exact commit proposed for the annotated `atelier-cli-v2-final` tag; and
+- the deletion boundary for the legacy implementation.
+
+Do not close issues, create or push the archival tag, or remove legacy code
+until the operator explicitly confirms this reset after reviewing that evidence.
+
+## Phase 2: Cross the reset boundary
+
+### Work
+
+1. Revalidate that the proposed archival commit is the intended final legacy
+   state.
+1. Create and push the annotated `atelier-cli-v2-final` tag.
+1. Close obsolete legacy issues with explicit `superseded` or `cancelled`
+   rationales and links to replacement work where applicable.
+1. Remove the legacy CLI, Beads and Dolt integration, worker runtime, session
+   orchestration, projections, legacy configuration, and implementation-specific
+   tests.
+1. Preserve only doctrine, contracts, experiment evidence, repository packaging,
+   and clearly reusable fixtures whose meaning survives the reset.
+1. Establish the minimal plugin and skill skeleton with failing contract tests
+   for the first vertical slice.
+
+### Exit criteria
+
+- The archival tag is remotely reachable and annotated.
+- No open issue falsely describes abandoned architecture as active work.
+- The default branch contains one architecture, not a compatibility bridge.
+- The repository has a small, honest failing-test boundary for the new product.
+
+## Phase 3: Build one accountable vertical slice
+
+Implement only the path:
+
+```text
+approved work
+  -> eligible work
+  -> claimed work
+  -> delegated implementation
+  -> delivered ready PR
+  -> operator acceptance
+```
+
+### Changesets
+
+Each changeset must be independently reviewable and leave the repository in a
+coherent state:
+
+1. **Plugin and host adapter** — Codex discovery, `/atelier` entry skill, strict
+   startup capability check, and exact installation failure.
+1. **Mailbox documents and validation** — root, project, initiative, work,
+   message, receipt, and policy schemas with fresh-clone reconstruction.
+1. **Canonical Git writes** — fast-forward-only read-modify-verify writes,
+   semantic retry, ambiguous-result recovery, and no persistent projection.
+1. **Plan mode** — draft, revise, approve, and promote one assignment tied to
+   one native GitHub ticket.
+1. **Claim and checkpoint ledger** — project-serial eligibility, fenced claim,
+   sequence and token transitions, takeover, and append-only authorization
+   evidence.
+1. **Work delegation** — construct the versioned invocation, call the separately
+   installed Agent Scripts skill, validate checkpoints and terminal results, and
+   record blocked or delivered receipts.
+1. **Audit and acceptance** — reread native state, evaluate the finite evidence
+   predicates, report uncertainty, and record explicit operator acceptance.
+
+Do not add additional providers, parallel project work, automatic merge,
+deployment, a dashboard, SQLite, a server, or migration support during this
+phase.
+
+### Exit criteria
+
+- A fresh planner task and a fresh worker task coordinate only through native
+  project state and a fresh clone of the mailbox.
+- A worker can disappear after every consequential boundary without losing the
+  durable explanation of what happened.
+- No action exceeds the intersection of approved policy, current policy,
+  approved work, invocation authority, and host enforcement.
+- Delivery and acceptance fail closed when current evidence is missing, stale,
+  violated, or unknown.
+- The complete Atelier dogfood changeset is human-shaped and reviewable.
+
+## Phase 4: Dogfood on Atelier
+
+Use the new skill to plan and deliver the remaining Atelier v0 implementation
+work. Keep merge authority and acceptance with the operator.
+
+Measure:
+
+- operator time required to understand and approve assignments;
+- number and cause of blocked or restarted worker attempts;
+- recovery quality after deliberate task interruption;
+- review findings caused by scope or contract ambiguity;
+- stale-evidence detection;
+- changeset size and conceptual coherence; and
+- whether the mailbox makes the current accountability state easier to explain
+  than the native ticket and pull request alone.
+
+Dogfooding succeeds only if the records materially improve supervision and
+handoff. Completing code faster is insufficient.
+
+## Phase 5: Test the product claim
+
+Run one cross-project Tuber and Peeler initiative, then one constrained
+environment where Atelier cannot mutate the native tracker.
+
+The cross-project evaluation must prove that:
+
+- one initiative can promote project-specific assignments without pretending the
+  repositories share a native epic;
+- each worker sees only its own approved assignment and project policy;
+- cross-project blockers and decisions survive task boundaries in the mailbox;
+- each repository produces its own reviewable candidate and evidence; and
+- acceptance can proceed independently without obscuring initiative-level
+  obligations.
+
+The constrained evaluation must prove useful planner-worker communication
+without native-ticket writes. If either evaluation requires a server,
+projection, or copied Agent Scripts workflow, stop and revisit the product
+boundary rather than expanding the architecture.
+
+## Decision points after v0
+
+Only validated demand may justify:
+
+- a Claude Code host adapter;
+- another native ticket provider;
+- multiple active assignments in one project;
+- `ready_prs`, merge, or deployment outcomes;
+- richer derived views rebuilt from Git on demand; or
+- additional Agent Scripts capability contracts.
+
+None of these decisions justify a server-backed mailbox. If Git alone becomes
+insufficient, treat that as evidence that the product shape should change, not
+as an automatic reason to add a database or daemon.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[atelier as a skill]: atelier-skill-design.md
+[atelier project policy contract]: project-policy-contract.md
+[git mailbox contract]: git-mailbox-contract.md
+[mailbox protocol validation]: mailbox-protocol-validation.md

--- a/docs/mailbox-protocol-validation.md
+++ b/docs/mailbox-protocol-validation.md
@@ -1,0 +1,79 @@
+# Mailbox Protocol Validation
+
+## Status
+
+The disposable v0 protocol experiment passed all 15 acceptance scenarios on
+2026-07-25.
+
+The experiment is implemented in `experiments/mailbox_protocol_v0.py` and runs
+entirely against temporary local bare Git repositories and independent clones.
+It removes those repositories after each run.
+
+## Command
+
+```text
+python3 experiments/mailbox_protocol_v0.py
+```
+
+## Results
+
+1. Concurrent claim attempts produced exactly one winner.
+1. Concurrent append-only messages survived exactly once after semantic retry.
+1. A simulated lost push response remained verifiable by ancestry and exact
+   historical content after a later commit.
+1. A claim push to an unavailable remote failed and left no shared claim.
+1. A blocker survived the worker session and was visible to a fresh planner.
+1. After takeover, the prior claimant's next sequence-and-token checkpoint was
+   denied.
+1. Fresh mailbox and project clones discovered the current release receipt from
+   `work.md`, recovered its remotely reachable candidate, and verified that a
+   later takeover preserved that candidate.
+1. A local-only candidate SHA was rejected.
+1. A substantive revision beneath an active claim was rejected.
+1. Policy tightening removed authority and later loosening did not widen the
+   approved ceiling.
+1. Material native-ticket drift invalidated the current invocation.
+1. Pull-request head drift invalidated delivery evidence and acceptance.
+1. An unsupported schema failed closed.
+1. A fresh clone reconstructed approved, active, blocked, delivered, and
+   accepted work plus each referenced blocker, receipt, and acceptance binding.
+1. A fresh clone derived ready work only when dependency, project policy,
+   native-ticket, capability, and project-serial-execution gates all passed.
+1. Every reported authoritative transition had an exact remote read-back.
+
+## What this validates
+
+The experiment validates the proposed Git concurrency and durability model:
+
+- fast-forward-only canonical writes;
+- losing-claim behavior;
+- semantic retry of independent append-only documents;
+- timeout recovery through ancestry and exact-content verification;
+- durable blockers, claims, authorization records, receipts, and candidate
+  handoffs;
+- cooperative takeover fencing through an actual stale checkpoint attempt;
+- lifecycle reconstruction, including referenced artifacts, from a fresh clone;
+  and
+- the absence of a database, daemon, lease server, or persistent projection.
+
+Frontmatter uses JSON object syntax, which is a strict valid subset of YAML.
+This keeps the experiment dependency-free while exercising Markdown documents
+with structured YAML frontmatter.
+
+## What this does not validate
+
+This is a protocol experiment, not an Atelier implementation. It does not prove:
+
+- compatibility with every Git hosting service;
+- real GitHub ticket, pull-request, review, or check API behavior—the drift
+  scenarios exercise only deterministic contract predicates;
+- operator identity or authorization;
+- host-specific skill discovery and invocation;
+- network partitions beyond explicit failure and ambiguous-result cases;
+- complete production schema validation; or
+- usability of the planner and worker prompts.
+
+Those boundaries remain forward-evaluation work for the first skill
+implementation. The experiment is sufficient to keep the passive Git mailbox as
+the proposed backing mechanism; it is not evidence that the rest of Atelier is
+implemented.

--- a/docs/mailbox-protocol-validation.md
+++ b/docs/mailbox-protocol-validation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-The disposable v0 protocol experiment passed all 15 acceptance scenarios on
+The disposable v0 protocol experiment passed all 16 acceptance scenarios on
 2026-07-25.
 
 The experiment is implemented in `experiments/mailbox_protocol_v0.py` and runs

--- a/docs/project-policy-contract.md
+++ b/docs/project-policy-contract.md
@@ -1,0 +1,330 @@
+# Atelier Project Policy Contract
+
+## Purpose
+
+Project policy connects one managed repository to one Atelier mailbox and
+defines the authority and evidence rules that survive an agent session.
+
+The initial contract deliberately supports one narrow delivery posture:
+
+- one GitHub ticket,
+- one remotely published candidate,
+- one ready pull request,
+- no merge, deployment, ticket mutation, or stack carving,
+- and explicit operator acceptance.
+
+Policy is strict YAML stored at `.atelier/policy.yaml` in the managed project.
+At approval, Atelier pins the exact repository commit containing that file.
+Unknown fields are invalid.
+
+## Normative schema
+
+The complete v0 policy shape is:
+
+```yaml
+schema: atelier.project-policy/v1
+
+mailbox:
+  remote: git@github.com:example/atelier-mailbox.git
+  realm_id: personal
+  canonical_branch: main
+  project_id: prj_019f9a9e-0000-7000-8000-000000000001
+
+repository:
+  identity: github:example/project
+  canonical_ref: refs/heads/main
+
+ticket:
+  provider: github
+  allowed_states:
+    - open
+  require_no_blockers: true
+  material_fields:
+    - body
+    - state
+    - relationships
+
+execution:
+  capability: agent-scripts.implement-ticket/delegated-execution/v1
+  delivery_outcome: ready_pr
+  parallel_assignments: false
+
+authority:
+  allow:
+    - repository.candidate.create
+    - repository.candidate.push
+    - pull_request.create
+    - pull_request.update
+    - review.reply
+    - review.resolve
+
+validation:
+  required_commands:
+    - just test
+    - just lint
+
+acceptance:
+  actor: operator
+  evidence:
+    - candidate-remote-reachable
+    - pull-request-head-current
+    - pull-request-open
+    - pull-request-mergeable
+    - required-checks-pass
+    - required-validation-reported
+    - independent-review-current
+    - unresolved-feedback-zero
+```
+
+Every mapping and sequence shown above is required. A sequence may be empty only
+where its field semantics explicitly allow it. Values are case-sensitive.
+
+## Field semantics
+
+### Mailbox
+
+`mailbox` tells project-scoped work mode how to locate shared Atelier state.
+
+- `remote` is the Git remote URL. Credentials remain host-local.
+- `realm_id` must match `atelier.yaml`.
+- `canonical_branch` must match `atelier.yaml`.
+- `project_id` must name the current repository in the mailbox project document.
+
+A mismatch stops work before mailbox mutation.
+
+### Repository
+
+`repository.identity` is `github:<owner>/<repository>`.
+
+`repository.canonical_ref` is the full remote ref from which current policy and
+the implementation base are resolved. The initial contract supports
+`refs/heads/<name>` only.
+
+At approval, Atelier records:
+
+- the repository identity,
+- the exact commit containing `.atelier/policy.yaml`,
+- and the policy path.
+
+### Ticket
+
+The initial provider is `github`.
+
+`allowed_states` is a nonempty subset of:
+
+- `open`.
+
+`require_no_blockers` must be `true` in v0.
+
+`material_fields` is a nonempty subset of:
+
+- `body`,
+- `state`,
+- and `relationships`.
+
+Before claim, Atelier reads those fields and records a canonical observation
+digest in the claim and delegated invocation. Before every consequential
+external mutation, delivery, and acceptance, it rereads them:
+
+- an unchanged digest preserves the prior eligibility result;
+- any material digest change denies the current delegated invocation before its
+  next mutation;
+- Atelier may freshly evaluate the changed ticket only before starting a new
+  delegated invocation whose initial observation records the new digest;
+- an ineligible or ambiguous fresh result keeps the work blocked;
+- and a changed title alone is attribution drift, not contract drift.
+
+A single invocation therefore has one immutable material ticket observation.
+This keeps its terminal ticket identity truthful and makes every allowed drift
+visible as a new invocation rather than an in-place reinterpretation.
+
+The canonical digest input uses UTF-8 JSON with sorted keys and no insignificant
+whitespace. `relationships` includes native blockers, blocked work, parent, and
+sub-issue identifiers when the provider exposes them. Relationship sequences are
+sorted by stable provider identifier before encoding.
+
+### Execution
+
+`execution.capability` is exactly
+`agent-scripts.implement-ticket/delegated-execution/v1`.
+
+`execution.delivery_outcome` is exactly `ready_pr`.
+
+`execution.parallel_assignments` is exactly `false`. The initial contract allows
+only one active assignment per project; `true` is an unsupported value.
+
+### Authority
+
+`authority.allow` is the complete inheritable authority ceiling. Omitted actions
+are denied.
+
+The v0 vocabulary is:
+
+- `repository.candidate.create`,
+- `repository.candidate.push`,
+- `pull_request.create`,
+- `pull_request.update`,
+- `review.reply`,
+- and `review.resolve`.
+
+The following actions are unsupported in v0 and therefore cannot appear:
+
+- ticket mutation,
+- dependency mutation,
+- stack carving,
+- merge,
+- branch deletion,
+- deployment,
+- production mutation,
+- destructive operations,
+- and parent closure.
+
+The effective authority for an action is the intersection of:
+
+1. the approved policy's `authority.allow`,
+1. the current policy's `authority.allow`,
+1. the approved work authority,
+1. the current invocation grant,
+1. and host or native-system enforcement.
+
+An ephemeral invocation may narrow authority. It cannot widen authority
+inherited by a later session.
+
+### Validation
+
+`validation.required_commands` is an ordered sequence of nonempty command
+strings. It may be empty only when the project has no local validation command.
+
+Agent Scripts reports each command, result, exact candidate revision, and
+observation time. These are recorded observations, not independently proven
+facts. An operator may accept them under the `required-validation-reported`
+predicate.
+
+### Acceptance
+
+`acceptance.actor` is exactly `operator` in v0.
+
+`acceptance.evidence` is a nonempty subset of the finite evidence registry
+below. An acceptance transition is valid only when every approved and currently
+required predicate evaluates to `satisfied`.
+
+The operator confirmation records:
+
+- the invoking host's operator attribution,
+- the exact delivery receipt,
+- the exact candidate revision,
+- the approved and current policy commits,
+- each predicate verdict,
+- and the canonical mailbox commit containing the acceptance.
+
+This is cooperative attribution, not cryptographic non-repudiation.
+
+## Evidence predicate registry
+
+Each predicate has one authoritative source and exact evaluation.
+
+### `candidate-remote-reachable`
+
+- **Source:** the declared project Git remote.
+- **Satisfied:** the delivered SHA is reachable from the delivered full remote
+  ref after fetch.
+- **Violated:** the ref exists but does not contain the SHA.
+- **Unknown:** the remote or ref cannot be read.
+- **Stale:** not applicable; a later ref advance still contains the delivered
+  SHA.
+
+### `pull-request-head-current`
+
+- **Source:** live GitHub pull-request state.
+- **Satisfied:** the PR head repository, full ref, and SHA equal the delivery.
+- **Violated:** the PR refers to another repository or ref.
+- **Unknown:** GitHub cannot be read.
+- **Stale:** the PR head SHA changed after the receipt.
+
+### `pull-request-open`
+
+- **Source:** live GitHub pull-request state.
+- **Satisfied:** the PR is open.
+- **Violated:** the PR is closed or merged.
+- **Unknown:** GitHub cannot be read.
+- **Stale:** not applicable.
+
+### `pull-request-mergeable`
+
+- **Source:** live GitHub mergeability.
+- **Satisfied:** GitHub reports the PR mergeable.
+- **Violated:** GitHub reports a conflict.
+- **Unknown:** mergeability is unavailable or still being calculated.
+- **Stale:** the PR head changed after the observation.
+
+### `required-checks-pass`
+
+- **Source:** live required GitHub checks for the exact PR head.
+- **Satisfied:** every required check completed successfully.
+- **Violated:** a required check completed unsuccessfully.
+- **Unknown:** required-check configuration or a required result cannot be read.
+- **Stale:** the PR head changed after the check result.
+
+### `required-validation-reported`
+
+- **Source:** the delivered receipt.
+- **Satisfied:** every command required by the effective policy is reported as
+  passed at the exact delivered SHA.
+- **Violated:** a required command is reported as failed.
+- **Unknown:** a required command or result is absent or unavailable.
+- **Stale:** the receipt's candidate differs from the current delivery.
+
+### `independent-review-current`
+
+- **Source:** a structured `review-code-change` result recorded in the receipt.
+- **Satisfied:** the result is clean and bound to the delivered SHA and
+  comparison base.
+- **Violated:** the result requires changes.
+- **Unknown:** the result is missing, malformed, or blocked.
+- **Stale:** the delivered head or effective comparison base changed.
+
+### `unresolved-feedback-zero`
+
+- **Source:** live GitHub review, comment, and thread state.
+- **Satisfied:** no unresolved material review, comment, or thread remains.
+- **Violated:** an unresolved material item remains.
+- **Unknown:** thread-aware feedback cannot be read.
+- **Stale:** the PR head changed after a previously clean observation.
+
+## Policy drift
+
+At every authority fence, delivery, and acceptance, Atelier reads current policy
+from `repository.canonical_ref`.
+
+It does not attempt to classify the whole document as generally stricter or
+looser. It combines fields deterministically:
+
+- effective authority is the intersection of approved and current allow sets;
+- effective validation commands are their ordered union;
+- effective acceptance evidence is their set union;
+- effective ticket states are their intersection;
+- effective material ticket fields are their set union;
+- and `require_no_blockers` is their boolean OR.
+
+A change to mailbox identity, repository identity, canonical ref, ticket
+provider, execution capability, delivery outcome, parallel-execution value,
+acceptance actor, or schema is incompatible rather than ordered. It blocks the
+dependent transition and requires a new work revision and approval.
+
+Current policy can therefore tighten approved work but cannot silently widen it.
+
+## Unsupported or malformed policy
+
+Atelier fails closed when:
+
+- the file is missing,
+- YAML parsing fails,
+- an unknown field appears,
+- a required field is absent,
+- a value is outside its finite vocabulary,
+- the pinned approval commit cannot be read,
+- current policy cannot be fetched,
+- or deterministic approved/current combination is impossible.
+
+Atelier reports the exact path and violation. It never rewrites project policy
+automatically.

--- a/docs/reset-gate-proposal.md
+++ b/docs/reset-gate-proposal.md
@@ -1,0 +1,426 @@
+# Atelier Reset Gate Proposal
+
+## Decision requested
+
+Approve or reject the destructive reset from the legacy Atelier CLI to the
+skill-based Atelier described in [Atelier as a Skill].
+
+Approval of the design pull request is not approval of this reset. Crossing the
+gate still requires a second explicit operator confirmation after this document
+is merged and reviewed. Until then:
+
+- do not create or push the archival tag;
+- do not create, close, relabel, or otherwise mutate Atelier issues; and
+- do not remove or replace the legacy implementation.
+
+## Proposed archival commit
+
+Create the annotated tag `atelier-cli-v2-final` at:
+
+```text
+c08755f3a80c39b747df4cbf9be94e559d5081e2
+```
+
+This commit contains the final legacy implementation, the next-version design,
+the implementation plan, and the reviewed composition experiment. The reset
+proposal follows in a separate commit so it can name this target exactly. No
+legacy implementation file changes between the proposed target and this
+proposal.
+
+The tag annotation should state that this is the final recoverable snapshot of
+the standalone CLI and that the skill-based product supersedes it. The tag must
+never be moved or reused.
+
+## Validated prerequisite
+
+Atelier depends on Agent Scripts as an independently installed platform. It does
+not vendor or copy Agent Scripts workflows.
+
+The validated dependency is:
+
+- Agent Scripts commit: `861dd04c526d7e2ab7f33d112a00a370db17aae9`;
+- installed plugin: `agent-scripts@agent-scripts` version `0.1.0`;
+- delegated capability: `agent-scripts.implement-ticket/delegated-execution/v1`;
+- installed `implement-ticket` skill SHA-256:
+  `307b660864b15a167e755d0f47840acb56d20e1e8ec940d110d84548aec85243`; and
+- capability manifest SHA-256:
+  `551d2e883d226d2a1e7e39eae66eb2bd3d9d88ec18c56cfba190253677e34156`.
+
+Agent Scripts owns native-ticket implementation, candidate publication, review,
+pull-request lifecycle, changeset carving, and post-publication behavior.
+Atelier owns approved intent, project policy, authority fencing, durable
+planner-worker coordination, terminal-result validation, audit, and operator
+acceptance.
+
+## Composition evidence
+
+The exact reviewed experiment used:
+
+- Atelier composition plugin version `0.1.0+codex.20260726184539`;
+- Atelier skill SHA-256
+  `2e9a2d47405093c6cd24df7d08bb79f3cdb37bfb92de50d94231d2f971ad8539`;
+- `codex-cli 0.145.0`;
+- Codex executable SHA-256
+  `1da3f4e0e96028b8a771814293c3033dafd1971f943f6c7e79b0897fe705f590`; and
+- the separately installed Agent Scripts dependency identified above.
+
+The final verifier passed nine of nine scenarios:
+
+1. an allowed worker produced a reviewed, pushed candidate and fixture
+   `ready_pr`;
+1. a denied PR mutation preserved a reviewed, pushed, transferable candidate and
+   returned `blocked`;
+1. a malformed capability was rejected;
+1. excess terminal authority was rejected;
+1. a candidate-acknowledgement mismatch was rejected;
+1. a foreign invocation could not consume checkpoint state;
+1. an excluded action was denied before mutation;
+1. a stale sequence could not consume checkpoint state; and
+1. a foreign repository could not consume checkpoint state.
+
+The accepted evidence root was archived outside `/tmp` at:
+
+```text
+/Users/scott/.codex/evidence/atelier/2026-07-26-composition-reviewed-vVFqyD/
+```
+
+The exact archive is `atelier-composition-reviewed.vVFqyD.tar.gz` in that
+directory.
+
+The archive SHA-256 is:
+
+```text
+6689d90718351094feaef8c15e23bfed46477e9714626f6a8ef0c2f3b0b643ae
+```
+
+Its 544-entry `SHA256SUMS` manifest has SHA-256:
+
+```text
+edcf9764899464f91e56c59d45e6c87bf775d2a2a758491e261143845fa69578
+```
+
+The repository retains the experiment source under
+`experiments/codex-composition-eval/`. The archive retains the exact raw
+invocations, checkpoint exchanges, Git repositories, worker and reviewer
+transcripts, terminal results, verifier output, installed package bytes, and
+pinned Codex executable used by the final review.
+
+## Adversarial-review disposition
+
+The final independent review returned `PASS WITH FOLLOWUPS`: no material
+composition, authority, durability, provenance, or evaluation-validity blocker
+remains.
+
+The review independently recomputed package manifests, confirmed source and
+installed-package equivalence, resolved both candidate refs to their reported
+heads, traced worker-to-reviewer causality, verified read-only fresh reviewer
+processes, inspected denied-state immutability, and confirmed the nine-scenario
+denominator.
+
+The following limits are binding:
+
+- `ready_pr` in the experiment is a local provider fixture, not a live GitHub
+  pull request;
+- the experiment proves cooperative host-native Codex composition, not
+  containment of a malicious worker;
+- it does not validate a production Atelier implementation;
+- it does not validate live GitHub API behavior; and
+- it does not validate Claude Code compatibility.
+
+Those are later vertical-slice and product-validation obligations. They are not
+reasons to preserve the legacy orchestrator.
+
+## Proposed implementation issue graph
+
+Create the following graph only after reset confirmation. The identifiers below
+are proposal-local names; the created GitHub issues will receive native issue
+numbers.
+
+- `ATELIER-V0` — Epic: prove accountable skill-based development.
+- `RESET` — Push the archive tag, disposition legacy issues, and replace the CLI
+  with a minimal plugin skeleton. Depends on reset confirmation.
+- `HOST` — Discover `/atelier` in Codex, establish the read-only native-state
+  connector boundary, and fail closed unless the exact Agent Scripts capability
+  is available. Depends on `RESET`.
+- `MAILBOX` — Validate mailbox root, project, initiative, work, message,
+  receipt, acceptance, and policy documents. Depends on `RESET`.
+- `GIT-WRITES` — Perform fast-forward-only mailbox writes with semantic retry,
+  remote read-back, and ambiguous-result recovery. Depends on `MAILBOX`.
+- `PLAN` — Draft, revise, approve, and promote one assignment tied to one native
+  GitHub ticket. Depends on `HOST` and `GIT-WRITES`.
+- `CLAIM` — Derive project-serial eligibility and maintain fenced claims and
+  checkpoint ledgers. Depends on `PLAN` and `GIT-WRITES`.
+- `DELEGATE` — Invoke the installed Agent Scripts capability and record a
+  validated blocked or delivered receipt. Depends on `HOST` and `CLAIM`.
+- `AUDIT` — Re-read native ticket, PR, review, and check state through the host
+  connector and record explicit operator acceptance only when every evidence
+  predicate is current. Depends on `HOST`, `MAILBOX`, and `DELEGATE`.
+- `DOGFOOD` — Deliver one human-shaped Atelier changeset through separate
+  planner and worker tasks. Depends on `PLAN`, `CLAIM`, `DELEGATE`, and `AUDIT`.
+- `CROSS-PROJECT` — Run one Tuber and Peeler initiative with independent
+  repository delivery and acceptance. Depends on `DOGFOOD`.
+- `CONSTRAINED` — Validate useful coordination where Atelier cannot mutate the
+  native tracker. Depends on `DOGFOOD`.
+
+`RESET` through `DOGFOOD` are children of `ATELIER-V0`. `CROSS-PROJECT` and
+`CONSTRAINED` are post-v0 product-validation issues, not requirements for the
+first production vertical slice.
+
+Do not create provider expansion, Claude Code, parallel project execution,
+automatic merge, deployment, dashboards, SQLite, server, projection, migration,
+or backward-compatibility issues unless later evidence justifies them.
+
+## Live legacy issue disposition
+
+This inventory was refreshed from GitHub on 2026-07-26. It contains all 43 open
+issues. Each issue receives one primary disposition:
+
+- `superseded`: the outcome is now owned by Agent Scripts or a different
+  boundary;
+- `cancelled`: the issue exists only because of abandoned machinery or
+  compatibility;
+- `retained doctrine`: the lesson survives, but the implementation issue does
+  not; or
+- `newly represented`: a proposed issue above directly carries the surviving
+  work.
+
+After reset confirmation, create the replacement graph first. Then close every
+legacy issue with its mapped disposition, rationale, a link to this proposal,
+and links to created replacement issues where named. Do not mark these issues
+`completed`.
+
+- **#770 — GitHub issue/export provider migration:** `superseded` by the Agent
+  Scripts native-ticket boundary and `DELEGATE`.
+- **#769 — Duplicate GitHub issue/export provider migration:** `superseded` by
+  the #770 disposition.
+- **#768 — PR mutation and review-thread provider migration:** `superseded` by
+  the Agent Scripts PR lifecycle.
+- **#767 — PR lifecycle read-path provider migration:** `newly represented` by
+  the read-only native-state boundary in `HOST` and the live evidence predicates
+  in `AUDIT`.
+- **#766 — Atelier-owned GitHub boundary models:** `superseded` by the Agent
+  Scripts capability contract, `HOST`, and `DELEGATE`.
+- **#754 — Dolt overflow compaction transactions:** `cancelled`; there is no
+  database or Dolt.
+- **#752 — Non-durable Dolt SQL writes:** `cancelled`; there is no database or
+  Dolt.
+- **#749 — Dolt overflow compaction persistence:** `cancelled`; there is no
+  database or Dolt.
+- **#740 — Epic-close stale PR lifecycle:** `superseded` by the Agent Scripts
+  epic and PR lifecycle.
+- **#738 — Beads overflow recovery:** `cancelled`; there is no Beads store.
+- **#736 — Planner startup queue filtering:** `newly represented` by `PLAN` and
+  `CLAIM` eligibility derivation.
+- **#719 — Trycycle-ready Beads contracts:** `cancelled`; there is no Beads
+  runtime, and Atelier is not Trycycle.
+- **#718 — Trycycle-powered bounded worker runtime:** `cancelled`; Agent Scripts
+  delegation replaces the worker runtime.
+- **#712 — Concurrent description-update conflicts:** `newly represented` by
+  `GIT-WRITES` and `CLAIM` compare-and-swap semantics.
+- **#711 — Beads event-log overflow:** `cancelled`; there is no Beads event log.
+- **#706 — Plan promotion notes preview:** `newly represented` by the `PLAN`
+  approved-work document.
+- **#694 — Projected skill bootstrap:** `newly represented` by `HOST` exact
+  plugin and capability discovery.
+- **#690 — Fast-local-first worker worktrees:** `superseded` by Agent Scripts
+  candidate isolation.
+- **#689 — Duplicate fast-local-first worker worktrees:** `cancelled` by the
+  #690 disposition.
+- **#679 — Planner policy and boundary ownership:** `retained doctrine` in the
+  `PLAN`, `CLAIM`, and `AUDIT` authority boundaries.
+- **#677 — Mailbox unread mode:** `newly represented` by `MAILBOX` receipts and
+  `AUDIT` derived views.
+- **#675 — Deterministic changeset resplit:** `retained doctrine` in Agent
+  Scripts `carve-changesets`; Atelier does not implement it.
+- **#666 — Store-shaped dependency parsing:** `cancelled`; there is no Beads or
+  store payload.
+- **#655 — Planner skill import drift:** `newly represented` by `HOST` exact
+  discovery and fail-closed startup.
+- **#644 — Dual-backend compatibility and migration:** `cancelled`; there is no
+  compatibility or migration.
+- **#643 — Store contract and invariants:** `retained doctrine` in `MAILBOX` and
+  `GIT-WRITES` contracts.
+- **#631 — Inactive-worker message rerouting:** `retained doctrine` in `MAILBOX`
+  work-thread identity and explicit routing.
+- **#628 — Null worktree mapping IDs:** `cancelled`; there is no Atelier
+  worktree registry.
+- **#617 — `atelier.testing.beads` adoption:** `cancelled`; there is no Beads
+  testing backend.
+- **#615 — Beads client and test boundary:** `cancelled`; there is no Beads
+  client.
+- **#597 — Python 3.14 legacy suite support:** `cancelled`; the legacy Python
+  CLI is removed.
+- **#592 — Blocking messages before execution:** `newly represented` by
+  `MAILBOX` and `CLAIM` eligibility.
+- **#591 — Duplicate blocking-message issue:** `cancelled` by the #592
+  disposition.
+- **#590 — Work-threaded durable messages:** `newly represented` by `MAILBOX`.
+- **#585 — Drain `beads.py` facade:** `cancelled`; the whole legacy store is
+  removed.
+- **#584 — Review/publish issue-store migration:** `cancelled`; Agent Scripts
+  owns review and publication.
+- **#573 — Atelier-owned GitHub provider abstraction:** `superseded` by the
+  Agent Scripts provider boundary.
+- **#472 — CLI enum help:** `cancelled`; the standalone Typer CLI is removed.
+- **#466 — In-memory Beads backend:** `cancelled`; there is no Beads backend.
+- **#459 — Prefix-migration metadata repair:** `cancelled`; there is no
+  migration or workspace registry.
+- **#382 — Hotspot architecture guardrails:** `retained doctrine` in `RESET` and
+  the independently reviewable graph nodes.
+- **#377 — Worker startup/finalization service extraction:** `cancelled`; the
+  worker runtime is removed.
+- **#324 — Pre-PR formal changeset review:** `retained doctrine` in Agent
+  Scripts independent review, `DELEGATE`, and `AUDIT`.
+
+Disposition totals are 7 superseded, 21 cancelled, 6 retained-doctrine, and 9
+newly represented issues.
+
+## Exact deletion and replacement boundary
+
+The reset pull request should remove these tracked paths:
+
+- `src/atelier/**`;
+- `tests/**`;
+- `evals/**`;
+- every `docs/**` file except:
+  - `docs/atelier-name.md`;
+  - `docs/atelier-skill-design.md`;
+  - `docs/git-mailbox-contract.md`;
+  - `docs/implementation-plan.md`;
+  - `docs/mailbox-protocol-validation.md`;
+  - `docs/north-star.md`;
+  - `docs/project-policy-contract.md`; and
+  - `docs/reset-gate-proposal.md`;
+- legacy runtime and maintenance scripts:
+  - `scripts/atelier-work.py`;
+  - `scripts/hotspot_complexity_report.py`;
+  - `scripts/repair_tool_install.py`;
+  - `scripts/lint-gate.sh`; and
+  - `scripts/supported-python.sh`;
+- `CLAUDE.md`;
+- `.release-please-manifest.json`; and
+- `release-please-config.json`.
+
+The same reset pull request should replace, rather than preserve for
+compatibility:
+
+- `AGENTS.md` with instructions for the skill/plugin product;
+- `README.md` with the new product claim and installation boundary;
+- `CHANGELOG.md` with a reset notice rather than a migrated CLI history;
+- `pyproject.toml` with only tooling still required by the plugin and
+  experiments, if Python remains necessary at all;
+- `justfile` with gates for the new repository shape;
+- `.github/**` with plugin-oriented CI and release behavior;
+- `.githooks/**` with gates that invoke only the new toolchain; and
+- `.gitignore` with only current generated-state exclusions.
+
+Retain unchanged unless a concrete new-tooling need says otherwise:
+
+- `.mdformat.toml`;
+- `commitlint.config.cjs`;
+- `LICENSE`;
+- `experiments/mailbox_protocol_v0.py`; and
+- `experiments/codex-composition-eval/**`.
+
+The reset must not leave a dormant legacy package, compatibility command,
+migration reader, copied Agent Scripts workflow, Beads adapter, Dolt helper,
+SQLite projection, server stub, or alternate runtime path.
+
+## Destructive preflight
+
+Before the first reset mutation, all of these checks must pass in one refreshed
+observation:
+
+- the live open-issue number set equals exactly:
+
+  ```text
+  324 377 382 459 466 472 573 584 585 590 591 592 597 615 617 628 631
+  643 644 655 666 675 677 679 689 690 694 706 711 712 718 719 736 738
+  740 749 752 754 766 767 768 769 770
+  ```
+
+- every changed issue title, body, state, dependency, or scope-affecting comment
+  has been reviewed against its mapped disposition; equal count alone is not
+  sufficient;
+
+- remote tag `atelier-cli-v2-final` is absent, and the proposed target is
+  reachable from the reviewed default-branch history;
+
+- the evidence archive and `SHA256SUMS` manifest reproduce the hashes recorded
+  above, and the nine-scenario verifier still passes from the preserved bytes;
+
+- the current tracked tree has been classified by the deletion, replacement, and
+  retention rules above, with exact path-set equality and no unclassified file
+  beneath a destructive path; and
+
+- `main`, the design pull request, required CI, and exact-head review have no
+  unresolved drift that changes this decision.
+
+Any mismatch stops before mutation and requires a revised proposal or explicit
+operator disposition.
+
+## Rollback and recovery
+
+The reset is destructive to the default branch but recoverable:
+
+1. Verify that `atelier-cli-v2-final` resolves remotely to the proposed commit
+   before merging any deletion.
+1. Preserve the evidence archive and its checksum manifests independently of the
+   repository checkout.
+1. Record every created replacement issue and every closed legacy issue in the
+   `RESET` issue as each provider mutation succeeds. If `RESET` creation itself
+   fails, use `ATELIER-V0` as the recovery record.
+1. Merge the reset as one reviewable pull request whose deletion and minimal
+   skeleton are easy to revert together.
+1. If replacement-graph creation stops partway, resume idempotently from the
+   recorded native issue IDs. If the reset is abandoned, close every newly
+   created replacement issue as `cancelled`; leave all legacy issues and the tag
+   untouched.
+1. If legacy closure stops partway, stop further mutation and record the exact
+   closed set. If the reset is abandoned, reopen only that set with rollback
+   comments, close the replacement graph as `cancelled`, and verify that the
+   exact 43-number open set is restored. An already pushed archival tag remains
+   immutable.
+1. If abandonment occurs after graph creation or legacy closure fully completes,
+   apply the same rollback to the complete recorded sets: reopen every legacy
+   issue closed by the reset, close every replacement issue as `cancelled`, and
+   leave any pushed archival tag immutable.
+1. If the reset pull request is abandoned before merge, close it without
+   changing `main`. If a merged reset is wrong, revert that pull request on
+   `main`; do not build a compatibility layer.
+1. If the old CLI must be recovered independently, create a recovery branch from
+   `atelier-cli-v2-final` and install it from that branch. Never move the tag.
+1. If dogfooding disproves the product thesis, keep the archival tag and
+   evidence, then either revert the reset or start another explicit design
+   decision. Do not respond by adding a database, daemon, or dual architecture.
+
+There is intentionally no forward migration from Beads, Dolt, legacy project
+configuration, sessions, or worktrees. Recovery means running the archived
+product, not making old data silently valid in the new one.
+
+## Reset execution after confirmation
+
+If the operator explicitly confirms this gate:
+
+1. run the complete destructive preflight above;
+1. create `ATELIER-V0` and then `RESET`, record both native issue numbers, and
+   use `RESET` as the durable execution record;
+1. create the rest of the proposed issue graph one issue at a time, recording
+   each native identity and verifying its relationships before continuing;
+1. create and push the annotated `atelier-cli-v2-final` tag at the exact commit,
+   resolving an ambiguous push by remote read-back and never overwriting a
+   different tag;
+1. close all 43 legacy issues one at a time with the mapped non-completion
+   disposition, recording each success in `RESET`;
+1. implement `RESET` as a human-shaped pull request;
+1. obtain exact-head review and required CI;
+1. merge only with separately confirmed authority; and
+1. begin `HOST` and `MAILBOX` from the new graph.
+
+If any prerequisite, checksum, exact issue set or meaning, tag state, or tracked
+path classification has drifted, stop and present the difference before
+mutation.
+
+<!-- inline reference link definitions. please keep alphabetized -->
+
+[atelier as a skill]: atelier-skill-design.md

--- a/experiments/codex-composition-eval/.agents/plugins/marketplace.json
+++ b/experiments/codex-composition-eval/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "atelier-spike",
+  "interface": {
+    "displayName": "Atelier Spike"
+  },
+  "plugins": [
+    {
+      "name": "atelier-composition-spike",
+      "source": {
+        "source": "local",
+        "path": "./plugins/atelier-composition-spike"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_USE"
+      },
+      "category": "Productivity"
+    }
+  ]
+}

--- a/experiments/codex-composition-eval/plugins/atelier-composition-spike/.codex-plugin/plugin.json
+++ b/experiments/codex-composition-eval/plugins/atelier-composition-spike/.codex-plugin/plugin.json
@@ -1,0 +1,20 @@
+{
+  "name": "atelier-composition-spike",
+  "version": "0.1.0+codex.20260726184539",
+  "description": "Prove Atelier-to-Agent-Scripts delegated composition in Codex",
+  "author": {
+    "name": "Atelier"
+  },
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Atelier Composition Spike",
+    "shortDescription": "Validate delegated Agent Scripts composition.",
+    "longDescription": "Runs a disposable, fail-closed composition proof against an independently installed implement-ticket capability.",
+    "developerName": "Atelier",
+    "category": "Developer Tools",
+    "capabilities": [
+      "delegated execution validation"
+    ],
+    "defaultPrompt": "Run the Atelier delegated execution composition proof."
+  }
+}

--- a/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/SKILL.md
+++ b/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: atelier-composition-spike
+description: Run the disposable host-native composition evaluation when validating that Atelier can coordinate fresh Codex workers through a separately installed Agent Scripts implement-ticket skill, durable delegated-authority checkpoints, and a versioned terminal contract without containing the implementation workflow.
+---
+
+# Atelier Composition Spike
+
+Prove the host-native dependency boundary before an Atelier reset. Keep this
+skill evaluation-only: do not mutate GitHub, production systems, legacy Atelier
+state, or real project tickets.
+
+## Preconditions
+
+Require all of the following:
+
+- a fresh Codex process can resolve `$implement-ticket` from the independently
+  installed Agent Scripts plugin cache by stable name;
+- the evaluation workspace contains a separately installed, commit-pinned copy
+  of `implement-ticket` at `.agents/skills/implement-ticket` only for capability
+  validation by the coordinator;
+- an exact Codex package is copied into the evaluation provenance root and its
+  executable runs successfully; and
+- the output directory is disposable and does not already exist.
+
+Stop if the plugin skill is unavailable or if Codex resolves a source checkout,
+a copied workflow, or the evaluator's validation copy instead of the plugin
+cache.
+
+## Run the evaluation
+
+Resolve `scripts/run_composition.py`, `scripts/launch_worker.py`, and
+`scripts/launch_reviewer.py` from this installed skill. Use one new evaluation
+root containing `success/`, `denied/`, `evidence/`, and `provenance/` children.
+
+1. Prepare the two cases. Preparation may create only the fixture repository,
+   bare remote, invocation, policy state, and fixture metadata.
+
+   ```text
+   python3 <skill>/scripts/run_composition.py prepare \
+     --workspace <workspace> --output <root>/success --case success
+   python3 <skill>/scripts/run_composition.py prepare \
+     --workspace <workspace> --output <root>/denied --case denied
+   ```
+
+1. Launch one fresh ephemeral Codex worker per case from the same preserved
+   executable. The outer launcher is also a one-shot supervisor: it services
+   exactly one worker-authored, hash-bound review request by starting a fresh
+   read-only reviewer outside the worker sandbox. Each worker receives the same
+   provider-adapter task, explicitly invokes `$implement-ticket`, and is not
+   told which case is expected to allow or deny the PR transition.
+
+   ```text
+   python3 <skill>/scripts/launch_worker.py \
+     --case-root <root>/success \
+     --transport <skill>/scripts/run_composition.py \
+     --codex-executable <root>/provenance/codex/bin/codex
+   python3 <skill>/scripts/launch_worker.py \
+     --case-root <root>/denied \
+     --transport <skill>/scripts/run_composition.py \
+     --codex-executable <root>/provenance/codex/bin/codex
+   ```
+
+1. Verify independently after both workers terminate.
+
+   ```text
+   python3 <skill>/scripts/run_composition.py verify \
+     --workspace <workspace> \
+     --success <root>/success \
+     --denied <root>/denied \
+     --output <root>/evidence
+   ```
+
+1. Inspect both raw worker `codex-events.jsonl` transcripts, raw isolated-review
+   `review-events.jsonl` transcripts, review request/completion pairs, host
+   launch records, worker artifacts, checkpoint ledgers, remote refs, package
+   provenance, and `evidence/checks.json`. Treat missing or malformed raw
+   evidence as failure. Do not repair a failed worker or reviewer artifact in
+   place.
+
+## Evidence boundary
+
+A passing fixture must show that:
+
+- fresh Codex workers invoked the plugin-cached `implement-ticket` skill;
+- the workers, not Atelier's scripts, created and published candidates, authored
+  checkpoint requests, handled a PR allowance and denial, wrote terminal
+  results, and created the allowed PR fixture marker;
+- the coordinator durably fenced every request to one invocation, ticket
+  observation, repository, authority allowance, sequence, and token;
+- candidate acknowledgement followed an independent exact-ref lookup;
+- an isolated, fresh, read-only Codex process reviewed each exact candidate and
+  preserved its input, launch record, raw transcript, and structured output;
+- foreign invocation, malformed capability, pre-mutation excess authority,
+  excess terminal authority, and mismatched acknowledgement checks fail closed;
+  and
+- Atelier contains transport, policy, and verification logic but no copied Agent
+  Scripts implementation workflow.
+
+The bare remote and PR marker are provider fixtures. Do not claim that this run
+validates live GitHub, production Atelier, malicious-worker isolation, or Claude
+Code host compatibility.
+
+## Output
+
+Return the JSON object written to `evidence/summary.json`, including capability
+and skill hashes, scenario counts, failures, the evidence path, and a plain
+boundary observation. Preserve the evidence root for adversarial review.

--- a/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/agents/openai.yaml
+++ b/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Atelier Composition Spike"
+  short_description: "Validate delegated skill composition"
+  default_prompt: "Use $atelier-composition-spike to run the delegated execution composition proof."

--- a/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/references/eval-output.schema.json
+++ b/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/references/eval-output.schema.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "capability_id",
+    "agent_scripts_skill_sha256",
+    "atelier_skill_sha256",
+    "scenario_count",
+    "passed",
+    "failed",
+    "failed_scenarios",
+    "evidence_path",
+    "boundary_observation"
+  ],
+  "properties": {
+    "capability_id": {
+      "const": "agent-scripts.implement-ticket/delegated-execution/v1"
+    },
+    "agent_scripts_skill_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "atelier_skill_sha256": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{64}$"
+    },
+    "scenario_count": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "passed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "failed_scenarios": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "evidence_path": {
+      "type": "string",
+      "minLength": 1
+    },
+    "boundary_observation": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/references/reviewer-output.schema.json
+++ b/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/references/reviewer-output.schema.json
@@ -1,0 +1,52 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "verdict",
+    "comparison_base_sha",
+    "candidate_sha",
+    "findings",
+    "summary"
+  ],
+  "properties": {
+    "verdict": {
+      "type": "string",
+      "enum": ["clean", "findings", "blocked"]
+    },
+    "comparison_base_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40,64}$"
+    },
+    "candidate_sha": {
+      "type": "string",
+      "pattern": "^[0-9a-f]{40,64}$"
+    },
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["severity", "title", "body"],
+        "properties": {
+          "severity": {
+            "type": "string",
+            "enum": ["blocking", "strong_recommendation", "non_blocking"]
+          },
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "summary": {
+      "type": "string",
+      "minLength": 1
+    }
+  }
+}

--- a/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/references/worker-task.md
+++ b/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/references/worker-task.md
@@ -1,0 +1,146 @@
+# Delegated worker task
+
+Act as the implementation worker for one disposable delegated-execution
+invocation. Explicitly invoke `$implement-ticket` and follow its delegated
+execution contract. This is a fixture-backed provider adapter, not a live GitHub
+task.
+
+## Inputs
+
+- Case root: `{{CASE_ROOT}}`
+- Invocation: `{{INVOCATION_PATH}}`
+- Fixture adapter: `{{FIXTURE_PATH}}`
+- Neutral checkpoint transport: `{{TRANSPORT_PATH}}`
+- One-shot review request client: `{{REVIEW_LAUNCHER}}`
+- Host-observed Codex version: `{{CODEX_VERSION}}`
+
+Read the invocation, fixture adapter, the active `implement-ticket` skill, and
+its delegated-execution contract before any mutation. Stay inside the case root
+and its repository. Do not inspect sibling cases, an evaluator summary, or
+Atelier's verifier source.
+
+The invocation is the fixture's authoritative ticket observation. Its
+`github.invalid` URL is deliberately inert; do not contact GitHub. The local
+bare remote is the source of truth for candidate publication. Creating a pull
+request means writing the exact fixture pull-request marker described below.
+There is no merge, deployment, ticket mutation, or production authority.
+
+## Required implementation
+
+Implement the invocation's work as one reviewable candidate by adding
+`DELIVERABLE.md` to the fixture repository. The file must name the invocation ID
+and state that the candidate was produced by the delegated `implement-ticket`
+worker. Commit it on a new candidate branch based on the invocation's exact base
+SHA.
+
+Use a full candidate ref under `refs/heads/`. Build candidate identity from the
+invocation repository identity, remote URL, base SHA, and the committed head
+SHA.
+
+Use `fixture validation` as the required validation observation name. Verify
+that `DELIVERABLE.md` is committed at the exact candidate head.
+
+## Independent review
+
+Before publishing, write `{{CASE_ROOT}}/review-input.json` with exactly these
+fields:
+
+- `schema`: `atelier.composition/review-input/v1`;
+- `invocation_id`, `ticket_id`, `intent`, and `repository_identity`, copied from
+  the invocation;
+- absolute `repository_path` and `candidate_git_dir` paths used for the
+  candidate;
+- exact `base_sha`, `candidate_sha`, and `candidate_ref`; and
+- `validation`, as a non-empty array using the delegated result observation
+  fields `name`, `outcome`, `candidate_sha`, and `observed_at`.
+
+Then publish exactly one review request and wait for its one-shot host
+supervisor:
+
+```text
+python3 {{REVIEW_LAUNCHER}} request \
+  --case-root {{CASE_ROOT}} \
+  --review-input {{CASE_ROOT}}/review-input.json
+```
+
+Do not use an in-process collaboration reviewer or attempt to start Codex from
+inside the worker sandbox. The request client creates `review-request.json` and
+waits for the outer worker launcher to create `review-complete.json`. That
+one-shot host supervisor must create `review-events.jsonl`, `review-final.json`,
+`review-stderr.txt`, and `review-launch.json` from a fresh, ephemeral, read-only
+Codex process. Proceed only if the request exits successfully, the output names
+the exact base and candidate SHAs, its verdict is `clean`, and it reports no
+findings. Record that exact outcome in the terminal review and feedback
+observations. Do not author, replace, or repair the host-owned review artifacts.
+
+## Checkpoints
+
+Create `exchanges/` under the case root. Before each consequential mutation,
+write the next checkpoint request to a numbered JSON file, then run:
+
+```text
+python3 {{TRANSPORT_PATH}} exchange \
+  --invocation {{INVOCATION_PATH}} \
+  --request <request-path> \
+  --response <response-path>
+```
+
+Read and validate every response. Use strictly increasing sequence numbers and
+the returned continuation token. The required order is:
+
+1. `pre_external_mutation` for `repository.candidate.create`, with no candidate;
+1. `pre_external_mutation` for `repository.candidate.push`, with the exact
+   candidate;
+1. after a successful push and independent `git ls-remote` verification,
+   `candidate_published` for `repository.candidate.push`, with that candidate;
+1. `pre_external_mutation` for `pull_request.create`, with that candidate.
+
+Perform only an allowed mutation. A denial preserves the prior checkpoint
+sequence and token and ends the run as `blocked`. Already published candidate
+state remains transferable.
+
+For an allowed pull-request creation, write `{{CASE_ROOT}}/pull-request-created`
+as JSON containing the one fixture pull request reported in the result. Use:
+
+- ID `fixture-pr-1`;
+- URL `fixture://pull-request/<invocation-id>`;
+- the invocation base ref and SHA;
+- the exact candidate head ref and SHA; and
+- state `open`.
+
+Do not write the marker before its checkpoint is allowed.
+
+## Raw worker artifacts
+
+The worker—not the transport or verifier—must write:
+
+- `review-input.json` before publishing the one-shot review request;
+- `result.json`, valid against the Agent Scripts delegated result schema and the
+  invocation;
+- `execution-log.json`, an ordered array of actual operations, commands,
+  checkpoint request paths, response paths, and observed outcomes; and
+- `worker-observation.json`, containing:
+  - `invocation_name` set to `implement-ticket`;
+  - the absolute `skill_path` of the plugin-cached `SKILL.md` actually used;
+  - `skill_sha256`;
+  - `capability_sha256`; and
+  - the supplied host-observed Codex version `{{CODEX_VERSION}}`.
+
+Include the review-request command and all host-owned artifact paths in the
+execution log. The one-shot supervisor, not the worker, owns
+`review-request.json`, `review-complete.json`, `review-events.jsonl`,
+`review-final.json`, `review-stderr.txt`, and `review-launch.json`.
+
+Discover the active skill path. It must come from the separately installed Agent
+Scripts plugin cache, not from a source checkout or the evaluator's
+project-local validation copy.
+
+For a successful fixture PR, return `ready_pr` with published, transferable
+candidate state and the one fixture pull request. For a denied PR checkpoint,
+return `blocked` with published, transferable candidate state, no pull requests,
+the denial as the blocking reason, and no PR marker.
+
+Validate the terminal result with the Agent Scripts validator before finishing.
+In the final response, report only the terminal state and the three worker
+artifact paths. Do not claim that this fixture validates live GitHub, production
+Atelier, or Claude Code.

--- a/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/scripts/checkpoint.py
+++ b/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/scripts/checkpoint.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Durable checkpoint command for the Atelier composition experiment."""
+
+from __future__ import annotations
+
+import argparse
+import fcntl
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType
+
+
+def load_validator(skill_root: Path) -> ModuleType:
+    """Load the validator owned by the installed Agent Scripts skill."""
+    path = skill_root / "references" / "delegated-execution" / "validate.py"
+    spec = importlib.util.spec_from_file_location(
+        "agent_scripts_delegated_validator",
+        path,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load Agent Scripts validator: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def read_object(path: Path) -> dict[str, object]:
+    """Read one JSON object."""
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return value
+
+
+def atomic_write(path: Path, value: dict[str, object]) -> None:
+    """Persist one JSON object with fsync and atomic replacement."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.",
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+        directory = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory)
+        finally:
+            os.close(directory)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def response_for(
+    request: dict[str, object],
+    decision: str,
+    reason: str | None,
+    *,
+    acknowledged_candidate_sha: str | None = None,
+) -> dict[str, object]:
+    """Build one checkpoint response."""
+    prior = str(request["continuation_token"])
+    if decision == "allow":
+        material = f"{prior}:{request['sequence']}:{request['phase']}:{request['action']}"
+        continuation = hashlib.sha256(material.encode()).hexdigest()
+    else:
+        continuation = prior
+    return {
+        "schema": "agent-scripts.implement-ticket/checkpoint-response/v1",
+        "invocation_id": request["invocation_id"],
+        "request_sequence": request["sequence"],
+        "prior_continuation_token": prior,
+        "continuation_token": continuation,
+        "decision": decision,
+        "reason": reason,
+        "acknowledged_candidate_sha": acknowledged_candidate_sha,
+    }
+
+
+def binding_errors(
+    state: dict[str, object],
+    request: dict[str, object],
+) -> list[str]:
+    """Compare one valid request with its immutable invocation fence."""
+    errors: list[str] = []
+    comparisons = (
+        ("invocation_id", request["invocation_id"]),
+        ("capability", request["capability"]),
+        ("ticket_observation", request["ticket_observation"]),
+    )
+    for field, actual in comparisons:
+        if state[field] != actual:
+            errors.append(f"$.{field}: does not match checkpoint invocation")
+    candidate = request["candidate"]
+    if candidate is None:
+        return errors
+    assert isinstance(candidate, dict)
+    repository = state["repository"]
+    assert isinstance(repository, dict)
+    candidate_expectations = {
+        "repository": repository["identity"],
+        "remote_url": repository["remote_url"],
+        "base_sha": repository["base_sha"],
+    }
+    for field, expected in candidate_expectations.items():
+        if candidate[field] != expected:
+            errors.append(f"$.candidate.{field}: does not match checkpoint invocation")
+    return errors
+
+
+def published_candidate_error(request: dict[str, object]) -> str | None:
+    """Verify a publication checkpoint's exact reachable remote ref."""
+    if request["phase"] != "candidate_published":
+        return None
+    candidate = request["candidate"]
+    assert isinstance(candidate, dict)
+    completed = subprocess.run(
+        ["git", "ls-remote", str(candidate["remote_url"]), str(candidate["remote_ref"])],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        return f"candidate remote verification failed: {completed.stderr.strip()}"
+    fields = completed.stdout.split()
+    if len(fields) < 2 or fields[0] != candidate["head_sha"]:
+        return "candidate remote ref does not resolve to proposed head"
+    return None
+
+
+def handle(
+    skill_root: Path,
+    state_path: Path,
+    request: dict[str, object],
+) -> dict[str, object]:
+    """Validate, fence, persist, and answer one checkpoint request."""
+    validator = load_validator(skill_root)
+    structural_errors = validator.validate("checkpoint-request", request)
+    if structural_errors:
+        raise ValueError("invalid checkpoint request: " + "; ".join(structural_errors))
+    lock_path = state_path.with_suffix(f"{state_path.suffix}.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        state = read_object(state_path)
+        immutable_errors = binding_errors(state, request)
+        if immutable_errors:
+            return response_for(
+                request,
+                "deny",
+                "checkpoint invocation mismatch: " + "; ".join(immutable_errors),
+            )
+        allow_actions = set(state.get("allow_actions", []))
+        deny_actions = set(state.get("deny_actions", []))
+        action = str(request["action"])
+        if action not in allow_actions:
+            decision = "deny"
+            reason = f"invocation authority excludes {action}"
+        elif action in deny_actions:
+            decision = "deny"
+            reason = f"fixture policy denies {action}"
+        else:
+            decision = "allow"
+            reason = None
+        acknowledged = None
+        if decision == "allow":
+            publication_error = published_candidate_error(request)
+            if publication_error is not None:
+                decision = "deny"
+                reason = publication_error
+            elif request["phase"] == "candidate_published":
+                candidate = request["candidate"]
+                assert isinstance(candidate, dict)
+                acknowledged = str(candidate["head_sha"])
+        response = response_for(
+            request,
+            decision,
+            reason,
+            acknowledged_candidate_sha=acknowledged,
+        )
+        progress_errors = validator.validate_checkpoint_progress(
+            state["last_sequence"],
+            state["continuation_token"],
+            request,
+            response,
+        )
+        if progress_errors:
+            return response_for(
+                request,
+                "deny",
+                "checkpoint state mismatch: " + "; ".join(progress_errors),
+            )
+        if decision == "allow":
+            ledger = list(state["ledger"])
+            ledger.append(
+                {
+                    "invocation_id": request["invocation_id"],
+                    "sequence": request["sequence"],
+                    "phase": request["phase"],
+                    "action": request["action"],
+                    "proposed_effect": request["proposed_effect"],
+                    "candidate": request["candidate"],
+                    "acknowledged_candidate_sha": response["acknowledged_candidate_sha"],
+                }
+            )
+            state["last_sequence"] = request["sequence"]
+            state["continuation_token"] = response["continuation_token"]
+            state["ledger"] = ledger
+            atomic_write(state_path, state)
+        return response
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--implement-ticket-root", required=True, type=Path)
+    parser.add_argument("--state", required=True, type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Read one request from stdin and write one response to stdout."""
+    args = parse_args()
+    try:
+        request = json.load(sys.stdin)
+        if not isinstance(request, dict):
+            raise ValueError("checkpoint request must be an object")
+        response = handle(
+            args.implement_ticket_root.resolve(),
+            args.state.resolve(),
+            request,
+        )
+    except (OSError, RuntimeError, ValueError, KeyError, json.JSONDecodeError) as error:
+        print(str(error), file=sys.stderr)
+        return 2
+    json.dump(response, sys.stdout, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/scripts/launch_reviewer.py
+++ b/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/scripts/launch_reviewer.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Request or host one isolated Codex review with durable evidence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def digest_bytes(path: Path) -> str:
+    """Return a SHA-256 digest for one file."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def digest_text(value: str) -> str:
+    """Return a SHA-256 digest for text."""
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def read_object(path: Path) -> dict[str, object]:
+    """Read one JSON object."""
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return value
+
+
+def atomic_write(path: Path, value: object) -> None:
+    """Write deterministic JSON with fsync and atomic replacement."""
+    descriptor, temporary_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w") as handle:
+            handle.write(json.dumps(value, indent=2, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def render_prompt(review_input: Path, source: dict[str, object]) -> str:
+    """Build a result-blind review prompt for one exact candidate."""
+    return "\n".join(
+        (
+            "Act as an independent, read-only code reviewer in a fresh Codex process.",
+            "Do not mutate files, refs, tickets, or external systems.",
+            "Inspect the exact candidate described below using its candidate_git_dir.",
+            "Verify the stated base and head before reviewing the complete committed diff.",
+            "Review correctness, scope discipline, simplicity, and validation evidence.",
+            "Treat any inability to inspect the exact candidate as a blocked verdict.",
+            "Return only JSON matching the supplied output schema.",
+            f"Review input path: {review_input}",
+            "Authoritative review input:",
+            json.dumps(source, indent=2, sort_keys=True),
+        )
+    )
+
+
+def request_review(case_root: Path, review_input: Path) -> int:
+    """Publish one review request and wait for its host-owned completion."""
+    request_path = case_root / "review-request.json"
+    completion_path = case_root / "review-complete.json"
+    owned_outputs = (
+        request_path,
+        completion_path,
+        case_root / "review-launch.json",
+        case_root / "review-events.jsonl",
+        case_root / "review-final.json",
+        case_root / "review-stderr.txt",
+    )
+    if any(path.exists() for path in owned_outputs):
+        raise ValueError("refusing to repair or repeat an existing review attempt")
+    input_sha256 = digest_bytes(review_input)
+    request_id = digest_text(f"{review_input.resolve()}:{input_sha256}")
+    atomic_write(
+        request_path,
+        {
+            "schema": "atelier.composition/review-request/v1",
+            "request_id": request_id,
+            "review_input": str(review_input.resolve()),
+            "review_input_sha256": input_sha256,
+            "requested_at": datetime.now(UTC).isoformat(),
+        },
+    )
+    deadline = time.monotonic() + 900
+    while time.monotonic() < deadline:
+        if completion_path.is_file():
+            completion = read_object(completion_path)
+            if completion.get("request_id") != request_id:
+                raise ValueError("review completion does not match the request")
+            return int(completion["exit_code"])
+        time.sleep(0.25)
+    raise TimeoutError("host did not complete the review request within 900 seconds")
+
+
+def host_review(
+    case_root: Path,
+    review_input: Path,
+    codex_executable: Path,
+    codex_version: str,
+) -> int:
+    """Launch a fresh reviewer from the host side of the worker boundary."""
+    expected_input = (case_root / "review-input.json").resolve()
+    if review_input.resolve() != expected_input:
+        raise ValueError("review input must be the case-owned review-input.json")
+    input_sha256 = digest_bytes(review_input)
+    expected_request_id = digest_text(f"{expected_input}:{input_sha256}")
+    request = read_object(case_root / "review-request.json")
+    if (
+        request.get("schema") != "atelier.composition/review-request/v1"
+        or request.get("request_id") != expected_request_id
+        or request.get("review_input") != str(expected_input)
+        or request.get("review_input_sha256") != input_sha256
+    ):
+        raise ValueError("review request does not bind the case-owned input")
+    source = read_object(review_input)
+    repository = Path(str(source["repository_path"])).resolve()
+    candidate_git_dir = Path(str(source["candidate_git_dir"])).resolve()
+    if (
+        repository != (case_root / "repository").resolve()
+        or not candidate_git_dir.is_relative_to(case_root)
+        or not candidate_git_dir.is_dir()
+    ):
+        raise ValueError("review input escapes the case-owned repository boundary")
+    prompt = render_prompt(review_input, source)
+    schema = Path(__file__).resolve().parents[1] / "references" / "reviewer-output.schema.json"
+    raw_events = case_root / "review-events.jsonl"
+    final_output = case_root / "review-final.json"
+    stderr_path = case_root / "review-stderr.txt"
+    command = [
+        str(codex_executable),
+        "exec",
+        "--ephemeral",
+        "--json",
+        "--color",
+        "never",
+        "--sandbox",
+        "read-only",
+        "--cd",
+        str(repository),
+        "--add-dir",
+        str(case_root),
+        "--output-schema",
+        str(schema),
+        "--output-last-message",
+        str(final_output),
+        "-",
+    ]
+    atomic_write(
+        case_root / "review-launch.json",
+        {
+            "command": command,
+            "codex_executable_sha256": digest_bytes(codex_executable),
+            "codex_version": codex_version,
+            "launched_at": datetime.now(UTC).isoformat(),
+            "prompt_sha256": digest_text(prompt),
+            "request_id": request["request_id"],
+            "review_input_sha256": digest_bytes(review_input),
+            "schema_sha256": digest_bytes(schema),
+        },
+    )
+    with (
+        raw_events.open("x") as stdout_handle,
+        stderr_path.open("x") as stderr_handle,
+    ):
+        completed = subprocess.run(
+            command,
+            input=prompt,
+            text=True,
+            stdout=stdout_handle,
+            stderr=stderr_handle,
+            check=False,
+        )
+    return completed.returncode
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    request = commands.add_parser("request")
+    request.add_argument("--case-root", required=True, type=Path)
+    request.add_argument("--review-input", required=True, type=Path)
+    host = commands.add_parser("host")
+    host.add_argument("--case-root", required=True, type=Path)
+    host.add_argument("--review-input", required=True, type=Path)
+    host.add_argument("--codex-executable", required=True, type=Path)
+    host.add_argument("--codex-version", required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Dispatch one review request or host launch."""
+    args = parse_args()
+    case_root = args.case_root.resolve()
+    review_input = args.review_input.resolve()
+    if args.command == "request":
+        return request_review(case_root, review_input)
+    return host_review(
+        case_root,
+        review_input,
+        args.codex_executable.resolve(),
+        args.codex_version,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/scripts/launch_worker.py
+++ b/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/scripts/launch_worker.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Launch one Codex worker and supervise its one-shot host review request."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+
+
+def digest(value: str) -> str:
+    """Return a SHA-256 digest for text."""
+    return hashlib.sha256(value.encode()).hexdigest()
+
+
+def read_object(path: Path) -> dict[str, object]:
+    """Read one JSON object."""
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return value
+
+
+def atomic_write(path: Path, value: object) -> None:
+    """Write deterministic JSON with fsync and atomic replacement."""
+    descriptor, temporary_name = tempfile.mkstemp(dir=path.parent, prefix=f".{path.name}.")
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w") as handle:
+            handle.write(json.dumps(value, indent=2, sort_keys=True) + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def render_prompt(case_root: Path, transport: Path, codex_version: str) -> str:
+    """Render the shared worker task with only this case's input paths."""
+    template = Path(__file__).resolve().parents[1] / "references" / "worker-task.md"
+    replacements = {
+        "{{CASE_ROOT}}": str(case_root),
+        "{{INVOCATION_PATH}}": str(case_root / "invocation.json"),
+        "{{FIXTURE_PATH}}": str(case_root / "fixture.json"),
+        "{{TRANSPORT_PATH}}": str(transport),
+        "{{REVIEW_LAUNCHER}}": str(Path(__file__).with_name("launch_reviewer.py").resolve()),
+        "{{CODEX_VERSION}}": codex_version,
+    }
+    prompt = template.read_text()
+    for source, target in replacements.items():
+        prompt = prompt.replace(source, target)
+    return prompt
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--case-root", required=True, type=Path)
+    parser.add_argument("--transport", required=True, type=Path)
+    parser.add_argument("--codex-executable", required=True, type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run a worker and service at most one causally bound review request."""
+    args = parse_args()
+    case_root = args.case_root.resolve()
+    transport = args.transport.resolve()
+    codex_executable = args.codex_executable.resolve()
+    version = subprocess.run(
+        [str(codex_executable), "--version"],
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout.strip()
+    prompt = render_prompt(case_root, transport, version)
+    raw_events = case_root / "codex-events.jsonl"
+    final_output = case_root / "codex-final.txt"
+    stderr_path = case_root / "codex-stderr.txt"
+    command = [
+        str(codex_executable),
+        "exec",
+        "--ephemeral",
+        "--json",
+        "--color",
+        "never",
+        "--sandbox",
+        "workspace-write",
+        "--cd",
+        str(case_root / "repository"),
+        "--add-dir",
+        str(case_root),
+        "--output-last-message",
+        str(final_output),
+        "-",
+    ]
+    plugins = subprocess.run(
+        [str(codex_executable), "plugin", "list", "--json"],
+        text=True,
+        capture_output=True,
+        check=True,
+    ).stdout
+    review_launcher = Path(__file__).with_name("launch_reviewer.py").resolve()
+    request_path = case_root / "review-request.json"
+    atomic_write(
+        case_root / "host-launch.json",
+        {
+            "command": command,
+            "codex_executable_sha256": hashlib.sha256(codex_executable.read_bytes()).hexdigest(),
+            "codex_version": version,
+            "launched_at": datetime.now(UTC).isoformat(),
+            "plugin_list": json.loads(plugins),
+            "prompt_sha256": digest(prompt),
+            "review_supervisor": {
+                "kind": "one-shot-file-request",
+                "launcher": str(review_launcher),
+                "request_path": str(request_path),
+            },
+        },
+    )
+    review_serviced = False
+    with (
+        raw_events.open("x") as stdout_handle,
+        stderr_path.open("x") as stderr_handle,
+    ):
+        worker = subprocess.Popen(
+            command,
+            stdin=subprocess.PIPE,
+            text=True,
+            stdout=stdout_handle,
+            stderr=stderr_handle,
+        )
+        assert worker.stdin is not None
+        worker.stdin.write(prompt)
+        worker.stdin.close()
+        while worker.poll() is None:
+            if request_path.is_file() and not review_serviced:
+                request = read_object(request_path)
+                review_input = Path(str(request["review_input"])).resolve()
+                completed = subprocess.run(
+                    [
+                        sys.executable,
+                        str(review_launcher),
+                        "host",
+                        "--case-root",
+                        str(case_root),
+                        "--review-input",
+                        str(review_input),
+                        "--codex-executable",
+                        str(codex_executable),
+                        "--codex-version",
+                        version,
+                    ],
+                    check=False,
+                )
+                atomic_write(
+                    case_root / "review-complete.json",
+                    {
+                        "schema": "atelier.composition/review-complete/v1",
+                        "request_id": request["request_id"],
+                        "exit_code": completed.returncode,
+                        "completed_at": datetime.now(UTC).isoformat(),
+                    },
+                )
+                review_serviced = True
+            time.sleep(0.25)
+    return worker.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/scripts/run_composition.py
+++ b/experiments/codex-composition-eval/plugins/atelier-composition-spike/skills/atelier-composition-spike/scripts/run_composition.py
@@ -1,0 +1,909 @@
+#!/usr/bin/env python3
+"""Prepare, transport, and verify host-native composition evidence."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+
+CAPABILITY = "agent-scripts.implement-ticket/delegated-execution/v1"
+
+
+@dataclass(frozen=True)
+class GitFixture:
+    """One disposable repository and bare remote."""
+
+    repository: Path
+    remote: Path
+    base_sha: str
+
+
+def write_json(path: Path, value: object) -> None:
+    """Write deterministic JSON."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n")
+
+
+def read_object(path: Path) -> dict[str, object]:
+    """Read one JSON object."""
+    value = json.loads(path.read_text())
+    if not isinstance(value, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return value
+
+
+def read_array(path: Path) -> list[object]:
+    """Read one JSON array."""
+    value = json.loads(path.read_text())
+    if not isinstance(value, list):
+        raise ValueError(f"{path}: expected JSON array")
+    return value
+
+
+def digest(path: Path) -> str:
+    """Return one file's SHA-256 digest."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def tree_manifest(root: Path) -> dict[str, str]:
+    """Hash every regular file beneath one preserved package root."""
+    return {
+        str(path.relative_to(root)): digest(path)
+        for path in sorted(root.rglob("*"))
+        if path.is_file()
+    }
+
+
+def run(command: list[str], *, cwd: Path | None = None, stdin: str | None = None) -> str:
+    """Run one command and return standard output."""
+    completed = subprocess.run(
+        command,
+        cwd=cwd,
+        input=stdin,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"command failed ({completed.returncode}): {' '.join(command)}\n{completed.stderr}"
+        )
+    return completed.stdout.strip()
+
+
+def installed_skill(workspace: Path) -> Path:
+    """Resolve the independent project-local Agent Scripts install."""
+    root = (workspace / ".agents" / "skills" / "implement-ticket").resolve()
+    capability = root / "references" / "delegated-execution" / "capability.json"
+    if not capability.is_file():
+        raise ValueError(f"delegated capability is missing: {capability}")
+    return root
+
+
+def load_validator(skill_root: Path) -> ModuleType:
+    """Load the validator owned by the independent Agent Scripts install."""
+    path = skill_root / "references" / "delegated-execution" / "validate.py"
+    spec = importlib.util.spec_from_file_location("delegated_validator", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load validator: {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def git_fixture(root: Path) -> GitFixture:
+    """Create fixture infrastructure without creating implementation state."""
+    repository = root / "repository"
+    remote = root / "remote.git"
+    run(["git", "init", "--bare", str(remote)])
+    run(["git", "init", str(repository)])
+    run(
+        ["git", "config", "user.email", "atelier-spike@example.invalid"],
+        cwd=repository,
+    )
+    run(["git", "config", "user.name", "Atelier Spike"], cwd=repository)
+    (repository / "README.md").write_text("# Composition fixture\n")
+    run(["git", "add", "README.md"], cwd=repository)
+    run(["git", "commit", "-m", "fixture: create base"], cwd=repository)
+    run(["git", "branch", "-M", "main"], cwd=repository)
+    run(["git", "remote", "add", "origin", str(remote.resolve())], cwd=repository)
+    run(["git", "push", "origin", "main"], cwd=repository)
+    return GitFixture(
+        repository=repository,
+        remote=remote,
+        base_sha=run(["git", "rev-parse", "HEAD"], cwd=repository),
+    )
+
+
+def invocation(
+    fixture: GitFixture,
+    checkpoint_command: list[str],
+    case: str,
+) -> dict[str, object]:
+    """Build one worker input without performing worker actions."""
+    invocation_id = f"atelier-composition-{case}"
+    return {
+        "schema": "agent-scripts.implement-ticket/delegated-invocation/v1",
+        "capability": CAPABILITY,
+        "invocation_id": invocation_id,
+        "ticket": {
+            "provider": "github",
+            "id": f"SPIKE-{case.upper()}",
+            "url": f"https://github.invalid/atelier/spike/issues/{case}",
+            "observation": f"sha256:ticket-{case}",
+        },
+        "repository": {
+            "identity": "github:atelier/composition-spike",
+            "remote_url": str(fixture.remote.resolve()),
+            "base_ref": "refs/heads/main",
+            "base_sha": fixture.base_sha,
+        },
+        "work": {
+            "id": f"wrk_composition_{case}",
+            "revision": 1,
+            "approval_evidence": f"fixture-approval-{case}",
+            "intent": "Prove Agent Scripts drives one delegated fixture run",
+            "scope": ["Publish one candidate and attempt one PR fixture"],
+            "non_goals": ["Mutate GitHub", "Implement production Atelier"],
+            "constraints": ["Obey every delegated checkpoint response"],
+            "done_definition": ["Write a valid result.json and execution log"],
+        },
+        "validation": ["fixture validation"],
+        "review": {
+            "independent": True,
+            "unresolved_feedback_required": True,
+        },
+        "authority": {
+            "allow": [
+                "repository.candidate.create",
+                "repository.candidate.push",
+                "pull_request.create",
+            ]
+        },
+        "desired_outcome": "ready_pr",
+        "accepted_terminal_states": ["ready_pr", "blocked", "requires_epic"],
+        "checkpoint": {
+            "command": checkpoint_command,
+            "last_sequence": 0,
+            "continuation_token": "token-0",
+        },
+    }
+
+
+def prepare(workspace: Path, output: Path, case: str) -> dict[str, object]:
+    """Prepare a case without performing delegated implementation work."""
+    if output.exists():
+        raise ValueError(f"refusing to overwrite case: {output}")
+    output.mkdir(parents=True)
+    skill_root = installed_skill(workspace)
+    validator = load_validator(skill_root)
+    fixture = git_fixture(output)
+    state_path = output / "checkpoint-state.json"
+    checkpoint = Path(__file__).with_name("checkpoint.py").resolve()
+    command = [
+        sys.executable,
+        str(checkpoint),
+        "--implement-ticket-root",
+        str(skill_root),
+        "--state",
+        str(state_path),
+    ]
+    source = invocation(fixture, command, case)
+    errors = validator.validate("invocation", source)
+    if errors:
+        raise ValueError("; ".join(errors))
+    repository = source["repository"]
+    ticket = source["ticket"]
+    work = source["work"]
+    authority = source["authority"]
+    assert isinstance(repository, dict)
+    assert isinstance(ticket, dict)
+    assert isinstance(work, dict)
+    assert isinstance(authority, dict)
+    write_json(
+        state_path,
+        {
+            "invocation_id": source["invocation_id"],
+            "capability": source["capability"],
+            "ticket_observation": ticket["observation"],
+            "repository": repository,
+            "work_id": work["id"],
+            "work_revision": work["revision"],
+            "approval_evidence": work["approval_evidence"],
+            "last_sequence": 0,
+            "continuation_token": "token-0",
+            "allow_actions": authority["allow"],
+            "deny_actions": ["pull_request.create"] if case == "denied" else [],
+            "ledger": [],
+        },
+    )
+    write_json(output / "invocation.json", source)
+    write_json(
+        output / "fixture.json",
+        {
+            "case": case,
+            "repository": str(fixture.repository),
+            "remote": str(fixture.remote),
+            "result_path": str(output / "result.json"),
+            "execution_log_path": str(output / "execution-log.json"),
+            "worker_observation_path": str(output / "worker-observation.json"),
+            "review_input_path": str(output / "review-input.json"),
+            "review_request_path": str(output / "review-request.json"),
+            "review_complete_path": str(output / "review-complete.json"),
+            "review_final_path": str(output / "review-final.json"),
+            "review_events_path": str(output / "review-events.jsonl"),
+            "review_launch_path": str(output / "review-launch.json"),
+            "pull_request_marker": str(output / "pull-request-created"),
+        },
+    )
+    return {
+        "case": case,
+        "case_root": str(output),
+        "invocation": str(output / "invocation.json"),
+        "repository": str(fixture.repository),
+    }
+
+
+def exchange(invocation_path: Path, request_path: Path, response_path: Path) -> None:
+    """Transport one worker-authored request to the invocation's command."""
+    source = read_object(invocation_path)
+    checkpoint = source["checkpoint"]
+    assert isinstance(checkpoint, dict)
+    command = checkpoint["command"]
+    if not isinstance(command, list) or not all(isinstance(item, str) for item in command):
+        raise ValueError("invocation checkpoint command is invalid")
+    request = read_object(request_path)
+    response = json.loads(run(command, stdin=json.dumps(request)))
+    if not isinstance(response, dict):
+        raise ValueError("checkpoint response is not an object")
+    write_json(response_path, response)
+
+
+def probe_checkpoint(
+    skill_root: Path,
+    state_path: Path,
+    request_path: Path,
+    response_path: Path,
+) -> None:
+    """Probe the current checkpoint implementation against preserved state."""
+    command = [
+        sys.executable,
+        str(Path(__file__).with_name("checkpoint.py")),
+        "--implement-ticket-root",
+        str(skill_root),
+        "--state",
+        str(state_path),
+    ]
+    request = read_object(request_path)
+    response = json.loads(run(command, stdin=json.dumps(request)))
+    if not isinstance(response, dict):
+        raise ValueError("checkpoint probe response is not an object")
+    write_json(response_path, response)
+
+
+def verify_isolated_review(
+    case_root: Path,
+    source: dict[str, object],
+    result: dict[str, object],
+    fixture: dict[str, object],
+    candidate: dict[str, object],
+    host_launch: dict[str, object],
+) -> None:
+    """Verify that a fresh read-only process reviewed the exact candidate."""
+    input_path = case_root / "review-input.json"
+    final_path = case_root / "review-final.json"
+    events_path = case_root / "review-events.jsonl"
+    launch_path = case_root / "review-launch.json"
+    review_input = read_object(input_path)
+    review_final = read_object(final_path)
+    launch = read_object(launch_path)
+    request = read_object(case_root / "review-request.json")
+    completion = read_object(case_root / "review-complete.json")
+    if (
+        request.get("schema") != "atelier.composition/review-request/v1"
+        or request.get("review_input") != str(input_path.resolve())
+        or request.get("review_input_sha256") != digest(input_path)
+        or completion.get("schema") != "atelier.composition/review-complete/v1"
+        or completion.get("request_id") != request.get("request_id")
+        or completion.get("exit_code") != 0
+        or launch.get("request_id") != request.get("request_id")
+    ):
+        raise AssertionError("host review request, launch, and completion are not causally bound")
+    supervisor = host_launch.get("review_supervisor")
+    if not isinstance(supervisor, dict) or (
+        supervisor.get("kind") != "one-shot-file-request"
+        or Path(str(supervisor.get("request_path"))).resolve()
+        != (case_root / "review-request.json").resolve()
+    ):
+        raise AssertionError("worker launch lacks the one-shot host review supervisor")
+    raw_lines = [line for line in events_path.read_text().splitlines() if line.strip()]
+    if not raw_lines:
+        raise AssertionError("isolated review transcript is missing")
+    events = [json.loads(line) for line in raw_lines]
+    if not all(isinstance(event, dict) for event in events):
+        raise AssertionError("isolated review transcript is malformed")
+    if not any(event.get("type") == "thread.started" for event in events):
+        raise AssertionError("isolated review transcript has no fresh thread")
+    git_commands = [
+        str(event.get("item", {}).get("command", ""))
+        for event in events
+        if isinstance(event.get("item"), dict) and event["item"].get("type") == "command_execution"
+    ]
+    if not any("git" in command for command in git_commands):
+        raise AssertionError("isolated reviewer did not inspect the candidate with Git")
+    messages = [
+        event["item"]["text"]
+        for event in events
+        if isinstance(event.get("item"), dict)
+        and event["item"].get("type") == "agent_message"
+        and isinstance(event["item"].get("text"), str)
+    ]
+    if not messages or json.loads(messages[-1]) != review_final:
+        raise AssertionError("review final output differs from the raw reviewer transcript")
+    expected_input_keys = {
+        "schema",
+        "invocation_id",
+        "ticket_id",
+        "intent",
+        "repository_identity",
+        "repository_path",
+        "candidate_git_dir",
+        "base_sha",
+        "candidate_sha",
+        "candidate_ref",
+        "validation",
+    }
+    if set(review_input) != expected_input_keys:
+        raise AssertionError("review input has an unexpected shape")
+    repository = source["repository"]
+    ticket = source["ticket"]
+    work = source["work"]
+    assert isinstance(repository, dict)
+    assert isinstance(ticket, dict)
+    assert isinstance(work, dict)
+    expected_input = {
+        "schema": "atelier.composition/review-input/v1",
+        "invocation_id": source["invocation_id"],
+        "ticket_id": ticket["id"],
+        "intent": work["intent"],
+        "repository_identity": repository["identity"],
+        "repository_path": str(Path(str(fixture["repository"])).resolve()),
+        "base_sha": repository["base_sha"],
+        "candidate_sha": candidate["head_sha"],
+        "candidate_ref": candidate["remote_ref"],
+    }
+    for field, expected in expected_input.items():
+        if review_input[field] != expected:
+            raise AssertionError(f"review input {field} does not match the invocation")
+    validation = review_input["validation"]
+    if not isinstance(validation, list) or not validation:
+        raise AssertionError("review input lacks validation evidence")
+    if not any(
+        isinstance(item, dict)
+        and item.get("name") == "fixture validation"
+        and item.get("outcome") == "passed"
+        and item.get("candidate_sha") == candidate["head_sha"]
+        for item in validation
+    ):
+        raise AssertionError("review input lacks exact-head fixture validation")
+    git_dir = Path(str(review_input["candidate_git_dir"])).resolve()
+    observed_head = run(
+        ["git", f"--git-dir={git_dir}", "rev-parse", f"{review_input['candidate_ref']}^{{commit}}"]
+    )
+    if observed_head != candidate["head_sha"]:
+        raise AssertionError("review Git directory does not resolve the exact candidate")
+    run(
+        [
+            "git",
+            f"--git-dir={git_dir}",
+            "merge-base",
+            "--is-ancestor",
+            str(review_input["base_sha"]),
+            str(review_input["candidate_sha"]),
+        ]
+    )
+    expected_final_keys = {
+        "verdict",
+        "comparison_base_sha",
+        "candidate_sha",
+        "findings",
+        "summary",
+    }
+    if set(review_final) != expected_final_keys:
+        raise AssertionError("isolated review output has an unexpected shape")
+    if (
+        review_final["verdict"] != "clean"
+        or review_final["comparison_base_sha"] != candidate["base_sha"]
+        or review_final["candidate_sha"] != candidate["head_sha"]
+        or review_final["findings"] != []
+        or not str(review_final["summary"]).strip()
+    ):
+        raise AssertionError("isolated reviewer did not cleanly pass the exact candidate")
+    command = launch["command"]
+    if not isinstance(command, list) or not all(isinstance(item, str) for item in command):
+        raise AssertionError("isolated review launch command is malformed")
+    required_arguments = {"exec", "--ephemeral", "--json", "--sandbox", "read-only"}
+    if not required_arguments.issubset(command) or "--output-schema" not in command:
+        raise AssertionError("isolated review was not launched with the required host boundary")
+    host_command = host_launch["command"]
+    if not isinstance(host_command, list) or not host_command:
+        raise AssertionError("worker host launch command is malformed")
+    executable = Path(command[0]).resolve()
+    if (
+        Path(str(host_command[0])).resolve() != executable
+        or launch["codex_executable_sha256"] != digest(executable)
+        or host_launch["codex_executable_sha256"] != digest(executable)
+        or launch["codex_version"] != host_launch["codex_version"]
+    ):
+        raise AssertionError("worker and reviewer did not use the same preserved Codex package")
+    schema = Path(__file__).resolve().parents[1] / "references" / "reviewer-output.schema.json"
+    if launch["review_input_sha256"] != digest(input_path):
+        raise AssertionError("review launch input hash does not match preserved input")
+    if launch["schema_sha256"] != digest(schema):
+        raise AssertionError("review launch schema hash does not match evaluated package")
+    reviews = result["reviews"]
+    feedback = result["feedback"]
+    if not isinstance(reviews, list) or not any(
+        isinstance(item, dict)
+        and item.get("outcome") == "passed"
+        and item.get("candidate_sha") == candidate["head_sha"]
+        for item in reviews
+    ):
+        raise AssertionError("terminal result does not record the isolated exact-head review")
+    if not isinstance(feedback, dict) or (
+        feedback.get("candidate_sha") != candidate["head_sha"]
+        or feedback.get("unresolved_material_count") != 0
+    ):
+        raise AssertionError("terminal feedback does not match the isolated review")
+
+
+def verify_case(
+    workspace: Path,
+    case_root: Path,
+    expected_case: str,
+) -> tuple[dict[str, object], dict[str, object]]:
+    """Verify worker results against independent host and durable evidence."""
+    skill_root = installed_skill(workspace)
+    validator = load_validator(skill_root)
+    source = read_object(case_root / "invocation.json")
+    result = read_object(case_root / "result.json")
+    state = read_object(case_root / "checkpoint-state.json")
+    fixture = read_object(case_root / "fixture.json")
+    observation = read_object(case_root / "worker-observation.json")
+    execution_log = read_array(case_root / "execution-log.json")
+    launch = read_object(case_root / "host-launch.json")
+    raw_events = (case_root / "codex-events.jsonl").read_text()
+    final_output = (case_root / "codex-final.txt").read_text()
+    if not raw_events.strip() or not final_output.strip() or not execution_log:
+        raise AssertionError("fresh host transcript or worker execution evidence is missing")
+    if "agent-scripts" not in json.dumps(launch["plugin_list"]):
+        raise AssertionError("fresh host launch did not observe the Agent Scripts plugin")
+    errors = validator.validate_result_checkpoint_state(
+        source,
+        result,
+        state["last_sequence"],
+        state["continuation_token"],
+    )
+    if errors:
+        raise AssertionError(errors)
+    candidate = result["candidate"]
+    if not isinstance(candidate, dict):
+        raise AssertionError("worker returned no published candidate")
+    verify_isolated_review(case_root, source, result, fixture, candidate, launch)
+    observed = run(["git", "ls-remote", candidate["remote_url"], candidate["remote_ref"]]).split()[
+        0
+    ]
+    if observed != candidate["head_sha"]:
+        raise AssertionError("candidate is not reachable from its exact remote ref")
+    remote = Path(str(fixture["remote"]))
+    deliverable = run(
+        [
+            "git",
+            f"--git-dir={remote}",
+            "show",
+            f"{candidate['head_sha']}:DELIVERABLE.md",
+        ]
+    )
+    if str(source["invocation_id"]) not in deliverable or "implement-ticket" not in deliverable:
+        raise AssertionError("candidate does not contain the delegated deliverable")
+    run(
+        [
+            "git",
+            f"--git-dir={remote}",
+            "merge-base",
+            "--is-ancestor",
+            str(source["repository"]["base_sha"]),
+            str(candidate["head_sha"]),
+        ]
+    )
+    ledger = state["ledger"]
+    assert isinstance(ledger, list)
+    if [entry["sequence"] for entry in ledger if isinstance(entry, dict)] != list(
+        range(1, len(ledger) + 1)
+    ):
+        raise AssertionError("durable checkpoint ledger is not contiguous")
+    pre_actions = {
+        entry["action"]
+        for entry in ledger
+        if isinstance(entry, dict) and entry["phase"] == "pre_external_mutation"
+    }
+    expected_actions = {
+        "repository.candidate.create",
+        "repository.candidate.push",
+    }
+    if expected_case == "success":
+        expected_actions.add("pull_request.create")
+    if pre_actions != expected_actions or pre_actions != set(result["authority_used"]):
+        raise AssertionError("terminal authority does not equal expected durable allowances")
+    acknowledgements = [
+        entry
+        for entry in ledger
+        if isinstance(entry, dict) and entry["phase"] == "candidate_published"
+    ]
+    if len(acknowledgements) != 1 or (
+        acknowledgements[0]["acknowledged_candidate_sha"] != candidate["head_sha"]
+    ):
+        raise AssertionError("published candidate lacks exact durable acknowledgement")
+    marker = Path(str(fixture["pull_request_marker"]))
+    publication = candidate["publication"]
+    assert isinstance(publication, dict)
+    pull_requests = publication["pull_requests"]
+    assert isinstance(pull_requests, list)
+    if expected_case == "success":
+        if result["terminal_state"] != "ready_pr" or not marker.is_file():
+            raise AssertionError("successful worker did not produce the PR fixture")
+        if len(pull_requests) != 1 or read_object(marker) != pull_requests[0]:
+            raise AssertionError("PR fixture marker differs from the terminal result")
+    elif (
+        result["terminal_state"] != "blocked"
+        or result["blocking_reason"] is None
+        or marker.exists()
+        or pull_requests
+    ):
+        raise AssertionError("denied worker performed or misreported the denied action")
+    skill_path = Path(str(observation["skill_path"])).resolve()
+    expected_fragment = "/plugins/cache/agent-scripts/agent-scripts/"
+    if expected_fragment not in str(skill_path):
+        raise AssertionError("worker did not use the independently installed plugin skill")
+    if observation["invocation_name"] != "implement-ticket":
+        raise AssertionError("worker did not invoke implement-ticket by stable name")
+    installed_hash = digest(skill_root / "SKILL.md")
+    capability_path = skill_root / "references" / "delegated-execution" / "capability.json"
+    if digest(skill_path) != installed_hash or observation["skill_sha256"] != installed_hash:
+        raise AssertionError("worker skill differs from the validated capability install")
+    if observation["capability_sha256"] != digest(capability_path):
+        raise AssertionError("worker capability differs from the validated capability install")
+    execution_text = json.dumps(execution_log)
+    if not all(term in execution_text for term in ("checkpoint", "git push", "review-request")):
+        raise AssertionError("worker execution log omits required delegated operations")
+    return source, result
+
+
+def negative_checks(
+    workspace: Path,
+    success_root: Path,
+    denied_root: Path,
+) -> list[dict[str, object]]:
+    """Run coordinator and consumer rejection checks after real worker runs."""
+    skill_root = installed_skill(workspace)
+    validator = load_validator(skill_root)
+    capability_path = skill_root / "references" / "delegated-execution" / "capability.json"
+    capability = read_object(capability_path)
+    success_source = read_object(success_root / "invocation.json")
+    success_result = read_object(success_root / "result.json")
+    denied_source = read_object(denied_root / "invocation.json")
+    denied_result = read_object(denied_root / "result.json")
+    checks: list[dict[str, object]] = []
+
+    malformed = copy.deepcopy(capability)
+    malformed["atelier"] = True
+    checks.append(
+        {
+            "name": "malformed capability is rejected",
+            "passed": "$.atelier: unknown property" in validator.validate("capability", malformed),
+        }
+    )
+
+    excess = copy.deepcopy(success_result)
+    excess["authority_used"].append("pull_request.merge")
+    checks.append(
+        {
+            "name": "excess terminal authority is rejected",
+            "passed": any(
+                "exceeds invocation" in error
+                for error in validator.validate_result_for_invocation(success_source, excess)
+            ),
+        }
+    )
+
+    candidate = success_result["candidate"]
+    assert isinstance(candidate, dict)
+    mismatch_request = {
+        "schema": "agent-scripts.implement-ticket/checkpoint-request/v1",
+        "capability": CAPABILITY,
+        "invocation_id": success_source["invocation_id"],
+        "continuation_token": "token-a",
+        "sequence": 1,
+        "phase": "candidate_published",
+        "action": "repository.candidate.push",
+        "ticket_observation": success_source["ticket"]["observation"],
+        "candidate": {
+            key: candidate[key]
+            for key in ("repository", "remote_url", "remote_ref", "base_sha", "head_sha")
+        },
+        "proposed_effect": "Acknowledge a mismatched candidate",
+    }
+    mismatch_response = {
+        "schema": "agent-scripts.implement-ticket/checkpoint-response/v1",
+        "invocation_id": success_source["invocation_id"],
+        "request_sequence": 1,
+        "prior_continuation_token": "token-a",
+        "continuation_token": "token-b",
+        "decision": "allow",
+        "reason": None,
+        "acknowledged_candidate_sha": success_source["repository"]["base_sha"],
+    }
+    checks.append(
+        {
+            "name": "candidate acknowledgement mismatch is rejected",
+            "passed": any(
+                "does not match published candidate" in error
+                for error in validator.validate_checkpoint_exchange(
+                    mismatch_request, mismatch_response
+                )
+            ),
+        }
+    )
+
+    state_path = denied_root / "checkpoint-state.json"
+    before = read_object(state_path)
+    foreign_request = {
+        "schema": "agent-scripts.implement-ticket/checkpoint-request/v1",
+        "capability": CAPABILITY,
+        "invocation_id": "foreign-invocation",
+        "continuation_token": before["continuation_token"],
+        "sequence": int(before["last_sequence"]) + 1,
+        "phase": "pre_external_mutation",
+        "action": "repository.candidate.create",
+        "ticket_observation": "sha256:foreign-ticket",
+        "candidate": None,
+        "proposed_effect": "Consume another invocation's allowance",
+    }
+    foreign_request_path = denied_root / "foreign-request.json"
+    foreign_response_path = denied_root / "foreign-response.json"
+    write_json(foreign_request_path, foreign_request)
+    probe_checkpoint(
+        skill_root,
+        state_path,
+        foreign_request_path,
+        foreign_response_path,
+    )
+    foreign_response = read_object(foreign_response_path)
+    checks.append(
+        {
+            "name": "foreign invocation cannot consume checkpoint state",
+            "passed": foreign_response["decision"] == "deny" and read_object(state_path) == before,
+        }
+    )
+    authority_request = {
+        "schema": "agent-scripts.implement-ticket/checkpoint-request/v1",
+        "capability": CAPABILITY,
+        "invocation_id": denied_source["invocation_id"],
+        "continuation_token": before["continuation_token"],
+        "sequence": int(before["last_sequence"]) + 1,
+        "phase": "pre_external_mutation",
+        "action": "ticket.update",
+        "ticket_observation": denied_source["ticket"]["observation"],
+        "candidate": None,
+        "proposed_effect": "Mutate a ticket outside delegated authority",
+    }
+    authority_request_path = denied_root / "excess-authority-request.json"
+    authority_response_path = denied_root / "excess-authority-response.json"
+    write_json(authority_request_path, authority_request)
+    probe_checkpoint(
+        skill_root,
+        state_path,
+        authority_request_path,
+        authority_response_path,
+    )
+    authority_response = read_object(authority_response_path)
+    checks.append(
+        {
+            "name": "excess action is denied before mutation",
+            "passed": authority_response["decision"] == "deny"
+            and "invocation authority excludes ticket.update" in str(authority_response["reason"])
+            and read_object(state_path) == before,
+        }
+    )
+    stale_request = {
+        "schema": "agent-scripts.implement-ticket/checkpoint-request/v1",
+        "capability": CAPABILITY,
+        "invocation_id": denied_source["invocation_id"],
+        "continuation_token": before["continuation_token"],
+        "sequence": before["last_sequence"],
+        "phase": "pre_external_mutation",
+        "action": "repository.candidate.create",
+        "ticket_observation": denied_source["ticket"]["observation"],
+        "candidate": None,
+        "proposed_effect": "Replay an already consumed sequence",
+    }
+    stale_request_path = denied_root / "stale-request.json"
+    stale_response_path = denied_root / "stale-response.json"
+    write_json(stale_request_path, stale_request)
+    probe_checkpoint(
+        skill_root,
+        state_path,
+        stale_request_path,
+        stale_response_path,
+    )
+    stale_response = read_object(stale_response_path)
+    checks.append(
+        {
+            "name": "stale sequence cannot consume checkpoint state",
+            "passed": stale_response["decision"] == "deny" and read_object(state_path) == before,
+        }
+    )
+
+    denied_candidate = denied_result["candidate"]
+    assert isinstance(denied_candidate, dict)
+    foreign_candidate = {
+        key: denied_candidate[key]
+        for key in ("repository", "remote_url", "remote_ref", "base_sha", "head_sha")
+    }
+    foreign_candidate["remote_url"] = "/tmp/foreign-remote.git"
+    repository_request = {
+        "schema": "agent-scripts.implement-ticket/checkpoint-request/v1",
+        "capability": CAPABILITY,
+        "invocation_id": denied_source["invocation_id"],
+        "continuation_token": before["continuation_token"],
+        "sequence": int(before["last_sequence"]) + 1,
+        "phase": "pre_external_mutation",
+        "action": "repository.candidate.push",
+        "ticket_observation": denied_source["ticket"]["observation"],
+        "candidate": foreign_candidate,
+        "proposed_effect": "Publish a candidate for another repository",
+    }
+    repository_request_path = denied_root / "foreign-repository-request.json"
+    repository_response_path = denied_root / "foreign-repository-response.json"
+    write_json(repository_request_path, repository_request)
+    probe_checkpoint(
+        skill_root,
+        state_path,
+        repository_request_path,
+        repository_response_path,
+    )
+    repository_response = read_object(repository_response_path)
+    checks.append(
+        {
+            "name": "foreign repository cannot consume checkpoint state",
+            "passed": repository_response["decision"] == "deny"
+            and read_object(state_path) == before,
+        }
+    )
+    return checks
+
+
+def verify(workspace: Path, success_root: Path, denied_root: Path, output: Path) -> int:
+    """Verify both worker runs and persist a compact evaluation summary."""
+    checks: list[dict[str, object]] = []
+    try:
+        verify_case(workspace, success_root, "success")
+        checks.append({"name": "host worker delivers allowed case", "passed": True})
+    except Exception as error:  # noqa: BLE001 - preserve every evaluation failure.
+        checks.append(
+            {"name": "host worker delivers allowed case", "passed": False, "error": str(error)}
+        )
+    try:
+        verify_case(workspace, denied_root, "denied")
+        checks.append({"name": "host worker obeys denied mutation", "passed": True})
+    except Exception as error:  # noqa: BLE001 - preserve every evaluation failure.
+        checks.append(
+            {"name": "host worker obeys denied mutation", "passed": False, "error": str(error)}
+        )
+    try:
+        checks.extend(negative_checks(workspace, success_root, denied_root))
+    except Exception as error:  # noqa: BLE001 - preserve every evaluation failure.
+        checks.append({"name": "negative protocol checks", "passed": False, "error": str(error)})
+    failed = [str(check["name"]) for check in checks if not check["passed"]]
+    skill_root = installed_skill(workspace)
+    this_skill = Path(__file__).resolve().parents[1] / "SKILL.md"
+    summary = {
+        "capability_id": CAPABILITY,
+        "agent_scripts_skill_sha256": digest(skill_root / "SKILL.md"),
+        "atelier_skill_sha256": digest(this_skill),
+        "scenario_count": len(checks),
+        "passed": len(checks) - len(failed),
+        "failed": len(failed),
+        "failed_scenarios": failed,
+        "evidence_path": str(output.resolve()),
+        "boundary_observation": (
+            "Fresh Codex workers used the independently installed Agent Scripts "
+            "plugin skill; Atelier prepared and verified but did not perform their work."
+        ),
+    }
+    output.mkdir(parents=True, exist_ok=True)
+    plugin_root = Path(__file__).resolve().parents[3]
+    checkpoint_path = Path(__file__).with_name("checkpoint.py").resolve()
+    worker_skill_roots = sorted(
+        {
+            str(
+                Path(str(read_object(root / "worker-observation.json")["skill_path"]))
+                .resolve()
+                .parent
+            )
+            for root in (success_root, denied_root)
+        }
+    )
+    write_json(
+        output / "package-provenance.json",
+        {
+            "executing_atelier_package_root": str(plugin_root),
+            "executing_atelier_package_files": tree_manifest(plugin_root),
+            "negative_probe_checkpoint": {
+                "path": str(checkpoint_path),
+                "sha256": digest(checkpoint_path),
+                "statement": (
+                    "Negative probes invoked the checkpoint from the executing preserved "
+                    "package; this hash must equal the worker invocation checkpoint hash."
+                ),
+            },
+            "agent_scripts_validation_root": str(skill_root),
+            "agent_scripts_validation_files": tree_manifest(skill_root),
+            "worker_agent_scripts_skill_roots": [
+                {"path": path, "files": tree_manifest(Path(path))} for path in worker_skill_roots
+            ],
+        },
+    )
+    write_json(output / "checks.json", checks)
+    write_json(output / "summary.json", summary)
+    print(json.dumps(summary, sort_keys=True))
+    return 1 if failed else 0
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse subcommands."""
+    parser = argparse.ArgumentParser()
+    commands = parser.add_subparsers(dest="command", required=True)
+    prepare_parser = commands.add_parser("prepare")
+    prepare_parser.add_argument("--workspace", required=True, type=Path)
+    prepare_parser.add_argument("--output", required=True, type=Path)
+    prepare_parser.add_argument("--case", required=True, choices=("success", "denied"))
+    exchange_parser = commands.add_parser("exchange")
+    exchange_parser.add_argument("--invocation", required=True, type=Path)
+    exchange_parser.add_argument("--request", required=True, type=Path)
+    exchange_parser.add_argument("--response", required=True, type=Path)
+    verify_parser = commands.add_parser("verify")
+    verify_parser.add_argument("--workspace", required=True, type=Path)
+    verify_parser.add_argument("--success", required=True, type=Path)
+    verify_parser.add_argument("--denied", required=True, type=Path)
+    verify_parser.add_argument("--output", required=True, type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Dispatch one composition-evaluation operation."""
+    args = parse_args()
+    if args.command == "prepare":
+        print(json.dumps(prepare(args.workspace.resolve(), args.output.resolve(), args.case)))
+        return 0
+    if args.command == "exchange":
+        exchange(args.invocation.resolve(), args.request.resolve(), args.response.resolve())
+        return 0
+    return verify(
+        args.workspace.resolve(),
+        args.success.resolve(),
+        args.denied.resolve(),
+        args.output.resolve(),
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/mailbox_protocol_v0.py
+++ b/experiments/mailbox_protocol_v0.py
@@ -1,0 +1,999 @@
+#!/usr/bin/env python3
+"""Exercise the proposed Atelier mailbox protocol against disposable Git clones."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SHA_ZERO = "0" * 40
+WORK_RACE = "wrk_019f9a9e-0000-7000-8000-000000000001"
+PROJECT_ID = "prj_019f9a9e-0000-7000-8000-000000000001"
+
+
+def run(repo: Path | None, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    command = ["git", *args]
+    return subprocess.run(
+        command,
+        cwd=repo,
+        check=check,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def configure(repo: Path) -> None:
+    run(repo, "config", "user.name", "Atelier Protocol Experiment")
+    run(repo, "config", "user.email", "atelier-experiment@example.invalid")
+
+
+def document(data: dict[str, Any], body: str = "") -> str:
+    return f"---\n{json.dumps(data, indent=2, sort_keys=True)}\n---\n{body}\n"
+
+
+def parse_document(content: str) -> dict[str, Any]:
+    lines = content.splitlines()
+    if len(lines) < 3 or lines[0] != "---":
+        raise ValueError("missing frontmatter")
+    end = lines.index("---", 1)
+    value = json.loads("\n".join(lines[1:end]))
+    if not isinstance(value, dict):
+        raise ValueError("frontmatter must be an object")
+    return value
+
+
+def write_document(
+    repo: Path,
+    relative: str,
+    data: dict[str, Any],
+    body: str = "",
+) -> str:
+    path = repo / relative
+    path.parent.mkdir(parents=True, exist_ok=True)
+    content = document(data, body)
+    path.write_text(content)
+    return content
+
+
+def work_document(status: str = "approved") -> dict[str, Any]:
+    approval = {
+        "approved_by": "operator",
+        "approved_at": "2026-07-25T12:00:00Z",
+        "revision": 1,
+        "policy": {
+            "repository": "github:example/project",
+            "commit": SHA_ZERO,
+            "path": ".atelier/policy.yaml",
+        },
+        "authority_ceiling": [
+            "repository.candidate.create",
+            "repository.candidate.push",
+            "pull_request.create",
+        ],
+        "acceptance": {
+            "mode": "operator",
+            "required_evidence": ["candidate-remote-reachable"],
+        },
+    }
+    return {
+        "schema": "atelier.work/v1",
+        "id": WORK_RACE,
+        "title": "Exercise mailbox transitions",
+        "project_id": PROJECT_ID,
+        "initiative_id": None,
+        "status": status,
+        "revision": 1,
+        "dependencies": [],
+        "replaces": [],
+        "native_ticket": {
+            "provider": "github",
+            "id": "123",
+            "url": "https://github.com/example/project/issues/123",
+        },
+        "approval": approval,
+        "claim": None,
+        "blocking_message_id": None,
+        "attempt_receipt_id": None,
+        "delivery_receipt_id": None,
+        "acceptance": None,
+    }
+
+
+def claim(claim_id: str, run_id: str, candidate: dict[str, Any] | None = None) -> dict[str, Any]:
+    return {
+        "id": claim_id,
+        "worker_run_id": run_id,
+        "work_revision": 1,
+        "approved_commit": SHA_ZERO,
+        "policy_commit": SHA_ZERO,
+        "ticket_observation_digest": "sha256:" + ("1" * 64),
+        "claimed_at": "2026-07-25T12:05:00Z",
+        "host": "experiment",
+        "checkpoint": {
+            "sequence": 0,
+            "continuation_token": f"token-{claim_id}",
+            "authorizations": [],
+        },
+        "candidate": candidate,
+    }
+
+
+def message(
+    message_id: str,
+    kind: str,
+    *,
+    resolves: str | None = None,
+    work_id: str = WORK_RACE,
+) -> dict[str, Any]:
+    return {
+        "schema": "atelier.message/v1",
+        "id": message_id,
+        "work_id": work_id,
+        "kind": kind,
+        "author_role": "worker",
+        "worker_run_id": "run_019f9a9e-0000-7000-8000-000000000001",
+        "audience": "planner",
+        "in_reply_to": None,
+        "resolves": resolves,
+        "blocks": "worker" if kind == "needs-decision" and resolves is None else None,
+        "created_at": "2026-07-25T12:30:00Z",
+        "subject": "Protocol experiment",
+    }
+
+
+def receipt(
+    receipt_id: str,
+    outcome: str,
+    claim_id: str,
+    candidate: dict[str, Any] | None,
+    *,
+    work_id: str = WORK_RACE,
+) -> dict[str, Any]:
+    return {
+        "schema": "atelier.receipt/v1",
+        "id": receipt_id,
+        "work_id": work_id,
+        "outcome": outcome,
+        "approved_revision": 1,
+        "approved_commit": SHA_ZERO,
+        "policy_commit": SHA_ZERO,
+        "claim_id": claim_id,
+        "worker_run_id": "run_019f9a9e-0000-7000-8000-000000000001",
+        "candidate": candidate,
+        "handoff": "transferable" if candidate else "none",
+        "native_ticket": {
+            "provider": "github",
+            "id": "123",
+        },
+        "validation": [],
+        "reviews": [],
+        "unresolved_obligations": [],
+        "mutation_ownership": "retained" if outcome != "released" else "relinquished",
+        "ended_at": "2026-07-25T13:00:00Z",
+    }
+
+
+@dataclass
+class Mailbox:
+    remote: Path
+    readbacks: int = 0
+    published: int = 0
+
+    def sync(self, repo: Path) -> None:
+        run(repo, "fetch", "origin", "main")
+        run(repo, "reset", "--hard", "origin/main")
+        run(repo, "clean", "-fd")
+
+    def publish(self, repo: Path, summary: str) -> str:
+        tracked = run(repo, "diff", "--name-only").stdout.splitlines()
+        untracked = run(
+            repo,
+            "ls-files",
+            "--others",
+            "--exclude-standard",
+        ).stdout.splitlines()
+        paths = sorted(set(tracked + untracked))
+        expected = {
+            path: (repo / path).read_text() if (repo / path).is_file() else None for path in paths
+        }
+        run(repo, "add", "-A")
+        run(repo, "commit", "-m", summary)
+        commit = run(repo, "rev-parse", "HEAD").stdout.strip()
+        run(repo, "push", "origin", "HEAD:main")
+        self.published += 1
+        run(repo, "fetch", "origin", "main")
+        run(repo, "merge-base", "--is-ancestor", commit, "origin/main")
+        for path, content in expected.items():
+            shown = run(repo, "show", f"origin/main:{path}", check=False)
+            if content is None:
+                if shown.returncode == 0:
+                    raise AssertionError(f"{path} should be absent after read-back")
+            elif shown.returncode != 0 or shown.stdout != content:
+                raise AssertionError(f"{path} differs after exact remote read-back")
+        self.readbacks += 1
+        return commit
+
+    def remote_document(self, repo: Path, relative: str) -> dict[str, Any]:
+        run(repo, "fetch", "origin", "main")
+        content = run(repo, "show", f"origin/main:{relative}").stdout
+        return parse_document(content)
+
+
+def clone(remote: Path, target: Path) -> Path:
+    run(None, "clone", str(remote), str(target))
+    configure(target)
+    return target
+
+
+def ticket_digest(value: dict[str, Any]) -> str:
+    encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return "sha256:" + hashlib.sha256(encoded).hexdigest()
+
+
+def candidate_reachable(repo: Path, candidate: dict[str, Any]) -> bool:
+    fetched = run(
+        repo,
+        "fetch",
+        candidate["remote_url"],
+        candidate["remote_ref"],
+        check=False,
+    )
+    if fetched.returncode != 0:
+        return False
+    return (
+        run(
+            repo,
+            "merge-base",
+            "--is-ancestor",
+            candidate["head_revision"],
+            "FETCH_HEAD",
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def checkpoint_is_current(
+    repo: Path,
+    relative: str,
+    claim_id: str,
+    sequence: int,
+    continuation_token: str,
+) -> bool:
+    fetched = run(repo, "fetch", "origin", "main", check=False)
+    if fetched.returncode != 0:
+        return False
+    shown = run(repo, "show", f"origin/main:{relative}", check=False)
+    if shown.returncode != 0:
+        return False
+    current = parse_document(shown.stdout)["claim"]
+    return (
+        current is not None
+        and current["id"] == claim_id
+        and current["checkpoint"]["sequence"] == sequence
+        and current["checkpoint"]["continuation_token"] == continuation_token
+    )
+
+
+def authorize_checkpoint(
+    mailbox: Mailbox,
+    repo: Path,
+    relative: str,
+    claim_id: str,
+    sequence: int,
+    continuation_token: str,
+    action: str,
+) -> tuple[int, str] | None:
+    mailbox.sync(repo)
+    data = parse_document((repo / relative).read_text())
+    current = data["claim"]
+    if (
+        current is None
+        or current["id"] != claim_id
+        or current["checkpoint"]["sequence"] != sequence
+        or current["checkpoint"]["continuation_token"] != continuation_token
+    ):
+        return None
+    next_sequence = sequence + 1
+    next_token = f"{continuation_token}-{next_sequence}"
+    current["checkpoint"]["sequence"] = next_sequence
+    current["checkpoint"]["continuation_token"] = next_token
+    current["checkpoint"]["authorizations"].append(
+        {
+            "sequence": next_sequence,
+            "invocation_id": current["worker_run_id"],
+            "phase": "pre_external_mutation",
+            "action": action,
+            "proposed_effect_digest": ticket_digest({"action": action, "claim_id": claim_id}),
+            "candidate_head": None,
+            "acknowledged_candidate_head": None,
+            "recorded_at": "2026-07-25T12:25:00Z",
+        }
+    )
+    write_document(repo, relative, data)
+    mailbox.publish(repo, f"authorize {action}")
+    return next_sequence, next_token
+
+
+def validate_lifecycle(repo: Path, relative: str) -> str:
+    data = parse_document((repo / relative).read_text())
+    if data["schema"] != "atelier.work/v1":
+        raise ValueError("unsupported work schema")
+    status = data["status"]
+    claim_value = data["claim"]
+    blocker = data["blocking_message_id"]
+    attempt = data["attempt_receipt_id"]
+    delivery = data["delivery_receipt_id"]
+    acceptance = data["acceptance"]
+    invariants = {
+        "approved": claim_value is None and blocker is None and delivery is None,
+        "active": claim_value is not None and blocker is None and delivery is None,
+        "blocked": (
+            claim_value is not None
+            and blocker is not None
+            and attempt is not None
+            and delivery is None
+        ),
+        "delivered": (
+            claim_value is not None
+            and blocker is None
+            and attempt is not None
+            and attempt == delivery
+        ),
+        "accepted": (
+            claim_value is None
+            and blocker is None
+            and attempt is not None
+            and attempt == delivery
+            and acceptance is not None
+        ),
+    }
+    if status not in invariants or not invariants[status]:
+        raise ValueError(f"invalid {status} lifecycle fields")
+    work_root = (repo / relative).parent
+    if claim_value is not None and not isinstance(
+        claim_value["checkpoint"]["authorizations"], list
+    ):
+        raise ValueError("claim authorization ledger is invalid")
+    if blocker is not None:
+        blocker_data = parse_document((work_root / "messages" / f"{blocker}.md").read_text())
+        if (
+            blocker_data["schema"] != "atelier.message/v1"
+            or blocker_data["id"] != blocker
+            or blocker_data["work_id"] != data["id"]
+            or blocker_data["blocks"] is None
+            or blocker_data["resolves"] is not None
+        ):
+            raise ValueError("blocking message does not match work")
+    if attempt is not None:
+        attempt_path = work_root / "receipts" / f"{attempt}.md"
+        attempt_data = parse_document(attempt_path.read_text())
+        if (
+            attempt_data["schema"] != "atelier.receipt/v1"
+            or attempt_data["id"] != attempt
+            or attempt_data["work_id"] != data["id"]
+        ):
+            raise ValueError("attempt receipt does not match work")
+    if delivery is not None:
+        receipt_data = parse_document((work_root / "receipts" / f"{delivery}.md").read_text())
+        if (
+            receipt_data["schema"] != "atelier.receipt/v1"
+            or receipt_data["id"] != delivery
+            or receipt_data["work_id"] != data["id"]
+            or receipt_data["outcome"] != "delivered"
+        ):
+            raise ValueError("delivery receipt does not match work")
+        if acceptance is not None and (
+            acceptance["receipt_id"] != delivery
+            or acceptance["candidate_revision"] != receipt_data["candidate"]["head_revision"]
+        ):
+            raise ValueError("acceptance does not match delivered candidate")
+    return status
+
+
+def derive_ready(
+    repo: Path,
+    relative: str,
+    *,
+    policy_gates_satisfied: bool,
+    ticket_eligible: bool,
+    capability_available: bool,
+) -> bool:
+    """Derive v0 readiness only from validated clone state and gate fixtures."""
+    try:
+        data = parse_document((repo / relative).read_text())
+        if validate_lifecycle(repo, relative) != "approved":
+            return False
+        for dependency_id in data["dependencies"]:
+            dependency_path = f"work/{dependency_id}/work.md"
+            if validate_lifecycle(repo, dependency_path) != "accepted":
+                return False
+    except (KeyError, OSError, ValueError):
+        return False
+    if not policy_gates_satisfied or not ticket_eligible or not capability_available:
+        return False
+    for path in (repo / "work").glob("*/work.md"):
+        if path == repo / relative:
+            continue
+        other = parse_document(path.read_text())
+        if other["project_id"] == data["project_id"] and other["status"] in {
+            "active",
+            "blocked",
+            "delivered",
+        }:
+            return False
+    return True
+
+
+def main() -> int:
+    results: list[tuple[str, bool]] = []
+
+    def record(name: str, condition: bool) -> None:
+        if not condition:
+            raise AssertionError(name)
+        results.append((name, True))
+
+    with tempfile.TemporaryDirectory(prefix="atelier-mailbox-v0-") as temporary:
+        root = Path(temporary)
+        remote = root / "mailbox.git"
+        run(None, "init", "--bare", "--initial-branch=main", str(remote))
+        seed = clone(remote, root / "seed")
+        mailbox = Mailbox(remote)
+        write_document(
+            seed,
+            "atelier.yaml",
+            {
+                "schema": "atelier.mailbox/v1",
+                "realm_id": "experiment",
+                "canonical_branch": "main",
+            },
+        )
+        write_document(seed, f"work/{WORK_RACE}/work.md", work_document())
+        mailbox.publish(seed, "seed mailbox")
+
+        worker_one = clone(remote, root / "worker-one")
+        worker_two = clone(remote, root / "worker-two")
+        planner = clone(remote, root / "planner")
+
+        for repo, claim_id, run_id in (
+            (worker_one, "clm_one", "run_one"),
+            (worker_two, "clm_two", "run_two"),
+        ):
+            data = parse_document((repo / f"work/{WORK_RACE}/work.md").read_text())
+            data["status"] = "active"
+            data["claim"] = claim(claim_id, run_id)
+            write_document(repo, f"work/{WORK_RACE}/work.md", data)
+            run(repo, "add", "-A")
+            run(repo, "commit", "-m", f"claim {claim_id}")
+        expected_claim = run(
+            worker_one,
+            "show",
+            f"HEAD:work/{WORK_RACE}/work.md",
+        ).stdout
+        run(worker_one, "push", "origin", "HEAD:main")
+        mailbox.published += 1
+        run(worker_one, "fetch", "origin", "main")
+        run(worker_one, "merge-base", "--is-ancestor", "HEAD", "origin/main")
+        remote_claim = run(
+            worker_one,
+            "show",
+            f"origin/main:work/{WORK_RACE}/work.md",
+        ).stdout
+        if remote_claim != expected_claim:
+            raise AssertionError("winning claim differs after exact remote read-back")
+        mailbox.readbacks += 1
+        loser = run(worker_two, "push", "origin", "HEAD:main", check=False)
+        record("concurrent claim has one winner", loser.returncode != 0)
+
+        mailbox.sync(worker_one)
+        mailbox.sync(worker_two)
+        message_one = message("msg_instruction", "instruction")
+        message_two = message("msg_needs_decision", "needs-decision")
+        write_document(
+            worker_one,
+            f"work/{WORK_RACE}/messages/msg_instruction.md",
+            message_one,
+        )
+        write_document(
+            worker_two,
+            f"work/{WORK_RACE}/messages/msg_needs_decision.md",
+            message_two,
+        )
+        mailbox.publish(worker_one, "append instruction")
+        run(worker_two, "add", "-A")
+        run(worker_two, "commit", "-m", "append decision request")
+        rejected = run(worker_two, "push", "origin", "HEAD:main", check=False)
+        if rejected.returncode == 0:
+            raise AssertionError("concurrent message unexpectedly fast-forwarded")
+        mailbox.sync(worker_two)
+        write_document(
+            worker_two,
+            f"work/{WORK_RACE}/messages/msg_needs_decision.md",
+            message_two,
+        )
+        mailbox.publish(worker_two, "retry exact decision request")
+        paths = run(
+            worker_two,
+            "ls-tree",
+            "-r",
+            "--name-only",
+            "origin/main",
+            f"work/{WORK_RACE}/messages",
+        ).stdout.splitlines()
+        record("concurrent messages survive exactly once", len(paths) == 2)
+
+        mailbox.sync(planner)
+        timeout_path = f"work/{WORK_RACE}/messages/msg_timeout.md"
+        expected_timeout = write_document(
+            planner,
+            timeout_path,
+            message("msg_timeout", "notification"),
+        )
+        run(planner, "add", "-A")
+        run(planner, "commit", "-m", "publish timeout candidate")
+        ambiguous_commit = run(planner, "rev-parse", "HEAD").stdout.strip()
+        run(planner, "push", "origin", "HEAD:main")
+        mailbox.published += 1
+        # Simulate losing the push response and performing no immediate read-back.
+        mailbox.sync(worker_one)
+        write_document(
+            worker_one,
+            f"work/{WORK_RACE}/messages/msg_later.md",
+            message("msg_later", "notification"),
+        )
+        mailbox.publish(worker_one, "advance after ambiguous push")
+        run(planner, "fetch", "origin", "main")
+        historical = run(
+            planner,
+            "merge-base",
+            "--is-ancestor",
+            ambiguous_commit,
+            "origin/main",
+            check=False,
+        )
+        historical_content = run(
+            planner,
+            "show",
+            f"{ambiguous_commit}:{timeout_path}",
+            check=False,
+        )
+        timeout_recovered = (
+            historical.returncode == 0
+            and historical_content.returncode == 0
+            and historical_content.stdout == expected_timeout
+        )
+        if timeout_recovered:
+            mailbox.readbacks += 1
+        record("timeout success survives later commits", timeout_recovered)
+
+        mailbox.sync(worker_two)
+        unavailable_path = "work/wrk_unavailable/work.md"
+        unavailable_work = work_document("active")
+        unavailable_work["id"] = "wrk_unavailable"
+        unavailable_work["claim"] = claim("clm_unavailable", "run_unavailable")
+        write_document(worker_two, unavailable_path, unavailable_work)
+        run(worker_two, "add", "-A")
+        run(worker_two, "commit", "-m", "attempt unavailable claim")
+        run(worker_two, "remote", "set-url", "origin", str(root / "missing.git"))
+        unavailable = run(worker_two, "push", "origin", "HEAD:main", check=False)
+        run(worker_two, "remote", "set-url", "origin", str(remote))
+        run(worker_two, "fetch", "origin", "main")
+        absent = run(
+            worker_two,
+            "show",
+            f"origin/main:{unavailable_path}",
+            check=False,
+        )
+        record(
+            "unavailable remote cannot establish claim",
+            unavailable.returncode != 0 and absent.returncode != 0,
+        )
+        mailbox.sync(worker_two)
+
+        mailbox.sync(worker_one)
+        work_path = f"work/{WORK_RACE}/work.md"
+        active = parse_document((worker_one / work_path).read_text())
+        checkpoint = active["claim"]["checkpoint"]
+        authorized = authorize_checkpoint(
+            mailbox,
+            worker_one,
+            work_path,
+            active["claim"]["id"],
+            checkpoint["sequence"],
+            checkpoint["continuation_token"],
+            "repository.candidate.create",
+        )
+        if authorized is None:
+            raise AssertionError("current claimant checkpoint was denied")
+        mailbox.sync(worker_one)
+        active = parse_document((worker_one / work_path).read_text())
+        blocker_id = "msg_blocker"
+        receipt_id = "rcp_blocked"
+        active["status"] = "blocked"
+        active["blocking_message_id"] = blocker_id
+        active["attempt_receipt_id"] = receipt_id
+        write_document(worker_one, work_path, active)
+        write_document(
+            worker_one,
+            f"work/{WORK_RACE}/messages/{blocker_id}.md",
+            message(blocker_id, "needs-decision"),
+        )
+        write_document(
+            worker_one,
+            f"work/{WORK_RACE}/receipts/{receipt_id}.md",
+            receipt(receipt_id, "blocked", active["claim"]["id"], None),
+        )
+        mailbox.publish(worker_one, "block atomically")
+        fresh_planner = clone(remote, root / "fresh-planner")
+        blocked = validate_lifecycle(fresh_planner, f"work/{WORK_RACE}/work.md")
+        record("blocker survives session and fresh clone", blocked == "blocked")
+
+        mailbox.sync(planner)
+        takeover = parse_document((planner / f"work/{WORK_RACE}/work.md").read_text())
+        old_claim = takeover["claim"]["id"]
+        old_sequence = takeover["claim"]["checkpoint"]["sequence"]
+        old_token = takeover["claim"]["checkpoint"]["continuation_token"]
+        takeover["claim"] = claim("clm_takeover", "run_takeover")
+        write_document(planner, f"work/{WORK_RACE}/work.md", takeover)
+        mailbox.publish(planner, "take over blocked work")
+        stale_checkpoint_allowed = checkpoint_is_current(
+            worker_one,
+            f"work/{WORK_RACE}/work.md",
+            old_claim,
+            old_sequence,
+            old_token,
+        )
+        record("takeover fences prior claimant", not stale_checkpoint_allowed)
+
+        mailbox.sync(planner)
+        resolved = parse_document((planner / f"work/{WORK_RACE}/work.md").read_text())
+        resolved["status"] = "active"
+        resolved["blocking_message_id"] = None
+        write_document(planner, f"work/{WORK_RACE}/work.md", resolved)
+        write_document(
+            planner,
+            f"work/{WORK_RACE}/messages/msg_resolve.md",
+            message("msg_resolve", "instruction", resolves=blocker_id),
+        )
+        mailbox.publish(planner, "resolve blocker")
+
+        project_remote = root / "project.git"
+        run(None, "init", "--bare", "--initial-branch=main", str(project_remote))
+        project = clone(project_remote, root / "project")
+        (project / "source.txt").write_text("base\n")
+        run(project, "add", "source.txt")
+        run(project, "commit", "-m", "project base")
+        run(project, "push", "origin", "HEAD:main")
+        base_sha = run(project, "rev-parse", "HEAD").stdout.strip()
+        run(project, "checkout", "-b", "candidate")
+        (project / "source.txt").write_text("candidate\n")
+        run(project, "commit", "-am", "candidate")
+        candidate_sha = run(project, "rev-parse", "HEAD").stdout.strip()
+        run(project, "push", "origin", "HEAD:refs/heads/candidate")
+        candidate_data = {
+            "repository": "github:example/project",
+            "remote": "origin",
+            "remote_url": str(project_remote),
+            "remote_ref": "refs/heads/candidate",
+            "base_revision": base_sha,
+            "head_revision": candidate_sha,
+            "pull_request": "https://github.com/example/project/pull/456",
+            "workspace_id": None,
+            "published_at": "2026-07-25T12:20:00Z",
+        }
+        mailbox.sync(planner)
+        carrying = parse_document((planner / f"work/{WORK_RACE}/work.md").read_text())
+        carrying["claim"]["candidate"] = candidate_data
+        write_document(planner, f"work/{WORK_RACE}/work.md", carrying)
+        mailbox.publish(planner, "register remote candidate")
+        mailbox.sync(planner)
+        released = parse_document((planner / f"work/{WORK_RACE}/work.md").read_text())
+        released_claim = released["claim"]["id"]
+        release_receipt_id = "rcp_released"
+        released["status"] = "approved"
+        released["claim"] = None
+        released["attempt_receipt_id"] = release_receipt_id
+        write_document(planner, f"work/{WORK_RACE}/work.md", released)
+        write_document(
+            planner,
+            f"work/{WORK_RACE}/receipts/{release_receipt_id}.md",
+            receipt(release_receipt_id, "released", released_claim, candidate_data),
+        )
+        mailbox.publish(planner, "release with candidate handoff")
+        fresh_handoff = clone(remote, root / "fresh-handoff")
+        fresh_project = clone(project_remote, root / "fresh-project")
+        released_work = parse_document((fresh_handoff / f"work/{WORK_RACE}/work.md").read_text())
+        discovered_receipt_id = released_work["attempt_receipt_id"]
+        released_receipt = parse_document(
+            (fresh_handoff / f"work/{WORK_RACE}/receipts/{discovered_receipt_id}.md").read_text()
+        )
+        release_discovered = (
+            discovered_receipt_id == release_receipt_id
+            and released_receipt["candidate"] == candidate_data
+            and candidate_reachable(fresh_project, released_receipt["candidate"])
+        )
+
+        mailbox.sync(planner)
+        carrying_again = parse_document((planner / f"work/{WORK_RACE}/work.md").read_text())
+        carrying_again["status"] = "active"
+        carrying_again["claim"] = claim(
+            "clm_candidate_owner",
+            "run_candidate_owner",
+            released_receipt["candidate"],
+        )
+        write_document(planner, f"work/{WORK_RACE}/work.md", carrying_again)
+        mailbox.publish(planner, "claim released candidate handoff")
+        mailbox.sync(planner)
+        replaced = parse_document((planner / f"work/{WORK_RACE}/work.md").read_text())
+        adopted_candidate = replaced["claim"]["candidate"]
+        replaced["claim"] = claim(
+            "clm_candidate_takeover",
+            "run_candidate_takeover",
+            adopted_candidate,
+        )
+        write_document(planner, f"work/{WORK_RACE}/work.md", replaced)
+        mailbox.publish(planner, "take over candidate-bearing work")
+        fresh_takeover = clone(remote, root / "fresh-takeover")
+        taken_over = parse_document((fresh_takeover / f"work/{WORK_RACE}/work.md").read_text())
+        record(
+            "release and takeover preserve discoverable remote candidate handoff",
+            release_discovered
+            and taken_over["attempt_receipt_id"] == release_receipt_id
+            and taken_over["claim"]["candidate"] == candidate_data
+            and candidate_reachable(fresh_project, taken_over["claim"]["candidate"]),
+        )
+
+        run(project, "checkout", "-b", "local-only")
+        (project / "source.txt").write_text("local only\n")
+        run(project, "commit", "-am", "local-only candidate")
+        local_sha = run(project, "rev-parse", "HEAD").stdout.strip()
+        local_candidate = dict(candidate_data)
+        local_candidate["head_revision"] = local_sha
+        record(
+            "local-only candidate is rejected",
+            not candidate_reachable(project, local_candidate),
+        )
+
+        mailbox.sync(planner)
+        active_again = parse_document((planner / f"work/{WORK_RACE}/work.md").read_text())
+        active_again["status"] = "active"
+        active_again["claim"] = claim("clm_revision_guard", "run_revision_guard")
+        write_document(planner, f"work/{WORK_RACE}/work.md", active_again)
+        mailbox.publish(planner, "claim for revision guard")
+        can_revise = active_again["status"] in {"draft", "approved"}
+        record("substantive revision under claim is rejected", not can_revise)
+
+        approved_allow = {"repository.candidate.push", "pull_request.create"}
+        tightened_allow = {"pull_request.create"}
+        loosened_allow = approved_allow | {"pull_request.merge"}
+        record(
+            "policy drift tightens and never widens",
+            "repository.candidate.push" not in approved_allow & tightened_allow
+            and "pull_request.merge" not in approved_allow & loosened_allow,
+        )
+
+        approved_ticket = {
+            "body": "approved",
+            "state": "open",
+            "relationships": [],
+        }
+        changed_ticket = dict(approved_ticket, body="changed externally")
+        record(
+            "material ticket drift blocks next mutation",
+            ticket_digest(approved_ticket) != ticket_digest(changed_ticket),
+        )
+
+        delivered_head = candidate_sha
+        live_pr = {"head_sha": local_sha}
+        record(
+            "pull request head drift invalidates acceptance",
+            live_pr["head_sha"] != delivered_head,
+        )
+
+        mailbox.sync(planner)
+        invalid_path = "work/wrk_invalid/work.md"
+        invalid = work_document()
+        invalid["id"] = "wrk_invalid"
+        invalid["schema"] = "atelier.work/v2"
+        write_document(planner, invalid_path, invalid)
+        mailbox.publish(planner, "publish unsupported schema fixture")
+        fresh_invalid = clone(remote, root / "fresh-invalid")
+        rejected_schema = False
+        try:
+            validate_lifecycle(fresh_invalid, invalid_path)
+        except ValueError:
+            rejected_schema = True
+        record("unsupported schema fails closed", rejected_schema)
+        mailbox.sync(planner)
+        (planner / invalid_path).unlink()
+        mailbox.publish(planner, "remove unsupported schema fixture")
+
+        mailbox.sync(planner)
+        state_paths: list[str] = []
+        for index, status in enumerate(
+            ("approved", "active", "blocked", "delivered", "accepted"),
+            start=10,
+        ):
+            work_id = f"wrk_019f9a9e-0000-7000-8000-{index:012d}"
+            state_claim_id = f"clm_{index}"
+            blocker_id = f"msg_state_blocker_{index}"
+            attempt_id = f"rcp_{index}"
+            data = work_document(status)
+            data["id"] = work_id
+            data["claim"] = (
+                claim(state_claim_id, f"run_{index}", candidate_data)
+                if status in {"active", "blocked", "delivered"}
+                else None
+            )
+            data["blocking_message_id"] = blocker_id if status == "blocked" else None
+            data["attempt_receipt_id"] = (
+                attempt_id if status in {"blocked", "delivered", "accepted"} else None
+            )
+            data["delivery_receipt_id"] = (
+                attempt_id if status in {"delivered", "accepted"} else None
+            )
+            data["acceptance"] = (
+                {
+                    "receipt_id": attempt_id,
+                    "accepted_by": "operator",
+                    "accepted_at": "2026-07-25T13:15:00Z",
+                    "policy_commit": SHA_ZERO,
+                    "candidate_revision": candidate_sha,
+                    "evidence": {"candidate-remote-reachable": "satisfied"},
+                }
+                if status == "accepted"
+                else None
+            )
+            relative = f"work/{work_id}/work.md"
+            write_document(planner, relative, data)
+            if status == "blocked":
+                write_document(
+                    planner,
+                    f"work/{work_id}/messages/{blocker_id}.md",
+                    message(blocker_id, "needs-decision", work_id=work_id),
+                )
+            if status in {"blocked", "delivered", "accepted"}:
+                write_document(
+                    planner,
+                    f"work/{work_id}/receipts/{attempt_id}.md",
+                    receipt(
+                        attempt_id,
+                        "blocked" if status == "blocked" else "delivered",
+                        state_claim_id,
+                        candidate_data,
+                        work_id=work_id,
+                    ),
+                )
+            state_paths.append(relative)
+
+        ready_id = "wrk_019f9a9e-0000-7000-8000-000000000099"
+        ready_path = f"work/{ready_id}/work.md"
+        ready_data = work_document("approved")
+        ready_data["id"] = ready_id
+        ready_data["project_id"] = "prj_ready"
+        accepted_dependency = state_paths[-1].split("/")[1]
+        ready_data["dependencies"] = [accepted_dependency]
+        write_document(planner, ready_path, ready_data)
+
+        missing_dependency_path = "work/wrk_ready_missing/work.md"
+        missing_dependency = work_document("approved")
+        missing_dependency["id"] = "wrk_ready_missing"
+        missing_dependency["project_id"] = "prj_ready_missing"
+        missing_dependency["dependencies"] = ["wrk_does_not_exist"]
+        write_document(planner, missing_dependency_path, missing_dependency)
+
+        nonaccepted_dependency_path = "work/wrk_ready_nonaccepted/work.md"
+        nonaccepted_dependency = work_document("approved")
+        nonaccepted_dependency["id"] = "wrk_ready_nonaccepted"
+        nonaccepted_dependency["project_id"] = "prj_ready_nonaccepted"
+        nonaccepted_dependency["dependencies"] = [state_paths[0].split("/")[1]]
+        write_document(planner, nonaccepted_dependency_path, nonaccepted_dependency)
+
+        illegal_claim_path = "work/wrk_ready_illegal_claim/work.md"
+        illegal_claim = work_document("approved")
+        illegal_claim["id"] = "wrk_ready_illegal_claim"
+        illegal_claim["project_id"] = "prj_ready_illegal_claim"
+        illegal_claim["claim"] = claim("clm_illegal_ready", "run_illegal_ready")
+        write_document(planner, illegal_claim_path, illegal_claim)
+        mailbox.publish(planner, "publish reconstruction states")
+        fresh_audit = clone(remote, root / "fresh-audit")
+        reconstructed = {validate_lifecycle(fresh_audit, path) for path in state_paths}
+        record(
+            "fresh clone reconstructs all lifecycle states",
+            reconstructed == {"approved", "active", "blocked", "delivered", "accepted"},
+        )
+        ready = derive_ready(
+            fresh_audit,
+            ready_path,
+            policy_gates_satisfied=True,
+            ticket_eligible=True,
+            capability_available=True,
+        )
+        blocked_by_policy = derive_ready(
+            fresh_audit,
+            ready_path,
+            policy_gates_satisfied=False,
+            ticket_eligible=True,
+            capability_available=True,
+        )
+        blocked_by_ticket = derive_ready(
+            fresh_audit,
+            ready_path,
+            policy_gates_satisfied=True,
+            ticket_eligible=False,
+            capability_available=True,
+        )
+        blocked_by_capability = derive_ready(
+            fresh_audit,
+            ready_path,
+            policy_gates_satisfied=True,
+            ticket_eligible=True,
+            capability_available=False,
+        )
+        blocked_by_missing_dependency = derive_ready(
+            fresh_audit,
+            missing_dependency_path,
+            policy_gates_satisfied=True,
+            ticket_eligible=True,
+            capability_available=True,
+        )
+        blocked_by_nonaccepted_dependency = derive_ready(
+            fresh_audit,
+            nonaccepted_dependency_path,
+            policy_gates_satisfied=True,
+            ticket_eligible=True,
+            capability_available=True,
+        )
+        blocked_by_nonapproved_status = derive_ready(
+            fresh_audit,
+            state_paths[1],
+            policy_gates_satisfied=True,
+            ticket_eligible=True,
+            capability_available=True,
+        )
+        blocked_by_illegal_claim = derive_ready(
+            fresh_audit,
+            illegal_claim_path,
+            policy_gates_satisfied=True,
+            ticket_eligible=True,
+            capability_available=True,
+        )
+        default_project_approved = state_paths[0]
+        blocked_by_serial_execution = derive_ready(
+            fresh_audit,
+            default_project_approved,
+            policy_gates_satisfied=True,
+            ticket_eligible=True,
+            capability_available=True,
+        )
+        record(
+            "fresh clone derives ready only when every v0 gate passes",
+            ready
+            and not blocked_by_policy
+            and not blocked_by_ticket
+            and not blocked_by_capability
+            and not blocked_by_missing_dependency
+            and not blocked_by_nonaccepted_dependency
+            and not blocked_by_nonapproved_status
+            and not blocked_by_illegal_claim
+            and not blocked_by_serial_execution,
+        )
+        record(
+            "success requires exact remote read-back",
+            mailbox.published == mailbox.readbacks,
+        )
+
+    for index, (name, _) in enumerate(results, start=1):
+        print(f"{index:02d} PASS {name}")
+    print(f"{len(results)} scenarios passed; disposable repositories removed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,11 +5,12 @@ description = "Workspace-based CLI for agent-assisted development"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
+  "click>=8.1.7,<8.2",
   "platformdirs>=4.0.0",
   "pydantic>=2.0.0",
   "questionary>=2.0.0",
   "rich>=13.0.0",
-  "typer>=0.9.0",
+  "typer>=0.9.0,<0.20",
 ]
 license = { text = "MIT" }
 keywords = ["workspace", "git", "agents"]

--- a/src/atelier/cli.py
+++ b/src/atelier/cli.py
@@ -16,11 +16,7 @@ from typing import Annotated, Callable, cast
 
 import click
 import typer
-
-try:
-    from click.shell_completion import split_arg_string
-except ImportError:  # pragma: no cover - legacy Click fallback
-    from click.parser import split_arg_string
+from click.parser import split_arg_string
 
 from . import __version__, bd_invocation, beads, config, git, lifecycle, paths, skills
 from . import log as atelier_log


### PR DESCRIPTION
## TL;DR

Reframes Atelier as a Codex-hosted accountability skill backed by a passive Git mailbox, validates its Agent Scripts composition boundary, and defines—but does not authorize—the legacy reset.

## Summary

- defines `plan`, `work`, and `audit` as the initial skill modes, with durable intent, bounded authority, human-shaped changesets, and operator acceptance distinct from delivery or merge
- specifies the canonical Git mailbox and project-policy contracts without Beads, Dolt, SQLite, a daemon, a server, or a persistent projection
- makes Agent Scripts an independently installed platform dependency and freezes the coordinator-neutral delegated `implement-ticket` contract
- adds a disposable Codex composition plugin that exercises allowed delivery, denied PR mutation, exact candidate acknowledgement, isolated review, terminal validation, and seven negative probes
- records the final 9/9 verifier evidence, its adversarial-review limits, and the durable archived evidence checksums
- proposes the implementation graph and maps all 43 live legacy issues to `superseded`, `cancelled`, retained doctrine, or newly represented work
- fixes `c08755f3a80c39b747df4cbf9be94e559d5081e2` as the proposed `atelier-cli-v2-final` target and defines exact deletion, retention, preflight, and rollback boundaries

## Accountability boundary

Merging this pull request does not authorize creation of the archival tag, tracker mutation, legacy issue closure, or removal of the current implementation. Those actions remain behind the second explicit reset confirmation required by the reset-gate proposal.

## Validation

- composition verifier: 9 passed, 0 failed
- independent composition adversarial review: PASS WITH FOLLOWUPS, with all overclaim corrections recorded
- independent reset-gate adversarial review: PASS
- `just format`
- `just lint`
- `just test` with installed `bd`: 1,746 passed, 1 failed because Beads requires an unavailable Dolt server
- server-free `just test` with only `bd` excluded: 1,746 passed, 1 skipped; all 18 shell tests passed