### PR TITLE
feat(host): discover the Codex host boundary

### DIFF
--- a/contract_tests/test_host_boundary.py
+++ b/contract_tests/test_host_boundary.py
@@ -7,6 +7,7 @@ import importlib.util
 import json
 import tempfile
 import unittest
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import ModuleType
 
@@ -197,6 +198,7 @@ class HostBoundaryContract(unittest.TestCase):
         )
         for name in (
             "CONTRACT.md",
+            "capability.schema.json",
             "checkpoint-request.schema.json",
             "checkpoint-response.schema.json",
             "result.schema.json",
@@ -235,6 +237,9 @@ class HostBoundaryContract(unittest.TestCase):
         }
         self.manifest_path = capability_root / "capability.json"
         write_json(self.manifest_path, manifest)
+        bundle_sha256 = {
+            name: sha256(capability_root / name) for name in HOST_BOUNDARY.BUNDLE_FILES
+        }
 
         self.schema_path = self.root / "github-observation.schema.json"
         write_json(self.schema_path, {"type": "object"})
@@ -250,11 +255,16 @@ class HostBoundaryContract(unittest.TestCase):
                 "skill_sha256": sha256(self.skill_file),
                 "capability_manifest": ("references/delegated-execution/capability.json"),
                 "capability_manifest_sha256": sha256(self.manifest_path),
+                "bundle_sha256": bundle_sha256,
             },
             "native_state": {
                 "access": "read-only",
                 "connector": "github@openai-curated",
                 "observation_schema": self.schema_path.name,
+                "freshness": {
+                    "max_age_seconds": 300,
+                    "max_future_skew_seconds": 5,
+                },
                 "required_operations": REQUIRED_OPERATIONS,
             },
             "native_state_access": "read-only",
@@ -278,6 +288,30 @@ class HostBoundaryContract(unittest.TestCase):
         path = self.root / "observation.json"
         write_json(path, value)
         return path
+
+    def validate_observation(
+        self,
+        value: dict[str, object],
+        *,
+        not_before: datetime | None = None,
+        now: datetime | None = None,
+    ) -> dict[str, object]:
+        """Validate an observation against a deterministic live-read window."""
+        read_boundary = not_before or datetime(2026, 7, 27, 3, tzinfo=UTC)
+        validation_time = now or read_boundary + timedelta(seconds=30)
+        return HOST_BOUNDARY.validate_observation(
+            self.write_observation(value),
+            not_before=read_boundary,
+            now=validation_time,
+            schema_path=OBSERVATION_SCHEMA,
+        )
+
+    def trust_changed_bundle_file(self, name: str) -> None:
+        """Update the fixture descriptor to trust one intentionally changed file."""
+        descriptor = json.loads(self.descriptor_path.read_text(encoding="utf-8"))
+        capability_root = self.manifest_path.parent
+        descriptor["delegated_skill"]["bundle_sha256"][name] = sha256(capability_root / name)
+        write_json(self.descriptor_path, descriptor)
 
     def test_host_capability_is_published(self) -> None:
         """Require a versioned, fail-closed host capability descriptor."""
@@ -335,7 +369,28 @@ class HostBoundaryContract(unittest.TestCase):
         (self.manifest_path.parent / "result.schema.json").unlink()
         with self.assertRaisesRegex(
             HOST_BOUNDARY.HostBoundaryError,
-            "result_schema missing",
+            "bundle file result.schema.json missing",
+        ):
+            self.check_host()
+
+    def test_changed_result_schema_fails_closed(self) -> None:
+        """Reject a protocol schema whose bytes differ from the pinned bundle."""
+        write_json(self.manifest_path.parent / "result.schema.json", {"type": "string"})
+        with self.assertRaisesRegex(
+            HOST_BOUNDARY.HostBoundaryError,
+            "bundle hash mismatch: result.schema.json",
+        ):
+            self.check_host()
+
+    def test_changed_dependency_validator_fails_closed(self) -> None:
+        """Reject a dependency validator whose bytes differ from the pinned bundle."""
+        (self.manifest_path.parent / "validate.py").write_text(
+            "raise SystemExit(0)\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(
+            HOST_BOUNDARY.HostBoundaryError,
+            "bundle hash mismatch: validate.py",
         ):
             self.check_host()
 
@@ -348,6 +403,7 @@ class HostBoundaryContract(unittest.TestCase):
                 "$defs": {"action": {"enum": AUTHORITY_ACTIONS[:-1]}},
             },
         )
+        self.trust_changed_bundle_file("invocation.schema.json")
         with self.assertRaisesRegex(
             HOST_BOUNDARY.HostBoundaryError,
             "review.resolve",
@@ -357,8 +413,28 @@ class HostBoundaryContract(unittest.TestCase):
     def test_complete_native_observation_passes(self) -> None:
         """Accept complete issue, PR, review, check, and thread evidence."""
         observation = complete_observation()
-        result = HOST_BOUNDARY.validate_observation(self.write_observation(observation))
+        result = self.validate_observation(observation)
         self.assertEqual(result["pull_request"]["head"]["sha"], HEAD_SHA)
+
+    def test_observation_at_read_boundary_passes(self) -> None:
+        """Accept a fresh observation captured exactly at the live-read boundary."""
+        boundary = datetime(2026, 7, 27, 3, tzinfo=UTC)
+        result = self.validate_observation(
+            complete_observation(),
+            not_before=boundary,
+            now=boundary + timedelta(seconds=300),
+        )
+        self.assertEqual(result["observed_at"], "2026-07-27T03:00:00Z")
+
+    def test_observation_before_read_boundary_fails_closed(self) -> None:
+        """Reject structurally valid evidence captured before the current live read."""
+        observation = complete_observation()
+        observation["observed_at"] = "2026-07-27T02:59:59Z"
+        with self.assertRaisesRegex(
+            HOST_BOUNDARY.HostBoundaryError,
+            "predates the live-read boundary",
+        ):
+            self.validate_observation(observation)
 
     def test_unknown_observation_field_fails_closed(self) -> None:
         """Reject provider drift rather than silently ignoring unknown state."""
@@ -368,7 +444,7 @@ class HostBoundaryContract(unittest.TestCase):
             HOST_BOUNDARY.HostBoundaryError,
             r"\$\.unexpected: unknown property",
         ):
-            HOST_BOUNDARY.validate_observation(self.write_observation(observation))
+            self.validate_observation(observation)
 
     def test_check_candidate_mismatch_fails_closed(self) -> None:
         """Bind check observations to the exact pull-request head."""
@@ -378,7 +454,7 @@ class HostBoundaryContract(unittest.TestCase):
             HOST_BOUNDARY.HostBoundaryError,
             "candidate SHA mismatch",
         ):
-            HOST_BOUNDARY.validate_observation(self.write_observation(observation))
+            self.validate_observation(observation)
 
     def test_incomplete_pagination_fails_closed(self) -> None:
         """Reject a partial collection even when its visible items are valid."""
@@ -388,7 +464,7 @@ class HostBoundaryContract(unittest.TestCase):
             HOST_BOUNDARY.HostBoundaryError,
             r"\$\.completeness\.threads: expected constant True",
         ):
-            HOST_BOUNDARY.validate_observation(self.write_observation(observation))
+            self.validate_observation(observation)
 
     def test_pull_request_collections_require_pull_request_identity(self) -> None:
         """Do not accept orphaned review evidence."""
@@ -398,7 +474,7 @@ class HostBoundaryContract(unittest.TestCase):
             HOST_BOUNDARY.HostBoundaryError,
             "collections require pull_request identity",
         ):
-            HOST_BOUNDARY.validate_observation(self.write_observation(observation))
+            self.validate_observation(observation)
 
 
 if __name__ == "__main__":

--- a/contract_tests/test_host_boundary.py
+++ b/contract_tests/test_host_boundary.py
@@ -1,23 +1,287 @@
-"""Executable contract for the first skill-based Atelier changeset."""
+"""Executable contract for the Codex host boundary."""
 
 from __future__ import annotations
 
+import hashlib
+import importlib.util
 import json
+import tempfile
 import unittest
 from pathlib import Path
+from types import ModuleType
 
 ROOT = Path(__file__).resolve().parents[1]
 HOST_CAPABILITY = ROOT / "skills" / "atelier" / "references" / "host-capability.json"
+OBSERVATION_SCHEMA = ROOT / "skills" / "atelier" / "references" / "github-observation.schema.json"
+HOST_BOUNDARY_MODULE = ROOT / "skills" / "atelier" / "scripts" / "host_boundary.py"
+REQUIRED_OPERATIONS = [
+    "github.issue.read",
+    "github.issue.relationships.read",
+    "github.pull-request.read",
+    "github.pull-request.comments.read",
+    "github.pull-request.reviews.read",
+    "github.pull-request.checks.read",
+    "github.pull-request.threads.read",
+]
+HEAD_SHA = "a" * 40
+BASE_SHA = "b" * 40
+AUTHORITY_ACTIONS = [
+    "repository.candidate.create",
+    "repository.candidate.push",
+    "pull_request.create",
+    "pull_request.update",
+    "review.reply",
+    "review.resolve",
+]
+
+
+def load_host_boundary() -> ModuleType:
+    """Load the skill-local helper without making the skill a Python package."""
+    spec = importlib.util.spec_from_file_location("atelier_host_boundary", HOST_BOUNDARY_MODULE)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load host boundary helper")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+HOST_BOUNDARY = load_host_boundary()
+
+
+def write_json(path: Path, value: object) -> None:
+    """Write one deterministic test fixture."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def sha256(path: Path) -> str:
+    """Hash one fixture file."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def issue_reference(number: int) -> dict[str, object]:
+    """Return one normalized native issue reference."""
+    return {
+        "id": f"issue-{number}",
+        "number": number,
+        "title": f"Issue {number}",
+        "state": "OPEN",
+        "url": f"https://github.com/shaug/atelier/issues/{number}",
+    }
+
+
+def comment(identifier: str) -> dict[str, object]:
+    """Return one normalized comment."""
+    return {
+        "id": identifier,
+        "author": "reviewer",
+        "body": "Evidence.",
+        "created_at": "2026-07-27T03:00:00Z",
+        "updated_at": "2026-07-27T03:00:00Z",
+        "url": f"https://github.com/shaug/atelier/{identifier}",
+    }
+
+
+def complete_observation() -> dict[str, object]:
+    """Return a complete exact-candidate observation."""
+    issue = issue_reference(774)
+    issue.update(
+        {
+            "body": "Discover the host boundary.",
+            "updated_at": "2026-07-27T03:00:00Z",
+            "parent": issue_reference(772),
+            "sub_issues": [],
+            "blocked_by": [issue_reference(773)],
+            "blocking": [issue_reference(777)],
+        }
+    )
+    return {
+        "schema": "atelier.github-observation/v1",
+        "observed_at": "2026-07-27T03:00:00Z",
+        "repository": {
+            "id": "repository-atelier",
+            "name_with_owner": "shaug/atelier",
+            "url": "https://github.com/shaug/atelier",
+        },
+        "issue": issue,
+        "issue_comments": [],
+        "pull_request": {
+            "id": "pull-request-785",
+            "number": 785,
+            "title": "Discover the Codex host boundary",
+            "body": "Fixes #774",
+            "url": "https://github.com/shaug/atelier/pull/785",
+            "state": "OPEN",
+            "is_draft": False,
+            "merged": False,
+            "mergeable": "MERGEABLE",
+            "merge_state_status": "CLEAN",
+            "review_decision": None,
+            "base": {
+                "repository": "shaug/atelier",
+                "ref": "refs/heads/main",
+                "sha": BASE_SHA,
+            },
+            "head": {
+                "repository": "shaug/atelier",
+                "ref": "refs/heads/scott/issue-774-host-boundary",
+                "sha": HEAD_SHA,
+            },
+            "updated_at": "2026-07-27T03:00:00Z",
+        },
+        "pull_request_comments": [comment("comment-1")],
+        "reviews": [
+            {
+                "id": "review-1",
+                "pull_request_number": 785,
+                "author": "reviewer",
+                "state": "APPROVED",
+                "body": "Looks good.",
+                "submitted_at": "2026-07-27T03:00:00Z",
+                "commit_sha": HEAD_SHA,
+                "url": "https://github.com/shaug/atelier/pull/785#review-1",
+            }
+        ],
+        "checks": [
+            {
+                "id": "check-1",
+                "pull_request_number": 785,
+                "kind": "CHECK_RUN",
+                "name": "test",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "candidate_sha": HEAD_SHA,
+                "details_url": "https://github.com/shaug/atelier/actions/runs/1",
+            }
+        ],
+        "threads": [
+            {
+                "id": "thread-1",
+                "pull_request_number": 785,
+                "is_resolved": True,
+                "is_outdated": False,
+                "path": "skills/atelier/SKILL.md",
+                "line": 20,
+                "start_line": None,
+                "comments": [comment("thread-comment-1")],
+            }
+        ],
+        "completeness": {
+            "issue": True,
+            "issue_comments": True,
+            "issue_relationships": True,
+            "pull_request": True,
+            "pull_request_comments": True,
+            "reviews": True,
+            "checks": True,
+            "threads": True,
+        },
+    }
 
 
 class HostBoundaryContract(unittest.TestCase):
-    """Define the missing capability that issue 774 must implement."""
+    """Define the production boundary implemented by issue 774."""
 
-    @unittest.expectedFailure
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temporary.cleanup)
+        self.root = Path(self.temporary.name)
+        self.skill_root = self.root / "installed-implement-ticket"
+        capability_root = self.skill_root / "references" / "delegated-execution"
+        capability_root.mkdir(parents=True)
+
+        self.skill_file = self.skill_root / "SKILL.md"
+        self.skill_file.write_text(
+            "---\nname: implement-ticket\ndescription: fixture\n---\n",
+            encoding="utf-8",
+        )
+        for name in (
+            "CONTRACT.md",
+            "checkpoint-request.schema.json",
+            "checkpoint-response.schema.json",
+            "result.schema.json",
+        ):
+            path = capability_root / name
+            if name.endswith(".json"):
+                write_json(path, {"type": "object"})
+            else:
+                path.write_text("# Contract\n", encoding="utf-8")
+        write_json(
+            capability_root / "invocation.schema.json",
+            {
+                "type": "object",
+                "$defs": {"action": {"enum": AUTHORITY_ACTIONS}},
+            },
+        )
+        validator = capability_root / "validate.py"
+        validator.write_text(
+            "import json, sys\n"
+            "value = json.load(open(sys.argv[2], encoding='utf-8'))\n"
+            "raise SystemExit(0 if value.get('id') == "
+            "'agent-scripts.implement-ticket/delegated-execution/v1' else 1)\n",
+            encoding="utf-8",
+        )
+        manifest = {
+            "schema": "agent-scripts.implement-ticket/capability-manifest/v1",
+            "id": "agent-scripts.implement-ticket/delegated-execution/v1",
+            "contract": "CONTRACT.md",
+            "invocation_schema": "invocation.schema.json",
+            "checkpoint_request_schema": "checkpoint-request.schema.json",
+            "checkpoint_response_schema": "checkpoint-response.schema.json",
+            "result_schema": "result.schema.json",
+            "validator": "validate.py",
+            "terminal_states": ["ready_pr", "blocked", "requires_epic"],
+            "checkpoint_phases": ["pre_external_mutation", "candidate_published"],
+        }
+        self.manifest_path = capability_root / "capability.json"
+        write_json(self.manifest_path, manifest)
+
+        self.schema_path = self.root / "github-observation.schema.json"
+        write_json(self.schema_path, {"type": "object"})
+        descriptor = {
+            "schema": "atelier.host-capability/v1",
+            "reference_host": "codex",
+            "delegated_capability": ("agent-scripts.implement-ticket/delegated-execution/v1"),
+            "delegated_authority_actions": AUTHORITY_ACTIONS,
+            "accepted_terminal_states": ["ready_pr", "blocked", "requires_epic"],
+            "delegated_skill": {
+                "stable_name": "agent-scripts:implement-ticket",
+                "frontmatter_name": "implement-ticket",
+                "skill_sha256": sha256(self.skill_file),
+                "capability_manifest": ("references/delegated-execution/capability.json"),
+                "capability_manifest_sha256": sha256(self.manifest_path),
+            },
+            "native_state": {
+                "access": "read-only",
+                "connector": "github@openai-curated",
+                "observation_schema": self.schema_path.name,
+                "required_operations": REQUIRED_OPERATIONS,
+            },
+            "native_state_access": "read-only",
+            "fallback_to_copied_workflows": False,
+        }
+        self.descriptor_path = self.root / "host-capability.json"
+        write_json(self.descriptor_path, descriptor)
+
+    def check_host(self, *, operations: list[str] | None = None) -> dict[str, object]:
+        """Run the fixture host check."""
+        return HOST_BOUNDARY.check_host(
+            descriptor_path=self.descriptor_path,
+            skill_name="agent-scripts:implement-ticket",
+            skill_root=self.skill_root,
+            connector="github@openai-curated",
+            operations=REQUIRED_OPERATIONS if operations is None else operations,
+        )
+
+    def write_observation(self, value: dict[str, object]) -> Path:
+        """Write one observation fixture."""
+        path = self.root / "observation.json"
+        write_json(path, value)
+        return path
+
     def test_host_capability_is_published(self) -> None:
         """Require a versioned, fail-closed host capability descriptor."""
         payload = json.loads(HOST_CAPABILITY.read_text(encoding="utf-8"))
-
         self.assertEqual(payload["schema"], "atelier.host-capability/v1")
         self.assertEqual(payload["reference_host"], "codex")
         self.assertEqual(
@@ -26,6 +290,115 @@ class HostBoundaryContract(unittest.TestCase):
         )
         self.assertEqual(payload["native_state_access"], "read-only")
         self.assertFalse(payload["fallback_to_copied_workflows"])
+        self.assertEqual(
+            payload["delegated_skill"]["stable_name"],
+            "agent-scripts:implement-ticket",
+        )
+        self.assertEqual(payload["delegated_authority_actions"], AUTHORITY_ACTIONS)
+        self.assertEqual(
+            payload["native_state"]["required_operations"],
+            REQUIRED_OPERATIONS,
+        )
+        self.assertIsInstance(
+            json.loads(OBSERVATION_SCHEMA.read_text(encoding="utf-8")),
+            dict,
+        )
+
+    def test_exact_dependency_and_read_operations_pass(self) -> None:
+        """Accept only the exact skill, manifest, connector, and read surface."""
+        result = self.check_host()
+        self.assertEqual(result["status"], "compatible")
+        self.assertEqual(result["native_state_access"], "read-only")
+
+    def test_missing_read_operation_fails_closed(self) -> None:
+        """Reject a host that cannot provide one required observation category."""
+        with self.assertRaisesRegex(
+            HOST_BOUNDARY.HostBoundaryError,
+            "github.pull-request.threads.read",
+        ):
+            self.check_host(operations=REQUIRED_OPERATIONS[:-1])
+
+    def test_changed_installed_skill_fails_closed(self) -> None:
+        """Reject a same-named but content-mismatched installed skill."""
+        self.skill_file.write_text(
+            self.skill_file.read_text(encoding="utf-8") + "\nchanged\n",
+            encoding="utf-8",
+        )
+        with self.assertRaisesRegex(
+            HOST_BOUNDARY.HostBoundaryError,
+            "installed skill hash mismatch",
+        ):
+            self.check_host()
+
+    def test_missing_capability_schema_fails_closed(self) -> None:
+        """Reject a manifest whose versioned protocol is incomplete."""
+        (self.manifest_path.parent / "result.schema.json").unlink()
+        with self.assertRaisesRegex(
+            HOST_BOUNDARY.HostBoundaryError,
+            "result_schema missing",
+        ):
+            self.check_host()
+
+    def test_missing_authority_action_fails_closed(self) -> None:
+        """Reject a dependency that cannot enforce the approved v0 vocabulary."""
+        write_json(
+            self.manifest_path.parent / "invocation.schema.json",
+            {
+                "type": "object",
+                "$defs": {"action": {"enum": AUTHORITY_ACTIONS[:-1]}},
+            },
+        )
+        with self.assertRaisesRegex(
+            HOST_BOUNDARY.HostBoundaryError,
+            "review.resolve",
+        ):
+            self.check_host()
+
+    def test_complete_native_observation_passes(self) -> None:
+        """Accept complete issue, PR, review, check, and thread evidence."""
+        observation = complete_observation()
+        result = HOST_BOUNDARY.validate_observation(self.write_observation(observation))
+        self.assertEqual(result["pull_request"]["head"]["sha"], HEAD_SHA)
+
+    def test_unknown_observation_field_fails_closed(self) -> None:
+        """Reject provider drift rather than silently ignoring unknown state."""
+        observation = complete_observation()
+        observation["unexpected"] = True
+        with self.assertRaisesRegex(
+            HOST_BOUNDARY.HostBoundaryError,
+            r"\$\.unexpected: unknown property",
+        ):
+            HOST_BOUNDARY.validate_observation(self.write_observation(observation))
+
+    def test_check_candidate_mismatch_fails_closed(self) -> None:
+        """Bind check observations to the exact pull-request head."""
+        observation = complete_observation()
+        observation["checks"][0]["candidate_sha"] = "c" * 40
+        with self.assertRaisesRegex(
+            HOST_BOUNDARY.HostBoundaryError,
+            "candidate SHA mismatch",
+        ):
+            HOST_BOUNDARY.validate_observation(self.write_observation(observation))
+
+    def test_incomplete_pagination_fails_closed(self) -> None:
+        """Reject a partial collection even when its visible items are valid."""
+        observation = complete_observation()
+        observation["completeness"]["threads"] = False
+        with self.assertRaisesRegex(
+            HOST_BOUNDARY.HostBoundaryError,
+            r"\$\.completeness\.threads: expected constant True",
+        ):
+            HOST_BOUNDARY.validate_observation(self.write_observation(observation))
+
+    def test_pull_request_collections_require_pull_request_identity(self) -> None:
+        """Do not accept orphaned review evidence."""
+        observation = complete_observation()
+        observation["pull_request"] = None
+        with self.assertRaisesRegex(
+            HOST_BOUNDARY.HostBoundaryError,
+            "collections require pull_request identity",
+        ):
+            HOST_BOUNDARY.validate_observation(self.write_observation(observation))
 
 
 if __name__ == "__main__":

--- a/skills/atelier/SKILL.md
+++ b/skills/atelier/SKILL.md
@@ -74,7 +74,8 @@ Preserve these boundaries in every future mode:
 - Delivery is not acceptance. Acceptance is not merge, deployment, or native
   ticket completion.
 - Every consequential action is bounded by current authority and fails closed on
-  missing, stale, contradictory, or unverifiable state.
+  missing, pre-read, stale, contradictory, or unverifiable state. Pin the
+  dependency's complete delegated protocol bundle before trusting it.
 - Do not add Beads, Dolt, SQLite, a daemon, a server, a persistent projection,
   or backward compatibility.
 

--- a/skills/atelier/SKILL.md
+++ b/skills/atelier/SKILL.md
@@ -4,8 +4,8 @@ description: >-
   Coordinate accountable software development through durable planning, bounded
   worker delegation, Git-mailbox state, live audit, and explicit operator
   acceptance. Use when the user explicitly invokes Atelier in plan, work, or
-  audit mode, or asks to continue an Atelier-managed initiative across separate
-  Codex tasks.
+  audit mode, asks to inspect Atelier host readiness, or asks to continue an
+  Atelier-managed initiative across separate Codex tasks.
 ---
 
 # Atelier
@@ -13,6 +13,32 @@ description: >-
 Atelier is a workflow framework for development at the speed of accountability.
 It separates durable intent, delegated implementation, current evidence, and
 human acceptance across agentic tasks.
+
+## Host boundary
+
+Codex is the v0 reference host. Before reading native project state or invoking
+future delegation behavior, read `references/host-boundary.md` and complete its
+fail-closed startup preflight.
+
+The preflight must prove:
+
+- the exact plugin-qualified `agent-scripts:implement-ticket` skill identity;
+- the compatible
+  `agent-scripts.implement-ticket/delegated-execution/v1` manifest, schemas, and
+  dependency-owned validator;
+- the six v0 candidate, pull-request, and review authority actions declared by
+  the host capability descriptor;
+- the installed and authorized `github@openai-curated` connector;
+- every required read-only issue, relationship, pull-request, comment, review,
+  check, and thread operation; and
+- one complete observation conforming to
+  `references/github-observation.schema.json` when live state is requested.
+
+Run `scripts/host_boundary.py` exactly as the reference describes. Stop with its
+diagnostic when any identity, operation, schema, pagination result, or
+observation is missing or mismatched. Never scan for a substitute skill, use a
+copied workflow, treat cached prose as native state, or cross into a provider
+mutation.
 
 ## Reset scaffold
 
@@ -30,6 +56,10 @@ When invoked before the required mode is implemented:
    - `work`: shaug/atelier#778 and shaug/atelier#779
    - `audit`: shaug/atelier#780
 1. Make no mailbox, repository, ticket, pull-request, or acceptance mutation.
+
+An explicit host-readiness request may complete the read-only host preflight and
+return its exact compatibility or failure result. That does not make any
+production mode available.
 
 ## Invariants
 

--- a/skills/atelier/references/github-observation.schema.json
+++ b/skills/atelier/references/github-observation.schema.json
@@ -1,0 +1,595 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/shaug/atelier/blob/main/skills/atelier/references/github-observation.schema.json",
+  "title": "Atelier GitHub native-state observation",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "observed_at",
+    "repository",
+    "issue",
+    "issue_comments",
+    "pull_request",
+    "pull_request_comments",
+    "reviews",
+    "checks",
+    "threads",
+    "completeness"
+  ],
+  "properties": {
+    "schema": {
+      "const": "atelier.github-observation/v1"
+    },
+    "observed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "repository": {
+      "$ref": "#/$defs/repository"
+    },
+    "issue": {
+      "$ref": "#/$defs/issue"
+    },
+    "issue_comments": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/comment"
+      }
+    },
+    "pull_request": {
+      "oneOf": [
+        {
+          "$ref": "#/$defs/pull_request"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "pull_request_comments": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/comment"
+      }
+    },
+    "reviews": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/review"
+      }
+    },
+    "checks": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/check"
+      }
+    },
+    "threads": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/thread"
+      }
+    },
+    "completeness": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "issue",
+        "issue_comments",
+        "issue_relationships",
+        "pull_request",
+        "pull_request_comments",
+        "reviews",
+        "checks",
+        "threads"
+      ],
+      "properties": {
+        "issue": {
+          "const": true
+        },
+        "issue_comments": {
+          "const": true
+        },
+        "issue_relationships": {
+          "const": true
+        },
+        "pull_request": {
+          "const": true
+        },
+        "pull_request_comments": {
+          "const": true
+        },
+        "reviews": {
+          "const": true
+        },
+        "checks": {
+          "const": true
+        },
+        "threads": {
+          "const": true
+        }
+      }
+    }
+  },
+  "$defs": {
+    "repository": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name_with_owner",
+        "url"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name_with_owner": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "issue_reference": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "number",
+        "title",
+        "state",
+        "url"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "title": {
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "OPEN",
+            "CLOSED"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "issue": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "number",
+        "title",
+        "state",
+        "url",
+        "body",
+        "updated_at",
+        "parent",
+        "sub_issues",
+        "blocked_by",
+        "blocking"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "title": {
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "OPEN",
+            "CLOSED"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "body": {
+          "type": "string"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "parent": {
+          "oneOf": [
+            {
+              "$ref": "#/$defs/issue_reference"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sub_issues": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/issue_reference"
+          }
+        },
+        "blocked_by": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/issue_reference"
+          }
+        },
+        "blocking": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/issue_reference"
+          }
+        }
+      }
+    },
+    "comment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "author",
+        "body",
+        "created_at",
+        "updated_at",
+        "url"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "author": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "body": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "git_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "repository",
+        "ref",
+        "sha"
+      ],
+      "properties": {
+        "repository": {
+          "type": "string",
+          "pattern": "^[^/]+/[^/]+$"
+        },
+        "ref": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        }
+      }
+    },
+    "pull_request": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "number",
+        "title",
+        "body",
+        "url",
+        "state",
+        "is_draft",
+        "merged",
+        "mergeable",
+        "merge_state_status",
+        "review_decision",
+        "base",
+        "head",
+        "updated_at"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "title": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state": {
+          "enum": [
+            "OPEN",
+            "CLOSED",
+            "MERGED"
+          ]
+        },
+        "is_draft": {
+          "type": "boolean"
+        },
+        "merged": {
+          "type": "boolean"
+        },
+        "mergeable": {
+          "enum": [
+            "MERGEABLE",
+            "CONFLICTING",
+            "UNKNOWN"
+          ]
+        },
+        "merge_state_status": {
+          "type": "string"
+        },
+        "review_decision": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "base": {
+          "$ref": "#/$defs/git_ref"
+        },
+        "head": {
+          "$ref": "#/$defs/git_ref"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "review": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "pull_request_number",
+        "author",
+        "state",
+        "body",
+        "submitted_at",
+        "commit_sha",
+        "url"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pull_request_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "author": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "state": {
+          "type": "string",
+          "minLength": 1
+        },
+        "body": {
+          "type": "string"
+        },
+        "submitted_at": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date-time"
+        },
+        "commit_sha": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "check": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "pull_request_number",
+        "kind",
+        "name",
+        "status",
+        "conclusion",
+        "candidate_sha",
+        "details_url"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pull_request_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "kind": {
+          "enum": [
+            "CHECK_RUN",
+            "STATUS_CONTEXT"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "type": "string",
+          "minLength": 1
+        },
+        "conclusion": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "candidate_sha": {
+          "type": "string",
+          "pattern": "^[0-9a-f]{40}$"
+        },
+        "details_url": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "thread_comment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "author",
+        "body",
+        "created_at",
+        "updated_at",
+        "url"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "author": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "body": {
+          "type": "string"
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "updated_at": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "url": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "thread": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "pull_request_number",
+        "is_resolved",
+        "is_outdated",
+        "path",
+        "line",
+        "start_line",
+        "comments"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "pull_request_number": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "is_resolved": {
+          "type": "boolean"
+        },
+        "is_outdated": {
+          "type": "boolean"
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "line": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "start_line": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "minimum": 1
+        },
+        "comments": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/thread_comment"
+          }
+        }
+      }
+    }
+  }
+}

--- a/skills/atelier/references/host-boundary.md
+++ b/skills/atelier/references/host-boundary.md
@@ -13,9 +13,9 @@ Before native-state inspection or future work delegation:
    Use the exact installed skill root supplied by Codex. A same-named repository
    skill, source checkout, copied directory, or guessed cache path is not an
    installed identity.
-   The helper also verifies that the dependency's invocation schema supports
-   every v0 authority action and terminal state declared by
-   `host-capability.json`.
+   The helper pins the complete delegated-execution contract bundle, then
+   verifies that the dependency's invocation schema supports every v0 authority
+   action and terminal state declared by `host-capability.json`.
 2. Prove that `github@openai-curated` is installed and callable in the current
    Codex task. Connector installation and GitHub authorization are separate
    prerequisites.
@@ -40,16 +40,24 @@ Before native-state inspection or future work delegation:
      --operation github.pull-request.threads.read
    ```
 
-5. Read live GitHub state and normalize it to
+5. Capture a UTC `read_started_at` timestamp immediately before the first live
+   provider read. Read live GitHub state and normalize it to
    `github-observation.schema.json`. Preserve GitHub node IDs, exact candidate
    SHAs, timestamps, native `parent`, `subIssues`, `blockedBy`, and `blocking`
    relationships, and complete pagination. Mark every completeness field true
-   only after the corresponding collection is fully read.
+   only after the corresponding collection is fully read. Set `observed_at`
+   after the last required read completes.
 6. Validate the observation:
 
    ```text
-   python3 scripts/host_boundary.py validate-observation <observation.json>
+   python3 scripts/host_boundary.py validate-observation \
+     <observation.json> \
+     --not-before <read_started_at>
    ```
+
+   The descriptor's deterministic freshness fence accepts observations no more
+   than five minutes old, permits five seconds of future clock skew, and rejects
+   evidence captured before this read boundary.
 
 Delete or retain the temporary observation according to the invoking task's
 artifact policy. It is an observation, not shared Atelier state.
@@ -63,7 +71,8 @@ diagnostic emitted by the helper or name the missing connector operation.
 In particular, fail closed when:
 
 - the plugin-qualified skill name is unavailable or resolves ambiguously;
-- the installed skill or capability manifest hash differs;
+- the installed skill, capability manifest, or delegated protocol bundle hash
+  differs;
 - the dependency-owned manifest validator fails;
 - any manifest-referenced schema, contract, or validator is missing;
 - the GitHub connector identity or authorization cannot be proven;

--- a/skills/atelier/references/host-boundary.md
+++ b/skills/atelier/references/host-boundary.md
@@ -1,0 +1,77 @@
+# Codex host boundary
+
+Atelier's v0 host adapter is instruction-led. Codex supplies installed-skill
+identity and live provider observations; the deterministic helper validates
+them. Atelier does not scan for a convenient substitute, copy Agent Scripts, or
+perform provider mutations through this boundary.
+
+## Startup preflight
+
+Before native-state inspection or future work delegation:
+
+1. Resolve `agent-scripts:implement-ticket` from the current Codex skill catalog.
+   Use the exact installed skill root supplied by Codex. A same-named repository
+   skill, source checkout, copied directory, or guessed cache path is not an
+   installed identity.
+   The helper also verifies that the dependency's invocation schema supports
+   every v0 authority action and terminal state declared by
+   `host-capability.json`.
+2. Prove that `github@openai-curated` is installed and callable in the current
+   Codex task. Connector installation and GitHub authorization are separate
+   prerequisites.
+3. Discover read-only host operations for every logical operation named in
+   `host-capability.json`. Codex may use an authenticated read-only `gh api`
+   query to fill a field the installed connector does not expose, but the
+   connector itself remains required. Never substitute a browser scrape, cached
+   prose, or a mutation tool.
+4. Run the dependency check from this skill directory:
+
+   ```text
+   python3 scripts/host_boundary.py check \
+     --skill-name agent-scripts:implement-ticket \
+     --skill-root <exact-installed-skill-root> \
+     --connector github@openai-curated \
+     --operation github.issue.read \
+     --operation github.issue.relationships.read \
+     --operation github.pull-request.read \
+     --operation github.pull-request.comments.read \
+     --operation github.pull-request.reviews.read \
+     --operation github.pull-request.checks.read \
+     --operation github.pull-request.threads.read
+   ```
+
+5. Read live GitHub state and normalize it to
+   `github-observation.schema.json`. Preserve GitHub node IDs, exact candidate
+   SHAs, timestamps, native `parent`, `subIssues`, `blockedBy`, and `blocking`
+   relationships, and complete pagination. Mark every completeness field true
+   only after the corresponding collection is fully read.
+6. Validate the observation:
+
+   ```text
+   python3 scripts/host_boundary.py validate-observation <observation.json>
+   ```
+
+Delete or retain the temporary observation according to the invoking task's
+artifact policy. It is an observation, not shared Atelier state.
+
+## Failure contract
+
+Stop before claim, delegation, mailbox mutation, provider mutation, delivery,
+or acceptance when any prerequisite is missing or mismatched. Report the exact
+diagnostic emitted by the helper or name the missing connector operation.
+
+In particular, fail closed when:
+
+- the plugin-qualified skill name is unavailable or resolves ambiguously;
+- the installed skill or capability manifest hash differs;
+- the dependency-owned manifest validator fails;
+- any manifest-referenced schema, contract, or validator is missing;
+- the GitHub connector identity or authorization cannot be proven;
+- a required read operation is unavailable;
+- pagination is incomplete;
+- an observation is malformed, stale, or candidate-inconsistent; or
+- only a copied workflow or mutation-capable fallback is available.
+
+The boundary proves compatibility and typed read access only. It does not
+implement `plan`, `work`, `audit`, mailbox writes, delegation, acceptance, or
+any Agent Scripts transitive workflow.

--- a/skills/atelier/references/host-capability.json
+++ b/skills/atelier/references/host-capability.json
@@ -1,0 +1,41 @@
+{
+  "schema": "atelier.host-capability/v1",
+  "reference_host": "codex",
+  "delegated_capability": "agent-scripts.implement-ticket/delegated-execution/v1",
+  "delegated_authority_actions": [
+    "repository.candidate.create",
+    "repository.candidate.push",
+    "pull_request.create",
+    "pull_request.update",
+    "review.reply",
+    "review.resolve"
+  ],
+  "accepted_terminal_states": [
+    "ready_pr",
+    "blocked",
+    "requires_epic"
+  ],
+  "delegated_skill": {
+    "stable_name": "agent-scripts:implement-ticket",
+    "frontmatter_name": "implement-ticket",
+    "skill_sha256": "307b660864b15a167e755d0f47840acb56d20e1e8ec940d110d84548aec85243",
+    "capability_manifest": "references/delegated-execution/capability.json",
+    "capability_manifest_sha256": "551d2e883d226d2a1e7e39eae66eb2bd3d9d88ec18c56cfba190253677e34156"
+  },
+  "native_state": {
+    "access": "read-only",
+    "connector": "github@openai-curated",
+    "observation_schema": "github-observation.schema.json",
+    "required_operations": [
+      "github.issue.read",
+      "github.issue.relationships.read",
+      "github.pull-request.read",
+      "github.pull-request.comments.read",
+      "github.pull-request.reviews.read",
+      "github.pull-request.checks.read",
+      "github.pull-request.threads.read"
+    ]
+  },
+  "native_state_access": "read-only",
+  "fallback_to_copied_workflows": false
+}

--- a/skills/atelier/references/host-capability.json
+++ b/skills/atelier/references/host-capability.json
@@ -20,12 +20,25 @@
     "frontmatter_name": "implement-ticket",
     "skill_sha256": "307b660864b15a167e755d0f47840acb56d20e1e8ec940d110d84548aec85243",
     "capability_manifest": "references/delegated-execution/capability.json",
-    "capability_manifest_sha256": "551d2e883d226d2a1e7e39eae66eb2bd3d9d88ec18c56cfba190253677e34156"
+    "capability_manifest_sha256": "551d2e883d226d2a1e7e39eae66eb2bd3d9d88ec18c56cfba190253677e34156",
+    "bundle_sha256": {
+      "CONTRACT.md": "760601f774a461e7f15b03bb52d284c8fdac0a119a88c63274b8e97fc8c9f016",
+      "capability.schema.json": "16188433bcbf979776a8e56c6905caaf5bede1b3eca8ab51d5798dd4841fb5f0",
+      "invocation.schema.json": "43ae1f337500d5955c9ed9c4c057a2105bc17f951533b095b63c6aea198c71af",
+      "checkpoint-request.schema.json": "d94d38243c411f98b7f9c0169684595b69b3de09655f0c258f7d3522e5354aa9",
+      "checkpoint-response.schema.json": "7e54a12959eaac937d62a97ad736f2bc924cb085df113b87d1272d6b35ed3abb",
+      "result.schema.json": "bc62b055faed7fce8bef4694e8bb9e714ed032092d687befebd549b4cffe21ce",
+      "validate.py": "a9e49308e7165eaa0abd18952f15185dfb463c35c39b38a2933b43147be560c1"
+    }
   },
   "native_state": {
     "access": "read-only",
     "connector": "github@openai-curated",
     "observation_schema": "github-observation.schema.json",
+    "freshness": {
+      "max_age_seconds": 300,
+      "max_future_skew_seconds": 5
+    },
     "required_operations": [
       "github.issue.read",
       "github.issue.relationships.read",

--- a/skills/atelier/scripts/host_boundary.py
+++ b/skills/atelier/scripts/host_boundary.py
@@ -9,7 +9,7 @@ import json
 import re
 import subprocess
 import sys
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 
@@ -32,11 +32,13 @@ EXPECTED_DELEGATED_KEYS = {
     "skill_sha256",
     "capability_manifest",
     "capability_manifest_sha256",
+    "bundle_sha256",
 }
 EXPECTED_NATIVE_STATE_KEYS = {
     "access",
     "connector",
     "observation_schema",
+    "freshness",
     "required_operations",
 }
 CAPABILITY_FILE_FIELDS = (
@@ -47,6 +49,15 @@ CAPABILITY_FILE_FIELDS = (
     "result_schema",
     "validator",
 )
+BUNDLE_FILES = {
+    "CONTRACT.md",
+    "capability.schema.json",
+    "invocation.schema.json",
+    "checkpoint-request.schema.json",
+    "checkpoint-response.schema.json",
+    "result.schema.json",
+    "validate.py",
+}
 
 
 class HostBoundaryError(ValueError):
@@ -86,6 +97,16 @@ def _matches_type(value: Any, expected: str) -> bool:
     if expected == "null":
         return value is None
     return False
+
+
+def _parse_timestamp(value: str, label: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise HostBoundaryError(f"{label} must be an ISO 8601 date-time") from error
+    if parsed.utcoffset() is None:
+        raise HostBoundaryError(f"{label} must include a UTC offset")
+    return parsed
 
 
 def _resolve_schema_ref(schema: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
@@ -137,12 +158,9 @@ def _schema_errors(
                 errors.append(f"{at}: does not match {pattern!r}")
         if schema.get("format") == "date-time":
             try:
-                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-            except ValueError:
-                errors.append(f"{at}: expected ISO 8601 date-time")
-            else:
-                if parsed.utcoffset() is None:
-                    errors.append(f"{at}: date-time must include a UTC offset")
+                _parse_timestamp(value, at)
+            except HostBoundaryError as error:
+                errors.append(str(error))
     if isinstance(value, int) and not isinstance(value, bool):
         if "minimum" in schema and value < schema["minimum"]:
             errors.append(f"{at}: must be at least {schema['minimum']}")
@@ -214,6 +232,30 @@ def load_descriptor(path: Path = DEFAULT_DESCRIPTOR) -> dict[str, Any]:
     _require_exact_keys(native_state, EXPECTED_NATIVE_STATE_KEYS, "native_state")
     if native_state["access"] != "read-only":
         raise HostBoundaryError("native_state.access must be read-only")
+    bundle = delegated["bundle_sha256"]
+    if not isinstance(bundle, dict):
+        raise HostBoundaryError("delegated_skill.bundle_sha256 must be an object")
+    _require_exact_keys(bundle, BUNDLE_FILES, "delegated_skill.bundle_sha256")
+    if any(
+        not isinstance(digest, str) or re.fullmatch(r"[0-9a-f]{64}", digest) is None
+        for digest in bundle.values()
+    ):
+        raise HostBoundaryError("delegated_skill.bundle_sha256 values must be SHA-256 digests")
+    freshness = native_state["freshness"]
+    if not isinstance(freshness, dict):
+        raise HostBoundaryError("native_state.freshness must be an object")
+    _require_exact_keys(
+        freshness,
+        {"max_age_seconds", "max_future_skew_seconds"},
+        "native_state.freshness",
+    )
+    if any(
+        not isinstance(freshness[field], int)
+        or isinstance(freshness[field], bool)
+        or freshness[field] < 0
+        for field in freshness
+    ):
+        raise HostBoundaryError("native_state.freshness values must be nonnegative integers")
     operations = native_state["required_operations"]
     if (
         not isinstance(operations, list)
@@ -280,6 +322,14 @@ def check_host(
         raise HostBoundaryError("delegated capability manifest identifier mismatch")
 
     capability_root = manifest_path.parent
+    for name, expected_digest in delegated["bundle_sha256"].items():
+        bundle_path = _resolve_within(
+            capability_root,
+            name,
+            f"delegated capability bundle file {name}",
+        )
+        if _sha256(bundle_path) != expected_digest:
+            raise HostBoundaryError(f"delegated capability bundle hash mismatch: {name}")
     referenced: dict[str, Path] = {}
     for field in CAPABILITY_FILE_FIELDS:
         relative = manifest.get(field)
@@ -360,6 +410,11 @@ def _require_unique_ids(items: list[dict[str, Any]], label: str) -> None:
 
 def validate_observation(
     path: Path,
+    *,
+    not_before: datetime,
+    now: datetime | None = None,
+    max_age_seconds: int = 300,
+    max_future_skew_seconds: int = 5,
     schema_path: Path = ROOT / "references" / "github-observation.schema.json",
 ) -> dict[str, Any]:
     """Validate one complete, normalized, read-only GitHub observation."""
@@ -371,6 +426,19 @@ def validate_observation(
         if len(errors) > 5:
             detail += f"; and {len(errors) - 5} more"
         raise HostBoundaryError(detail)
+
+    if not_before.utcoffset() is None:
+        raise HostBoundaryError("read boundary must include a UTC offset")
+    validation_time = now or datetime.now(UTC)
+    if validation_time.utcoffset() is None:
+        raise HostBoundaryError("validation time must include a UTC offset")
+    observed_at = _parse_timestamp(value["observed_at"], "observed_at")
+    if observed_at < not_before:
+        raise HostBoundaryError("observation predates the live-read boundary")
+    if observed_at > validation_time + timedelta(seconds=max_future_skew_seconds):
+        raise HostBoundaryError("observation timestamp is implausibly in the future")
+    if validation_time - observed_at > timedelta(seconds=max_age_seconds):
+        raise HostBoundaryError("observation is older than the allowed freshness window")
 
     repository = value["repository"]["name_with_owner"]
     issue = value["issue"]
@@ -421,6 +489,11 @@ def _parser() -> argparse.ArgumentParser:
         help="Validate one normalized GitHub observation",
     )
     observation.add_argument("path", type=Path)
+    observation.add_argument(
+        "--not-before",
+        required=True,
+        help="UTC timestamp captured immediately before the live provider reads",
+    )
     return parser
 
 
@@ -436,7 +509,14 @@ def main() -> int:
                 operations=args.operation,
             )
         else:
-            observation = validate_observation(args.path)
+            descriptor = load_descriptor(args.descriptor)
+            freshness = descriptor["native_state"]["freshness"]
+            observation = validate_observation(
+                args.path,
+                not_before=_parse_timestamp(args.not_before, "--not-before"),
+                max_age_seconds=freshness["max_age_seconds"],
+                max_future_skew_seconds=freshness["max_future_skew_seconds"],
+            )
             pull_request = observation["pull_request"]
             result = {
                 "schema": "atelier.observation-check/v1",

--- a/skills/atelier/scripts/host_boundary.py
+++ b/skills/atelier/scripts/host_boundary.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""Validate Atelier's fail-closed Codex host boundary."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_DESCRIPTOR = ROOT / "references" / "host-capability.json"
+EXPECTED_DESCRIPTOR_KEYS = {
+    "schema",
+    "reference_host",
+    "delegated_capability",
+    "delegated_authority_actions",
+    "accepted_terminal_states",
+    "delegated_skill",
+    "native_state",
+    "native_state_access",
+    "fallback_to_copied_workflows",
+}
+EXPECTED_DELEGATED_KEYS = {
+    "stable_name",
+    "frontmatter_name",
+    "skill_sha256",
+    "capability_manifest",
+    "capability_manifest_sha256",
+}
+EXPECTED_NATIVE_STATE_KEYS = {
+    "access",
+    "connector",
+    "observation_schema",
+    "required_operations",
+}
+CAPABILITY_FILE_FIELDS = (
+    "contract",
+    "invocation_schema",
+    "checkpoint_request_schema",
+    "checkpoint_response_schema",
+    "result_schema",
+    "validator",
+)
+
+
+class HostBoundaryError(ValueError):
+    """A host prerequisite or observation is not trustworthy."""
+
+
+def _read_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise HostBoundaryError(f"{label} unreadable: {error}") from error
+    if not isinstance(value, dict):
+        raise HostBoundaryError(f"{label} must be a JSON object")
+    return value
+
+
+def _require_exact_keys(value: dict[str, Any], expected: set[str], label: str) -> None:
+    missing = sorted(expected - value.keys())
+    unknown = sorted(value.keys() - expected)
+    if missing:
+        raise HostBoundaryError(f"{label} missing fields: {', '.join(missing)}")
+    if unknown:
+        raise HostBoundaryError(f"{label} unknown fields: {', '.join(unknown)}")
+
+
+def _matches_type(value: Any, expected: str) -> bool:
+    if expected == "object":
+        return isinstance(value, dict)
+    if expected == "array":
+        return isinstance(value, list)
+    if expected == "string":
+        return isinstance(value, str)
+    if expected == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected == "boolean":
+        return isinstance(value, bool)
+    if expected == "null":
+        return value is None
+    return False
+
+
+def _resolve_schema_ref(schema: dict[str, Any], root: dict[str, Any]) -> dict[str, Any]:
+    reference = schema.get("$ref")
+    if not reference:
+        return schema
+    prefix = "#/$defs/"
+    if not isinstance(reference, str) or not reference.startswith(prefix):
+        raise HostBoundaryError(f"unsupported observation schema reference: {reference}")
+    name = reference.removeprefix(prefix)
+    try:
+        resolved = root["$defs"][name]
+    except KeyError as error:
+        raise HostBoundaryError(f"missing observation schema definition: {name}") from error
+    if not isinstance(resolved, dict):
+        raise HostBoundaryError(f"observation schema definition {name} must be an object")
+    return resolved
+
+
+def _schema_errors(
+    value: Any,
+    schema: dict[str, Any],
+    root: dict[str, Any],
+    at: str = "$",
+) -> list[str]:
+    schema = _resolve_schema_ref(schema, root)
+    errors: list[str] = []
+    if branches := schema.get("oneOf"):
+        matches = [not _schema_errors(value, branch, root, at) for branch in branches]
+        if matches.count(True) != 1:
+            return [f"{at}: expected exactly one allowed shape"]
+        return []
+
+    expected = schema.get("type")
+    if expected:
+        choices = expected if isinstance(expected, list) else [expected]
+        if not any(_matches_type(value, choice) for choice in choices):
+            return [f"{at}: expected {' or '.join(choices)}"]
+    if "const" in schema and value != schema["const"]:
+        errors.append(f"{at}: expected constant {schema['const']!r}")
+    if "enum" in schema and value not in schema["enum"]:
+        errors.append(f"{at}: expected one of {schema['enum']!r}")
+
+    if isinstance(value, str):
+        if len(value) < schema.get("minLength", 0):
+            errors.append(f"{at}: string is too short")
+        if pattern := schema.get("pattern"):
+            if re.fullmatch(pattern, value) is None:
+                errors.append(f"{at}: does not match {pattern!r}")
+        if schema.get("format") == "date-time":
+            try:
+                parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            except ValueError:
+                errors.append(f"{at}: expected ISO 8601 date-time")
+            else:
+                if parsed.utcoffset() is None:
+                    errors.append(f"{at}: date-time must include a UTC offset")
+    if isinstance(value, int) and not isinstance(value, bool):
+        if "minimum" in schema and value < schema["minimum"]:
+            errors.append(f"{at}: must be at least {schema['minimum']}")
+    if isinstance(value, list):
+        if len(value) < schema.get("minItems", 0):
+            errors.append(f"{at}: expected at least {schema['minItems']} item(s)")
+        if item_schema := schema.get("items"):
+            for index, item in enumerate(value):
+                errors.extend(_schema_errors(item, item_schema, root, f"{at}[{index}]"))
+    if isinstance(value, dict):
+        properties = schema.get("properties", {})
+        for key in schema.get("required", []):
+            if key not in value:
+                errors.append(f"{at}: missing required property {key!r}")
+        if schema.get("additionalProperties") is False:
+            for key in value.keys() - properties.keys():
+                errors.append(f"{at}.{key}: unknown property")
+        for key, child in value.items():
+            if key in properties:
+                errors.extend(_schema_errors(child, properties[key], root, f"{at}.{key}"))
+    return errors
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for chunk in iter(lambda: stream.read(65536), b""):
+                digest.update(chunk)
+    except OSError as error:
+        raise HostBoundaryError(f"cannot hash {path}: {error}") from error
+    return digest.hexdigest()
+
+
+def _resolve_within(root: Path, relative: str, label: str) -> Path:
+    candidate = (root / relative).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError as error:
+        raise HostBoundaryError(f"{label} escapes installed skill root") from error
+    if not candidate.is_file():
+        raise HostBoundaryError(f"{label} missing: {candidate}")
+    return candidate
+
+
+def load_descriptor(path: Path = DEFAULT_DESCRIPTOR) -> dict[str, Any]:
+    """Load and validate the repository-owned host descriptor."""
+    descriptor = _read_object(path, "host capability descriptor")
+    _require_exact_keys(descriptor, EXPECTED_DESCRIPTOR_KEYS, "host capability descriptor")
+    if descriptor["schema"] != "atelier.host-capability/v1":
+        raise HostBoundaryError("unsupported host capability descriptor schema")
+    if descriptor["reference_host"] != "codex":
+        raise HostBoundaryError("reference host must be codex")
+    if (
+        descriptor["delegated_capability"]
+        != "agent-scripts.implement-ticket/delegated-execution/v1"
+    ):
+        raise HostBoundaryError("delegated capability identifier is incompatible")
+    if descriptor["native_state_access"] != "read-only":
+        raise HostBoundaryError("native state access must be read-only")
+    if descriptor["fallback_to_copied_workflows"] is not False:
+        raise HostBoundaryError("copied workflow fallback must be disabled")
+
+    delegated = descriptor["delegated_skill"]
+    native_state = descriptor["native_state"]
+    if not isinstance(delegated, dict) or not isinstance(native_state, dict):
+        raise HostBoundaryError("delegated_skill and native_state must be objects")
+    _require_exact_keys(delegated, EXPECTED_DELEGATED_KEYS, "delegated_skill")
+    _require_exact_keys(native_state, EXPECTED_NATIVE_STATE_KEYS, "native_state")
+    if native_state["access"] != "read-only":
+        raise HostBoundaryError("native_state.access must be read-only")
+    operations = native_state["required_operations"]
+    if (
+        not isinstance(operations, list)
+        or not operations
+        or any(not isinstance(item, str) or not item for item in operations)
+        or len(operations) != len(set(operations))
+    ):
+        raise HostBoundaryError("native_state.required_operations must be unique strings")
+    for field in ("delegated_authority_actions", "accepted_terminal_states"):
+        values = descriptor[field]
+        if (
+            not isinstance(values, list)
+            or not values
+            or any(not isinstance(item, str) or not item for item in values)
+            or len(values) != len(set(values))
+        ):
+            raise HostBoundaryError(f"{field} must be unique strings")
+    return descriptor
+
+
+def check_host(
+    *,
+    descriptor_path: Path,
+    skill_name: str,
+    skill_root: Path,
+    connector: str,
+    operations: list[str],
+) -> dict[str, Any]:
+    """Prove exact dependency identity and required read-only host operations."""
+    descriptor = load_descriptor(descriptor_path)
+    delegated = descriptor["delegated_skill"]
+    native_state = descriptor["native_state"]
+    if skill_name != delegated["stable_name"]:
+        raise HostBoundaryError(
+            f"installed skill name mismatch: expected {delegated['stable_name']}"
+        )
+    if connector != native_state["connector"]:
+        raise HostBoundaryError(
+            f"connector identity mismatch: expected {native_state['connector']}"
+        )
+    missing_operations = sorted(set(native_state["required_operations"]) - set(operations))
+    if missing_operations:
+        raise HostBoundaryError(
+            "missing read-only host operations: " + ", ".join(missing_operations)
+        )
+
+    resolved_root = skill_root.resolve()
+    skill_file = _resolve_within(resolved_root, "SKILL.md", "installed skill")
+    if _sha256(skill_file) != delegated["skill_sha256"]:
+        raise HostBoundaryError("installed skill hash mismatch")
+    first_lines = skill_file.read_text(encoding="utf-8").splitlines()[:4]
+    if f"name: {delegated['frontmatter_name']}" not in first_lines:
+        raise HostBoundaryError("installed skill frontmatter identity mismatch")
+
+    manifest_path = _resolve_within(
+        resolved_root,
+        delegated["capability_manifest"],
+        "delegated capability manifest",
+    )
+    if _sha256(manifest_path) != delegated["capability_manifest_sha256"]:
+        raise HostBoundaryError("delegated capability manifest hash mismatch")
+    manifest = _read_object(manifest_path, "delegated capability manifest")
+    if manifest.get("id") != descriptor["delegated_capability"]:
+        raise HostBoundaryError("delegated capability manifest identifier mismatch")
+
+    capability_root = manifest_path.parent
+    referenced: dict[str, Path] = {}
+    for field in CAPABILITY_FILE_FIELDS:
+        relative = manifest.get(field)
+        if not isinstance(relative, str) or not relative:
+            raise HostBoundaryError(f"delegated capability manifest missing {field}")
+        referenced[field] = _resolve_within(
+            capability_root,
+            relative,
+            f"delegated capability {field}",
+        )
+    for field in (
+        "invocation_schema",
+        "checkpoint_request_schema",
+        "checkpoint_response_schema",
+        "result_schema",
+    ):
+        _read_object(referenced[field], f"delegated capability {field}")
+    invocation_schema = _read_object(
+        referenced["invocation_schema"],
+        "delegated capability invocation_schema",
+    )
+    try:
+        supported_actions = set(invocation_schema["$defs"]["action"]["enum"])
+    except (KeyError, TypeError) as error:
+        raise HostBoundaryError(
+            "delegated invocation schema does not expose authority actions"
+        ) from error
+    missing_actions = sorted(set(descriptor["delegated_authority_actions"]) - supported_actions)
+    if missing_actions:
+        raise HostBoundaryError(
+            "delegated invocation schema lacks authority actions: " + ", ".join(missing_actions)
+        )
+    terminal_states = manifest.get("terminal_states")
+    if not isinstance(terminal_states, list):
+        raise HostBoundaryError("delegated capability manifest missing terminal_states")
+    missing_terminals = sorted(set(descriptor["accepted_terminal_states"]) - set(terminal_states))
+    if missing_terminals:
+        raise HostBoundaryError(
+            "delegated capability manifest lacks terminal states: " + ", ".join(missing_terminals)
+        )
+
+    completed = subprocess.run(
+        [sys.executable, str(referenced["validator"]), "capability", str(manifest_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or completed.stdout.strip() or "no diagnostic"
+        raise HostBoundaryError(f"dependency-owned capability validation failed: {detail}")
+
+    schema_path = _resolve_within(
+        descriptor_path.parent,
+        native_state["observation_schema"],
+        "native-state observation schema",
+    )
+    _read_object(schema_path, "native-state observation schema")
+    return {
+        "schema": "atelier.host-check/v1",
+        "status": "compatible",
+        "reference_host": "codex",
+        "delegated_skill": skill_name,
+        "delegated_capability": descriptor["delegated_capability"],
+        "delegated_authority_actions": descriptor["delegated_authority_actions"],
+        "accepted_terminal_states": descriptor["accepted_terminal_states"],
+        "connector": connector,
+        "native_state_access": "read-only",
+        "operations": sorted(set(native_state["required_operations"])),
+    }
+
+
+def _require_unique_ids(items: list[dict[str, Any]], label: str) -> None:
+    ids = [item["id"] for item in items]
+    duplicates = sorted({identifier for identifier in ids if ids.count(identifier) > 1})
+    if duplicates:
+        raise HostBoundaryError(f"{label} contains duplicate ids: {', '.join(duplicates)}")
+
+
+def validate_observation(
+    path: Path,
+    schema_path: Path = ROOT / "references" / "github-observation.schema.json",
+) -> dict[str, Any]:
+    """Validate one complete, normalized, read-only GitHub observation."""
+    value = _read_object(path, "native-state observation")
+    schema = _read_object(schema_path, "native-state observation schema")
+    errors = _schema_errors(value, schema, schema)
+    if errors:
+        detail = "; ".join(errors[:5])
+        if len(errors) > 5:
+            detail += f"; and {len(errors) - 5} more"
+        raise HostBoundaryError(detail)
+
+    repository = value["repository"]["name_with_owner"]
+    issue = value["issue"]
+    pull_request = value["pull_request"]
+    pr_number = pull_request["number"] if pull_request else None
+    candidate_sha = pull_request["head"]["sha"] if pull_request else None
+    if pull_request is None and any(
+        value[name] for name in ("pull_request_comments", "reviews", "checks", "threads")
+    ):
+        raise HostBoundaryError("pull-request collections require pull_request identity")
+    if pull_request is not None:
+        if pull_request["base"]["repository"] != repository:
+            raise HostBoundaryError("pull_request.base repository identity mismatch")
+        if pull_request["merged"] != (pull_request["state"] == "MERGED"):
+            raise HostBoundaryError("pull_request merged state is inconsistent")
+    for collection in ("issue_comments", "pull_request_comments", "reviews", "checks", "threads"):
+        _require_unique_ids(value[collection], collection)
+    for collection in ("sub_issues", "blocked_by", "blocking"):
+        ids = [item["id"] for item in issue[collection]]
+        if ids != sorted(set(ids)):
+            raise HostBoundaryError(f"issue.{collection} must be unique and sorted by id")
+    for collection in ("reviews", "checks", "threads"):
+        for index, item in enumerate(value[collection]):
+            if item["pull_request_number"] != pr_number:
+                raise HostBoundaryError(f"{collection}[{index}] pull request identity mismatch")
+    for index, check in enumerate(value["checks"]):
+        if check["candidate_sha"] != candidate_sha:
+            raise HostBoundaryError(f"checks[{index}] candidate SHA mismatch")
+    return value
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--descriptor",
+        type=Path,
+        default=DEFAULT_DESCRIPTOR,
+        help="Repository-owned host capability descriptor",
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    check = subparsers.add_parser("check", help="Validate installed host dependencies")
+    check.add_argument("--skill-name", required=True)
+    check.add_argument("--skill-root", required=True, type=Path)
+    check.add_argument("--connector", required=True)
+    check.add_argument("--operation", action="append", default=[])
+    observation = subparsers.add_parser(
+        "validate-observation",
+        help="Validate one normalized GitHub observation",
+    )
+    observation.add_argument("path", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    try:
+        if args.command == "check":
+            result = check_host(
+                descriptor_path=args.descriptor,
+                skill_name=args.skill_name,
+                skill_root=args.skill_root,
+                connector=args.connector,
+                operations=args.operation,
+            )
+        else:
+            observation = validate_observation(args.path)
+            pull_request = observation["pull_request"]
+            result = {
+                "schema": "atelier.observation-check/v1",
+                "status": "valid",
+                "repository": observation["repository"]["name_with_owner"],
+                "issue": observation["issue"]["number"],
+                "pull_request": pull_request["number"] if pull_request else None,
+                "candidate_sha": pull_request["head"]["sha"] if pull_request else None,
+            }
+    except HostBoundaryError as error:
+        print(f"ERROR host-boundary: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## TL;DR

Adds the fail-closed Codex host adapter that verifies the exact installed Agent Scripts protocol and normalizes fresh, typed, read-only GitHub state.

## Summary

- publish a versioned host capability descriptor pinned to the installed `agent-scripts:implement-ticket` skill, manifest, and complete delegated-execution bundle
- validate the required read-only GitHub issue, relationship, pull-request, review, check, comment, and thread observation surface
- reject missing operations, dependency drift, incomplete pagination, candidate mismatches, pre-read evidence, and stale observations with explicit diagnostics
- replace the intentional `HOST` expected failure with executable contract coverage and document the Codex startup preflight

## Validation

- `just lint`
- `just test`
- `ruff check contract_tests/test_host_boundary.py skills/atelier/scripts/host_boundary.py`
- `ruff format --check contract_tests/test_host_boundary.py skills/atelier/scripts/host_boundary.py`
- live compatibility check against installed Agent Scripts `implement-ticket` v0.1.0 and all seven required logical GitHub read operations
- clean repository-owned review of exact head `5d2c7319169e300604d17155405c98eb0d109d0a` against base `6dfe91e15e898d9524d2152d84ea83c57e0fa3e0`

## Non-goals

This does not implement `plan`, `work`, or `audit`; copy Agent Scripts workflows; add provider mutations or non-Codex hosts; restore the legacy CLI; or add a database, daemon, server, or persistent projection.

## Tickets

Fixes #774