### PR TITLE
feat(mailbox): implement verified Git mailbox writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ human acceptance distinct across agentic tasks.
 ## Status
 
 This repository is the post-CLI reset implementation. It contains a valid Codex
-plugin, an explicit `/atelier` skill entrypoint, the Codex host boundary, and
-strict read-only v1 mailbox reconstruction. Production `plan`, `work`, and
-`audit` behavior is intentionally unavailable.
+plugin, an explicit `/atelier` skill entrypoint, the Codex host boundary, strict
+v1 mailbox reconstruction, and verified fast-forward mailbox writes. Production
+`plan`, `work`, and `audit` behavior is intentionally unavailable.
 
 Invoking an unavailable mode fails closed without mutating a mailbox,
 repository, ticket, pull request, or acceptance record.

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -494,6 +494,70 @@ class GitMailboxWriteContract(unittest.TestCase):
             )
         self.assertEqual(self.remote_head(), self.seed_revision)
 
+    def test_deleted_canonical_ref_is_not_recreated_after_fetch(self) -> None:
+        path, content = planner_message(self.work_id, 1)
+
+        def delete_canonical_ref() -> None:
+            git(
+                None,
+                "--git-dir",
+                str(self.remote),
+                "update-ref",
+                "-d",
+                "refs/heads/main",
+            )
+
+        with self.assertRaises(MailboxPersistenceUnknown):
+            self.writer(runner=AdvanceBeforeFirstPush(delete_canonical_ref)).publish(
+                "append after deleted canonical ref",
+                revalidate=lambda context: None,
+                plan=lambda context: TransitionPlan(
+                    "append after deleted canonical ref",
+                    (FileChange(path, content),),
+                ),
+            )
+        missing = run_git(
+            None,
+            ("--git-dir", str(self.remote), "rev-parse", "--verify", "refs/heads/main"),
+        )
+        self.assertNotEqual(missing.returncode, 0)
+
+    def test_rewound_canonical_ref_fails_closed_after_fetch(self) -> None:
+        self._append_instruction(1)
+        fetched_head = self.remote_head()
+        revalidations = 0
+
+        def rewind_canonical_ref() -> None:
+            git(
+                None,
+                "--git-dir",
+                str(self.remote),
+                "update-ref",
+                "refs/heads/main",
+                self.seed_revision,
+                fetched_head,
+            )
+
+        def revalidate(context: TransitionContext) -> None:
+            nonlocal revalidations
+            revalidations += 1
+
+        path, content = planner_message(self.work_id, 2)
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "moved backwards or diverged",
+        ):
+            self.writer(runner=AdvanceBeforeFirstPush(rewind_canonical_ref)).publish(
+                "append after canonical rewind",
+                revalidate=revalidate,
+                plan=lambda context: TransitionPlan(
+                    "append after canonical rewind",
+                    (FileChange(path, content),),
+                ),
+            )
+        self.assertEqual(revalidations, 1)
+        self.assertEqual(self.remote_head(), self.seed_revision)
+
     def test_external_preconditions_are_reread_after_concurrent_update(self) -> None:
         observation = {"ticket": "approved"}
         attempts: list[int] = []

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -20,6 +20,7 @@ from skills.atelier.scripts.git_mailbox import (
     MailboxPersistenceUnknown,
     MailboxRemoteUnavailable,
     MailboxTransitionRejected,
+    PendingWrite,
     TransitionContext,
     TransitionPlan,
     run_git,
@@ -407,6 +408,19 @@ class GitMailboxWriteContract(unittest.TestCase):
         )
         self.assertEqual(ancestor.returncode, 0)
 
+    def test_absent_ambiguous_commit_recovers_as_safely_retryable(self) -> None:
+        path, content = planner_message(self.work_id, 1)
+        pending = PendingWrite(
+            operation="append absent instruction",
+            branch="main",
+            commit="f" * 40,
+            base_revision=self.seed_revision,
+            changes=(FileChange(path, content),),
+        )
+
+        self.assertIsNone(self.writer().recover(pending))
+        self.assertEqual(self.remote_head(), self.seed_revision)
+
     def test_unavailable_remote_never_reports_shared_success(self) -> None:
         missing = self.root / "missing.git"
         writer = GitMailboxWriter(str(missing), "main")
@@ -712,6 +726,43 @@ class GitMailboxWriteContract(unittest.TestCase):
         with self.assertRaises(MailboxTransitionRejected):
             self.writer().publish(
                 "hidden mutation",
+                revalidate=lambda context: None,
+                plan=plan,
+            )
+        self.assertEqual(self.remote_head(), before)
+
+    def test_callback_history_mutation_cannot_publish_an_extra_commit(self) -> None:
+        before = self.remote_head()
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            committed = run_git(
+                context.checkout,
+                (
+                    "-c",
+                    "user.name=Atelier Test",
+                    "-c",
+                    "user.email=atelier-test@invalid",
+                    "commit",
+                    "--quiet",
+                    "--no-gpg-sign",
+                    "--allow-empty",
+                    "-m",
+                    "hidden callback commit",
+                ),
+            )
+            self.assertEqual(committed.returncode, 0)
+            path, content = planner_message(self.work_id, 1)
+            return TransitionPlan(
+                "declared transition",
+                (FileChange(path, content),),
+            )
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "one commit directly atop the fetched base",
+        ):
+            self.writer().publish(
+                "callback history mutation",
                 revalidate=lambda context: None,
                 plan=plan,
             )

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -1,0 +1,538 @@
+"""Executable contract for verified fast-forward Git mailbox writes."""
+
+from __future__ import annotations
+
+import copy
+import subprocess
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from contract_tests import test_mailbox as fixtures
+from skills.atelier.scripts.git_mailbox import (
+    FileChange,
+    GitMailboxWriter,
+    MailboxPersistenceUnknown,
+    MailboxRemoteUnavailable,
+    MailboxTransitionRejected,
+    TransitionContext,
+    TransitionPlan,
+    run_git,
+)
+from skills.atelier.scripts.mailbox import MailboxValidationError
+
+
+def git(cwd: Path | None, *arguments: str) -> subprocess.CompletedProcess[str]:
+    result = run_git(cwd, arguments)
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+    return result
+
+
+def markdown(value: dict[str, Any], body: str = "Fixture.\n") -> str:
+    return f"---\n{fixtures.yaml_text(value)}---\n{body}"
+
+
+def read_markdown(path: Path) -> dict[str, Any]:
+    text = path.read_text(encoding="utf-8")
+    _, frontmatter, _ = text.split("---", 2)
+    value = yaml.safe_load(frontmatter)
+    if not isinstance(value, dict):
+        raise AssertionError("fixture frontmatter is not a mapping")
+    return value
+
+
+def planner_message(work_id: str, number: int) -> tuple[str, str]:
+    message_id = fixtures.identifier("msg", number)
+    value = {
+        "schema": "atelier.message/v1",
+        "id": message_id,
+        "work_id": work_id,
+        "kind": "instruction",
+        "author_role": "planner",
+        "worker_run_id": None,
+        "audience": "worker",
+        "in_reply_to": None,
+        "resolves": None,
+        "blocks": None,
+        "created_at": fixtures.TIMESTAMP,
+        "subject": f"Instruction {number}",
+    }
+    return (
+        f"work/{work_id}/messages/{message_id}.md",
+        markdown(value),
+    )
+
+
+class LostPushResponse:
+    """Let one push succeed, then hide its response and immediate read-back."""
+
+    def __init__(self):
+        self.hide_push = True
+        self.hide_fetch = False
+
+    def __call__(
+        self,
+        cwd: Path | None,
+        arguments: tuple[str, ...] | list[str],
+    ) -> subprocess.CompletedProcess[str]:
+        result = run_git(cwd, arguments)
+        if arguments and arguments[0] == "push" and self.hide_push and result.returncode == 0:
+            self.hide_push = False
+            self.hide_fetch = True
+            return subprocess.CompletedProcess(
+                ["git", *arguments],
+                1,
+                result.stdout,
+                "simulated lost push response",
+            )
+        if arguments and arguments[0] == "fetch" and self.hide_fetch:
+            self.hide_fetch = False
+            return subprocess.CompletedProcess(
+                ["git", *arguments],
+                1,
+                "",
+                "simulated read-back outage",
+            )
+        return result
+
+
+class AdvanceBeforeFirstPush:
+    """Advance the canonical branch and external observation before one stale push."""
+
+    def __init__(
+        self,
+        remote: Path,
+        work_id: str,
+        external_observation: dict[str, str],
+    ):
+        self.remote = remote
+        self.work_id = work_id
+        self.external_observation = external_observation
+        self.advance = True
+
+    def __call__(
+        self,
+        cwd: Path | None,
+        arguments: tuple[str, ...] | list[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if arguments and arguments[0] == "push" and self.advance:
+            self.advance = False
+            self.external_observation["ticket"] = "changed"
+            path, content = planner_message(self.work_id, 99)
+            GitMailboxWriter(str(self.remote), "main").publish(
+                "publish concurrent instruction",
+                revalidate=lambda context: None,
+                plan=lambda context: TransitionPlan(
+                    "publish concurrent instruction",
+                    (FileChange(path, content),),
+                ),
+            )
+        return run_git(cwd, arguments)
+
+
+class GitMailboxWriteContract(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="atelier-git-write-test-")
+        self.root = Path(self.temporary.name)
+        self.remote = self.root / "mailbox.git"
+        git(None, "init", "--bare", "--initial-branch=main", str(self.remote))
+        seed = self.root / "seed"
+        git(None, "clone", str(self.remote), str(seed))
+        mailbox = fixtures.MailboxFixture(seed)
+        self.work_id = mailbox.add_work(1, "approved")
+        self.repository = mailbox.projects[mailbox.works[self.work_id]["project_id"]][
+            "repository"
+        ]
+        git(seed, "add", "-A")
+        git(
+            seed,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "-m",
+            "seed valid mailbox",
+        )
+        git(seed, "push", "origin", "HEAD:main")
+        self.seed_revision = git(seed, "rev-parse", "HEAD").stdout.strip()
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def writer(self, **kwargs: Any) -> GitMailboxWriter:
+        return GitMailboxWriter(str(self.remote), "main", **kwargs)
+
+    def remote_head(self) -> str:
+        return git(None, "--git-dir", str(self.remote), "rev-parse", "main").stdout.strip()
+
+    def test_one_transition_is_committed_and_read_back_exactly(self) -> None:
+        path, content = planner_message(self.work_id, 1)
+        result = self.writer().publish(
+            "append instruction",
+            revalidate=lambda context: None,
+            plan=lambda context: TransitionPlan(
+                "append instruction",
+                (FileChange(path, content),),
+            ),
+        )
+
+        self.assertEqual(result.base_revision, self.seed_revision)
+        self.assertEqual(result.commit, self.remote_head())
+        self.assertEqual(result.attempts, 1)
+        self.assertFalse(result.recovered)
+        shown = git(None, "--git-dir", str(self.remote), "show", f"{result.commit}:{path}")
+        self.assertEqual(shown.stdout, content)
+        parent_count = git(
+            None,
+            "--git-dir",
+            str(self.remote),
+            "rev-list",
+            "--count",
+            f"{self.seed_revision}..{result.commit}",
+        )
+        self.assertEqual(parent_count.stdout.strip(), "1")
+
+    def test_concurrent_independent_messages_are_each_published_once(self) -> None:
+        barrier = threading.Barrier(2)
+        outcomes: list[Any] = []
+
+        def publish(number: int) -> None:
+            path, content = planner_message(self.work_id, number)
+
+            def revalidate(context: TransitionContext) -> None:
+                if context.attempt == 1:
+                    barrier.wait(timeout=5)
+
+            try:
+                outcomes.append(
+                    self.writer().publish(
+                        f"append instruction {number}",
+                        revalidate=revalidate,
+                        plan=lambda context: TransitionPlan(
+                            f"append instruction {number}",
+                            (FileChange(path, content),),
+                        ),
+                    )
+                )
+            except Exception as error:  # pragma: no cover - assertion reports the exception
+                outcomes.append(error)
+
+        threads = [threading.Thread(target=publish, args=(number,)) for number in (1, 2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        self.assertEqual(len(outcomes), 2)
+        self.assertTrue(all(not isinstance(outcome, Exception) for outcome in outcomes), outcomes)
+        self.assertEqual(sorted(outcome.attempts for outcome in outcomes), [1, 2])
+        listing = git(
+            None,
+            "--git-dir",
+            str(self.remote),
+            "ls-tree",
+            "-r",
+            "--name-only",
+            "main",
+            f"work/{self.work_id}/messages",
+        ).stdout.splitlines()
+        self.assertEqual(len(listing), 2)
+        self.assertEqual(len(set(listing)), 2)
+
+    def test_concurrent_claims_have_exactly_one_winner(self) -> None:
+        barrier = threading.Barrier(2)
+        outcomes: list[Any] = []
+
+        def publish(number: int) -> None:
+            def revalidate(context: TransitionContext) -> None:
+                work = read_markdown(context.checkout / f"work/{self.work_id}/work.md")
+                if work["status"] != "approved" or work["claim"] is not None:
+                    raise MailboxTransitionRejected("claim already exists")
+                if context.attempt == 1:
+                    barrier.wait(timeout=5)
+
+            def plan(context: TransitionContext) -> TransitionPlan:
+                work = read_markdown(context.checkout / f"work/{self.work_id}/work.md")
+                work["status"] = "active"
+                work["claim"] = fixtures.claim(
+                    self.repository,
+                    number,
+                    with_candidate=False,
+                )
+                return TransitionPlan(
+                    f"claim work {number}",
+                    (FileChange(f"work/{self.work_id}/work.md", markdown(work)),),
+                )
+
+            try:
+                outcomes.append(
+                    self.writer().publish(
+                        f"claim work {number}",
+                        revalidate=revalidate,
+                        plan=plan,
+                    )
+                )
+            except Exception as error:
+                outcomes.append(error)
+
+        threads = [threading.Thread(target=publish, args=(number,)) for number in (1, 2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=10)
+
+        winners = [outcome for outcome in outcomes if not isinstance(outcome, Exception)]
+        losers = [outcome for outcome in outcomes if isinstance(outcome, Exception)]
+        self.assertEqual(len(winners), 1, outcomes)
+        self.assertEqual(len(losers), 1, outcomes)
+        self.assertIsInstance(losers[0], MailboxTransitionRejected)
+        fresh = self.root / "fresh-claim"
+        git(None, "clone", str(self.remote), str(fresh))
+        snapshot = fixtures.MAILBOX.reconstruct_mailbox(fresh)
+        self.assertEqual(snapshot["views"]["active"], [self.work_id])
+
+    def test_atomic_multi_document_transition_is_valid_in_a_fresh_clone(self) -> None:
+        claim_result = self._claim()
+        blocker_id = fixtures.identifier("msg", 9)
+        receipt_id = fixtures.identifier("rcp", 9)
+
+        def revalidate(context: TransitionContext) -> None:
+            work = read_markdown(context.checkout / f"work/{self.work_id}/work.md")
+            if work["claim"]["id"] != claim_result["claim_id"]:
+                raise MailboxTransitionRejected("claim changed")
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            work_path = f"work/{self.work_id}/work.md"
+            work = read_markdown(context.checkout / work_path)
+            work["status"] = "blocked"
+            work["blocking_message_id"] = blocker_id
+            work["attempt_receipt_id"] = receipt_id
+            message = {
+                "schema": "atelier.message/v1",
+                "id": blocker_id,
+                "work_id": self.work_id,
+                "kind": "needs-decision",
+                "author_role": "worker",
+                "worker_run_id": work["claim"]["worker_run_id"],
+                "audience": "planner",
+                "in_reply_to": None,
+                "resolves": None,
+                "blocks": "worker",
+                "created_at": fixtures.TIMESTAMP,
+                "subject": "Choose the bounded behavior",
+            }
+            receipt = fixtures.receipt(
+                work,
+                self.repository,
+                1,
+                outcome="blocked",
+                with_candidate=False,
+            )
+            receipt["id"] = receipt_id
+            return TransitionPlan(
+                "block work atomically",
+                (
+                    FileChange(work_path, markdown(work)),
+                    FileChange(
+                        f"work/{self.work_id}/messages/{blocker_id}.md",
+                        markdown(message),
+                    ),
+                    FileChange(
+                        f"work/{self.work_id}/receipts/{receipt_id}.md",
+                        markdown(receipt),
+                    ),
+                ),
+            )
+
+        result = self.writer().publish(
+            "block work",
+            revalidate=revalidate,
+            plan=plan,
+        )
+        fresh = self.root / "fresh-blocked"
+        git(None, "clone", str(self.remote), str(fresh))
+        snapshot = fixtures.MAILBOX.reconstruct_mailbox(fresh)
+        self.assertEqual(snapshot["views"]["blocked"], [self.work_id])
+        changed = git(
+            None,
+            "--git-dir",
+            str(self.remote),
+            "diff-tree",
+            "--no-commit-id",
+            "--name-only",
+            "-r",
+            result.commit,
+        ).stdout.splitlines()
+        self.assertEqual(len(changed), 3)
+
+    def test_ambiguous_push_recovers_after_later_commit_without_duplication(self) -> None:
+        path, content = planner_message(self.work_id, 1)
+        writer = self.writer(runner=LostPushResponse())
+        with self.assertRaises(MailboxPersistenceUnknown) as raised:
+            writer.publish(
+                "append ambiguous instruction",
+                revalidate=lambda context: None,
+                plan=lambda context: TransitionPlan(
+                    "append ambiguous instruction",
+                    (FileChange(path, content),),
+                ),
+            )
+        pending = raised.exception.pending
+
+        later_path, later_content = planner_message(self.work_id, 2)
+        self.writer().publish(
+            "append later instruction",
+            revalidate=lambda context: None,
+            plan=lambda context: TransitionPlan(
+                "append later instruction",
+                (FileChange(later_path, later_content),),
+            ),
+        )
+        recovered = self.writer().recover(pending)
+
+        self.assertIsNotNone(recovered)
+        self.assertTrue(recovered.recovered)
+        history = git(
+            None,
+            "--git-dir",
+            str(self.remote),
+            "rev-list",
+            "--all",
+            "--",
+            path,
+        ).stdout.splitlines()
+        self.assertEqual(history, [pending.commit])
+        current = git(None, "--git-dir", str(self.remote), "rev-parse", "main").stdout.strip()
+        ancestor = run_git(
+            None,
+            (
+                "--git-dir",
+                str(self.remote),
+                "merge-base",
+                "--is-ancestor",
+                pending.commit,
+                current,
+            ),
+        )
+        self.assertEqual(ancestor.returncode, 0)
+
+    def test_unavailable_remote_never_reports_shared_success(self) -> None:
+        missing = self.root / "missing.git"
+        writer = GitMailboxWriter(str(missing), "main")
+        with self.assertRaises(MailboxRemoteUnavailable):
+            writer.publish(
+                "unavailable transition",
+                revalidate=lambda context: None,
+                plan=lambda context: TransitionPlan(
+                    "unavailable transition",
+                    (FileChange("atelier.yaml", "unreachable"),),
+                ),
+            )
+        self.assertEqual(self.remote_head(), self.seed_revision)
+
+    def test_external_preconditions_are_reread_after_concurrent_update(self) -> None:
+        observation = {"ticket": "approved"}
+        attempts: list[int] = []
+        path, content = planner_message(self.work_id, 1)
+
+        def revalidate(context: TransitionContext) -> None:
+            attempts.append(context.attempt)
+            if observation["ticket"] != "approved":
+                raise MailboxTransitionRejected("material ticket observation changed")
+
+        writer = self.writer(
+            runner=AdvanceBeforeFirstPush(self.remote, self.work_id, observation)
+        )
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "material ticket observation changed",
+        ):
+            writer.publish(
+                "append instruction under approved ticket",
+                revalidate=revalidate,
+                plan=lambda context: TransitionPlan(
+                    "append instruction under approved ticket",
+                    (FileChange(path, content),),
+                ),
+            )
+
+        self.assertEqual(attempts, [1, 2])
+        target = run_git(
+            None,
+            (
+                "--git-dir",
+                str(self.remote),
+                "show",
+                f"main:{path}",
+            ),
+        )
+        self.assertNotEqual(target.returncode, 0)
+        concurrent_path, _ = planner_message(self.work_id, 99)
+        concurrent = git(
+            None,
+            "--git-dir",
+            str(self.remote),
+            "show",
+            f"main:{concurrent_path}",
+        )
+        self.assertTrue(concurrent.stdout)
+
+    def test_invalid_transition_fails_closed_before_push(self) -> None:
+        path = f"work/{fixtures.identifier('wrk', 9)}/work.md"
+        before = self.remote_head()
+        with self.assertRaises(MailboxValidationError):
+            self.writer().publish(
+                "publish unsupported schema",
+                revalidate=lambda context: None,
+                plan=lambda context: TransitionPlan(
+                    "publish unsupported schema",
+                    (
+                        FileChange(
+                            path,
+                            "---\nschema: atelier.work/v2\n---\nUnsupported.\n",
+                        ),
+                    ),
+                ),
+            )
+        self.assertEqual(self.remote_head(), before)
+
+    def test_callback_mutation_is_rejected_before_commit(self) -> None:
+        before = self.remote_head()
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            (context.checkout / "unexpected.txt").write_text("hidden", encoding="utf-8")
+            path, content = planner_message(self.work_id, 1)
+            return TransitionPlan("hidden mutation", (FileChange(path, content),))
+
+        with self.assertRaises(MailboxTransitionRejected):
+            self.writer().publish(
+                "hidden mutation",
+                revalidate=lambda context: None,
+                plan=plan,
+            )
+        self.assertEqual(self.remote_head(), before)
+
+    def _claim(self) -> dict[str, str]:
+        claim_value = fixtures.claim(self.repository, 1, with_candidate=False)
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / f"work/{self.work_id}/work.md")
+            work["status"] = "active"
+            work["claim"] = copy.deepcopy(claim_value)
+            return TransitionPlan(
+                "claim work",
+                (FileChange(f"work/{self.work_id}/work.md", markdown(work)),),
+            )
+
+        self.writer().publish(
+            "claim work",
+            revalidate=lambda context: None,
+            plan=plan,
+        )
+        return {"claim_id": claim_value["id"]}

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+import os
 import subprocess
 import tempfile
 import threading
@@ -1145,6 +1146,58 @@ class GitMailboxWriteContract(unittest.TestCase):
             revalidate=lambda context: None,
             plan=plan,
         )
+
+        self.assertNotEqual(result.commit, canonical_before)
+        self.assertEqual(self.remote_head(), result.commit)
+        alternate_after = git(
+            None,
+            "--git-dir",
+            str(alternate),
+            "rev-parse",
+            "main",
+        ).stdout.strip()
+        self.assertEqual(alternate_after, alternate_before)
+
+    def test_callback_environment_cannot_redirect_canonical_remote(self) -> None:
+        alternate = self.root / "environment-alternate.git"
+        git(None, "clone", "--bare", str(self.remote), str(alternate))
+        canonical_before = self.remote_head()
+        alternate_before = git(
+            None,
+            "--git-dir",
+            str(alternate),
+            "rev-parse",
+            "main",
+        ).stdout.strip()
+        injected_keys = (
+            "GIT_CONFIG_COUNT",
+            "GIT_CONFIG_KEY_0",
+            "GIT_CONFIG_VALUE_0",
+        )
+        original_environment = {key: os.environ.get(key) for key in injected_keys}
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            os.environ["GIT_CONFIG_COUNT"] = "1"
+            os.environ["GIT_CONFIG_KEY_0"] = f"url.{alternate}.insteadOf"
+            os.environ["GIT_CONFIG_VALUE_0"] = str(self.remote)
+            path, content = planner_message(self.work_id, 1)
+            return TransitionPlan(
+                "publish with sealed transport environment",
+                (FileChange(path, content),),
+            )
+
+        try:
+            result = self.writer().publish(
+                "ignore callback transport environment",
+                revalidate=lambda context: None,
+                plan=plan,
+            )
+        finally:
+            for key, value in original_environment.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
 
         self.assertNotEqual(result.commit, canonical_before)
         self.assertEqual(self.remote_head(), result.commit)

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -103,6 +103,37 @@ class LostPushResponse:
         return result
 
 
+class TimeoutAfterSuccessfulPush:
+    """Raise a real timeout after one push has reached the remote."""
+
+    def __init__(self):
+        self.timeout_push = True
+
+    def __call__(
+        self,
+        cwd: Path | None,
+        arguments: tuple[str, ...] | list[str],
+    ) -> subprocess.CompletedProcess[str]:
+        result = run_git(cwd, arguments)
+        if arguments and arguments[0] == "push" and self.timeout_push and result.returncode == 0:
+            self.timeout_push = False
+            raise subprocess.TimeoutExpired(["git", *arguments], timeout=1)
+        return result
+
+
+class FetchTimeout:
+    """Raise a real timeout at the first canonical fetch."""
+
+    def __call__(
+        self,
+        cwd: Path | None,
+        arguments: tuple[str, ...] | list[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if arguments and arguments[0] == "fetch":
+            raise subprocess.TimeoutExpired(["git", *arguments], timeout=1)
+        return run_git(cwd, arguments)
+
+
 class AdvanceBeforeFirstPush:
     """Run one concurrent transition before allowing a stale push to continue."""
 
@@ -407,6 +438,34 @@ class GitMailboxWriteContract(unittest.TestCase):
             ),
         )
         self.assertEqual(ancestor.returncode, 0)
+
+    def test_timeout_after_success_enters_exact_read_back_recovery(self) -> None:
+        path, content = planner_message(self.work_id, 1)
+        result = self.writer(runner=TimeoutAfterSuccessfulPush()).publish(
+            "append timed-out instruction",
+            revalidate=lambda context: None,
+            plan=lambda context: TransitionPlan(
+                "append timed-out instruction",
+                (FileChange(path, content),),
+            ),
+        )
+
+        self.assertTrue(result.recovered)
+        self.assertEqual(result.commit, self.remote_head())
+        shown = git(None, "--git-dir", str(self.remote), "show", f"{result.commit}:{path}")
+        self.assertEqual(shown.stdout, content)
+
+    def test_fetch_timeout_fails_as_unavailable_current_state(self) -> None:
+        with self.assertRaises(MailboxRemoteUnavailable):
+            self.writer(runner=FetchTimeout()).publish(
+                "unavailable fetch",
+                revalidate=lambda context: None,
+                plan=lambda context: TransitionPlan(
+                    "unavailable fetch",
+                    (FileChange("atelier.yaml", "unreachable"),),
+                ),
+            )
+        self.assertEqual(self.remote_head(), self.seed_revision)
 
     def test_absent_ambiguous_commit_recovers_as_safely_retryable(self) -> None:
         path, content = planner_message(self.work_id, 1)
@@ -789,6 +848,53 @@ class GitMailboxWriteContract(unittest.TestCase):
                 plan=plan,
             )
         self.assertEqual(self.remote_head(), before)
+
+    def test_commit_hook_content_mutation_fails_before_push(self) -> None:
+        before = self.remote_head()
+        path, content = planner_message(self.work_id, 1)
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            hook = context.checkout / ".git" / "hooks" / "pre-commit"
+            hook.write_text(
+                "#!/bin/sh\n"
+                f"printf 'corrupted\\n' > {path}\n"
+                f"git add -- {path}\n",
+                encoding="utf-8",
+            )
+            hook.chmod(0o700)
+            return TransitionPlan(
+                "declared transition",
+                (FileChange(path, content),),
+            )
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "committed mailbox content differs",
+        ):
+            self.writer().publish(
+                "commit hook content mutation",
+                revalidate=lambda context: None,
+                plan=plan,
+            )
+        self.assertEqual(self.remote_head(), before)
+
+    def test_option_looking_remote_is_rejected_before_git_runs(self) -> None:
+        calls: list[tuple[str, ...]] = []
+
+        def recording_runner(
+            cwd: Path | None,
+            arguments: tuple[str, ...] | list[str],
+        ) -> subprocess.CompletedProcess[str]:
+            calls.append(tuple(arguments))
+            return run_git(cwd, arguments)
+
+        with self.assertRaisesRegex(ValueError, "must not begin"):
+            GitMailboxWriter(
+                "--upload-pack=/tmp/untrusted",
+                "main",
+                runner=recording_runner,
+            )
+        self.assertEqual(calls, [])
 
     def _append_instruction(self, number: int) -> None:
         path, content = planner_message(self.work_id, number)

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -153,6 +153,30 @@ class AdvanceBeforeFirstPush:
         return run_git(cwd, arguments)
 
 
+class AdvanceThenRewindBeforeRetry:
+    """Advance before the first push, then rewind before the retry fetch."""
+
+    def __init__(self, advance: Callable[[], None], rewind: Callable[[], None]):
+        self._advance = advance
+        self._rewind = rewind
+        self._advanced = False
+        self._fetches = 0
+
+    def __call__(
+        self,
+        cwd: Path | None,
+        arguments: tuple[str, ...] | list[str],
+    ) -> subprocess.CompletedProcess[str]:
+        if arguments and arguments[0] == "push" and not self._advanced:
+            self._advanced = True
+            self._advance()
+        if arguments and arguments[0] == "fetch":
+            self._fetches += 1
+            if self._fetches == 3:
+                self._rewind()
+        return run_git(cwd, arguments)
+
+
 class GitMailboxWriteContract(unittest.TestCase):
     def setUp(self) -> None:
         self.temporary = tempfile.TemporaryDirectory(prefix="atelier-git-write-test-")
@@ -603,6 +627,49 @@ class GitMailboxWriteContract(unittest.TestCase):
                 revalidate=revalidate,
                 plan=lambda context: TransitionPlan(
                     "append after canonical rewind",
+                    (FileChange(path, content),),
+                ),
+            )
+        self.assertEqual(revalidations, 1)
+        self.assertEqual(self.remote_head(), self.seed_revision)
+
+    def test_retry_rejects_rewind_after_observing_concurrent_advance(self) -> None:
+        advanced_head: str | None = None
+        revalidations = 0
+
+        def advance() -> None:
+            nonlocal advanced_head
+            self._append_instruction(99)
+            advanced_head = self.remote_head()
+
+        def rewind() -> None:
+            if advanced_head is None:
+                raise AssertionError("concurrent advance was not observed")
+            git(
+                None,
+                "--git-dir",
+                str(self.remote),
+                "update-ref",
+                "refs/heads/main",
+                self.seed_revision,
+                advanced_head,
+            )
+
+        def revalidate(context: TransitionContext) -> None:
+            nonlocal revalidations
+            revalidations += 1
+
+        path, content = planner_message(self.work_id, 1)
+        runner = AdvanceThenRewindBeforeRetry(advance, rewind)
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "moved backwards or diverged",
+        ):
+            self.writer(runner=runner).publish(
+                "append across observed rewind",
+                revalidate=revalidate,
+                plan=lambda context: TransitionPlan(
+                    "append across observed rewind",
                     (FileChange(path, content),),
                 ),
             )

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -1041,6 +1041,7 @@ class GitMailboxWriteContract(unittest.TestCase):
         before = self.remote_head()
 
         def plan(context: TransitionContext) -> TransitionPlan:
+            self.assertFalse((context.checkout / ".git").exists())
             committed = run_git(
                 context.checkout,
                 (
@@ -1056,30 +1057,36 @@ class GitMailboxWriteContract(unittest.TestCase):
                     "hidden callback commit",
                 ),
             )
-            self.assertEqual(committed.returncode, 0)
+            self.assertNotEqual(committed.returncode, 0)
             path, content = planner_message(self.work_id, 1)
             return TransitionPlan(
                 "declared transition",
                 (FileChange(path, content),),
             )
 
-        with self.assertRaisesRegex(
-            MailboxTransitionRejected,
-            "one commit directly atop the fetched base",
-        ):
-            self.writer().publish(
-                "callback history mutation",
-                revalidate=lambda context: None,
-                plan=plan,
-            )
-        self.assertEqual(self.remote_head(), before)
+        result = self.writer().publish(
+            "callback history mutation",
+            revalidate=lambda context: None,
+            plan=plan,
+        )
+        self.assertEqual(self.remote_head(), result.commit)
+        commit_count = git(
+            None,
+            "--git-dir",
+            str(self.remote),
+            "rev-list",
+            "--count",
+            f"{before}..main",
+        )
+        self.assertEqual(commit_count.stdout.strip(), "1")
 
-    def test_commit_hook_content_mutation_fails_before_push(self) -> None:
+    def test_callback_cannot_install_commit_hook_in_writer_checkout(self) -> None:
         before = self.remote_head()
         path, content = planner_message(self.work_id, 1)
 
         def plan(context: TransitionContext) -> TransitionPlan:
             hook = context.checkout / ".git" / "hooks" / "pre-commit"
+            hook.parent.mkdir(parents=True)
             hook.write_text(
                 "#!/bin/sh\n"
                 f"printf 'corrupted\\n' > {path}\n"
@@ -1094,7 +1101,7 @@ class GitMailboxWriteContract(unittest.TestCase):
 
         with self.assertRaisesRegex(
             MailboxTransitionRejected,
-            "committed mailbox content differs",
+            "mutated its read-only context",
         ):
             self.writer().publish(
                 "commit hook content mutation",
@@ -1102,6 +1109,53 @@ class GitMailboxWriteContract(unittest.TestCase):
                 plan=plan,
             )
         self.assertEqual(self.remote_head(), before)
+
+    def test_callback_git_config_cannot_redirect_canonical_remote(self) -> None:
+        alternate = self.root / "alternate.git"
+        git(None, "clone", "--bare", str(self.remote), str(alternate))
+        canonical_before = self.remote_head()
+        alternate_before = git(
+            None,
+            "--git-dir",
+            str(alternate),
+            "rev-parse",
+            "main",
+        ).stdout.strip()
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            self.assertFalse((context.checkout / ".git").exists())
+            redirected = run_git(
+                context.checkout,
+                (
+                    "config",
+                    "--local",
+                    f"url.{alternate}.insteadOf",
+                    str(self.remote),
+                ),
+            )
+            self.assertNotEqual(redirected.returncode, 0)
+            path, content = planner_message(self.work_id, 1)
+            return TransitionPlan(
+                "publish without transport redirect",
+                (FileChange(path, content),),
+            )
+
+        result = self.writer().publish(
+            "reject callback transport redirect",
+            revalidate=lambda context: None,
+            plan=plan,
+        )
+
+        self.assertNotEqual(result.commit, canonical_before)
+        self.assertEqual(self.remote_head(), result.commit)
+        alternate_after = git(
+            None,
+            "--git-dir",
+            str(alternate),
+            "rev-parse",
+            "main",
+        ).stdout.strip()
+        self.assertEqual(alternate_after, alternate_before)
 
     def test_existing_messages_and_receipts_are_append_only(self) -> None:
         remote = self.root / "append-only-mailbox.git"

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -760,6 +760,49 @@ class GitMailboxWriteContract(unittest.TestCase):
         self.assertEqual(current["claim"]["id"], takeover_claim["id"])
         fixtures.MAILBOX.reconstruct_mailbox(fresh)
 
+    def test_release_and_new_claim_require_distinct_transitions(self) -> None:
+        original_claim = self._claim(with_candidate=True)
+        replacement_claim = fixtures.claim(self.repository, 2, with_candidate=False)
+        replacement_claim["candidate"] = copy.deepcopy(original_claim["candidate"])
+        work_path = f"work/{self.work_id}/work.md"
+        receipt_id = fixtures.identifier("rcp", 1)
+        before = self.remote_head()
+
+        def compound_release_and_claim(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / work_path)
+            released = fixtures.receipt(
+                work,
+                self.repository,
+                1,
+                outcome="released",
+                with_candidate=True,
+            )
+            released["mutation_ownership"] = "relinquished"
+            work["status"] = "active"
+            work["claim"] = copy.deepcopy(replacement_claim)
+            work["attempt_receipt_id"] = receipt_id
+            return TransitionPlan(
+                "compound release and new claim",
+                (
+                    FileChange(work_path, markdown(work)),
+                    FileChange(
+                        f"work/{self.work_id}/receipts/{receipt_id}.md",
+                        markdown(released),
+                    ),
+                ),
+            )
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "release and new claim require distinct transitions",
+        ):
+            self.writer().publish(
+                "compound release and new claim",
+                revalidate=lambda context: None,
+                plan=compound_release_and_claim,
+            )
+        self.assertEqual(self.remote_head(), before)
+
     def test_policy_tightening_after_contention_does_not_widen_authority(self) -> None:
         approved = {"repository.candidate.push"}
         current = set(approved)

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -1000,6 +1000,32 @@ class GitMailboxWriteContract(unittest.TestCase):
             )
         self.assertEqual(self.remote_head(), before)
 
+    def test_transition_cannot_change_the_canonical_branch(self) -> None:
+        before = self.remote_head()
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            manifest = (context.checkout / "atelier.yaml").read_text(encoding="utf-8")
+            changed = manifest.replace(
+                'canonical_branch: "main"',
+                'canonical_branch: "other"',
+            )
+            self.assertNotEqual(changed, manifest)
+            return TransitionPlan(
+                "change canonical branch",
+                (FileChange("atelier.yaml", changed),),
+            )
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "manifest canonical branch 'other' does not match 'main'",
+        ):
+            self.writer().publish(
+                "change canonical branch",
+                revalidate=lambda context: None,
+                plan=plan,
+            )
+        self.assertEqual(self.remote_head(), before)
+
     def test_declared_non_mailbox_paths_fail_before_push(self) -> None:
         before = self.remote_head()
         for path in (

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -7,6 +7,7 @@ import subprocess
 import tempfile
 import threading
 import unittest
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -102,17 +103,10 @@ class LostPushResponse:
 
 
 class AdvanceBeforeFirstPush:
-    """Advance the canonical branch and external observation before one stale push."""
+    """Run one concurrent transition before allowing a stale push to continue."""
 
-    def __init__(
-        self,
-        remote: Path,
-        work_id: str,
-        external_observation: dict[str, str],
-    ):
-        self.remote = remote
-        self.work_id = work_id
-        self.external_observation = external_observation
+    def __init__(self, advance: Callable[[], None]):
+        self._advance = advance
         self.advance = True
 
     def __call__(
@@ -122,16 +116,7 @@ class AdvanceBeforeFirstPush:
     ) -> subprocess.CompletedProcess[str]:
         if arguments and arguments[0] == "push" and self.advance:
             self.advance = False
-            self.external_observation["ticket"] = "changed"
-            path, content = planner_message(self.work_id, 99)
-            GitMailboxWriter(str(self.remote), "main").publish(
-                "publish concurrent instruction",
-                revalidate=lambda context: None,
-                plan=lambda context: TransitionPlan(
-                    "publish concurrent instruction",
-                    (FileChange(path, content),),
-                ),
-            )
+            self._advance()
         return run_git(cwd, arguments)
 
 
@@ -304,7 +289,7 @@ class GitMailboxWriteContract(unittest.TestCase):
 
         def revalidate(context: TransitionContext) -> None:
             work = read_markdown(context.checkout / f"work/{self.work_id}/work.md")
-            if work["claim"]["id"] != claim_result["claim_id"]:
+            if work["claim"]["id"] != claim_result["id"]:
                 raise MailboxTransitionRejected("claim changed")
 
         def plan(context: TransitionContext) -> TransitionPlan:
@@ -441,14 +426,16 @@ class GitMailboxWriteContract(unittest.TestCase):
         attempts: list[int] = []
         path, content = planner_message(self.work_id, 1)
 
+        def advance() -> None:
+            observation["ticket"] = "changed"
+            self._append_instruction(99)
+
         def revalidate(context: TransitionContext) -> None:
             attempts.append(context.attempt)
             if observation["ticket"] != "approved":
                 raise MailboxTransitionRejected("material ticket observation changed")
 
-        writer = self.writer(
-            runner=AdvanceBeforeFirstPush(self.remote, self.work_id, observation)
-        )
+        writer = self.writer(runner=AdvanceBeforeFirstPush(advance))
         with self.assertRaisesRegex(
             MailboxTransitionRejected,
             "material ticket observation changed",
@@ -482,6 +469,218 @@ class GitMailboxWriteContract(unittest.TestCase):
             f"main:{concurrent_path}",
         )
         self.assertTrue(concurrent.stdout)
+
+    def test_takeover_fences_the_prior_claimant_after_contention(self) -> None:
+        old_claim = self._claim()
+        new_claim = fixtures.claim(self.repository, 2, with_candidate=False)
+        work_path = f"work/{self.work_id}/work.md"
+
+        def take_over() -> None:
+            def plan(context: TransitionContext) -> TransitionPlan:
+                work = read_markdown(context.checkout / work_path)
+                work["claim"] = copy.deepcopy(new_claim)
+                return TransitionPlan(
+                    "take over active work",
+                    (FileChange(work_path, markdown(work)),),
+                )
+
+            self.writer().publish(
+                "take over active work",
+                revalidate=lambda context: None,
+                plan=plan,
+            )
+
+        def revalidate(context: TransitionContext) -> None:
+            claim = read_markdown(context.checkout / work_path)["claim"]
+            if (
+                claim["id"] != old_claim["id"]
+                or claim["checkpoint"]["sequence"] != 0
+                or claim["checkpoint"]["continuation_token"]
+                != old_claim["checkpoint"]["continuation_token"]
+            ):
+                raise MailboxTransitionRejected("prior claim is fenced")
+
+        def authorize(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / work_path)
+            checkpoint = work["claim"]["checkpoint"]
+            checkpoint["sequence"] = 1
+            checkpoint["continuation_token"] = "rotated-token"
+            checkpoint["authorizations"].append(
+                {
+                    "sequence": 1,
+                    "invocation_id": old_claim["worker_run_id"],
+                    "phase": "pre_external_mutation",
+                    "action": "repository.candidate.create",
+                    "proposed_effect_digest": fixtures.DIGEST,
+                    "candidate_head": None,
+                    "acknowledged_candidate_head": None,
+                    "recorded_at": fixtures.TIMESTAMP,
+                }
+            )
+            return TransitionPlan(
+                "authorize stale claimant",
+                (FileChange(work_path, markdown(work)),),
+            )
+
+        with self.assertRaisesRegex(MailboxTransitionRejected, "prior claim is fenced"):
+            self.writer(runner=AdvanceBeforeFirstPush(take_over)).publish(
+                "authorize stale claimant",
+                revalidate=revalidate,
+                plan=authorize,
+            )
+
+        fresh = self.root / "fresh-takeover"
+        git(None, "clone", str(self.remote), str(fresh))
+        current = read_markdown(fresh / work_path)
+        self.assertEqual(current["claim"]["id"], new_claim["id"])
+        self.assertEqual(current["claim"]["checkpoint"]["authorizations"], [])
+
+    def test_release_and_takeover_preserve_candidate_handoff(self) -> None:
+        original_claim = self._claim(with_candidate=True)
+        candidate = copy.deepcopy(original_claim["candidate"])
+        work_path = f"work/{self.work_id}/work.md"
+        receipt_id = fixtures.identifier("rcp", 1)
+
+        def release(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / work_path)
+            released = fixtures.receipt(
+                work,
+                self.repository,
+                1,
+                outcome="released",
+                with_candidate=True,
+            )
+            released["mutation_ownership"] = "relinquished"
+            work["status"] = "approved"
+            work["claim"] = None
+            work["attempt_receipt_id"] = receipt_id
+            return TransitionPlan(
+                "release candidate handoff",
+                (
+                    FileChange(work_path, markdown(work)),
+                    FileChange(
+                        f"work/{self.work_id}/receipts/{receipt_id}.md",
+                        markdown(released),
+                    ),
+                ),
+            )
+
+        self.writer().publish(
+            "release candidate handoff",
+            revalidate=lambda context: None,
+            plan=release,
+        )
+
+        adopted_claim = fixtures.claim(self.repository, 2, with_candidate=False)
+        adopted_claim["candidate"] = copy.deepcopy(candidate)
+
+        def adopt(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / work_path)
+            receipt = read_markdown(
+                context.checkout / f"work/{self.work_id}/receipts/{receipt_id}.md"
+            )
+            if receipt["candidate"] != candidate:
+                raise MailboxTransitionRejected("released candidate changed")
+            work["status"] = "active"
+            work["claim"] = copy.deepcopy(adopted_claim)
+            return TransitionPlan(
+                "adopt released candidate",
+                (FileChange(work_path, markdown(work)),),
+            )
+
+        self.writer().publish(
+            "adopt released candidate",
+            revalidate=lambda context: None,
+            plan=adopt,
+        )
+
+        takeover_claim = fixtures.claim(self.repository, 3, with_candidate=False)
+        takeover_claim["candidate"] = copy.deepcopy(candidate)
+
+        def take_over(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / work_path)
+            work["claim"] = copy.deepcopy(takeover_claim)
+            return TransitionPlan(
+                "take over candidate handoff",
+                (FileChange(work_path, markdown(work)),),
+            )
+
+        self.writer().publish(
+            "take over candidate handoff",
+            revalidate=lambda context: None,
+            plan=take_over,
+        )
+
+        fresh = self.root / "fresh-handoff"
+        git(None, "clone", str(self.remote), str(fresh))
+        current = read_markdown(fresh / work_path)
+        released = read_markdown(
+            fresh / f"work/{self.work_id}/receipts/{receipt_id}.md"
+        )
+        self.assertEqual(released["candidate"], candidate)
+        self.assertEqual(current["attempt_receipt_id"], receipt_id)
+        self.assertEqual(current["claim"]["candidate"], candidate)
+        self.assertEqual(current["claim"]["id"], takeover_claim["id"])
+        fixtures.MAILBOX.reconstruct_mailbox(fresh)
+
+    def test_policy_tightening_after_contention_does_not_widen_authority(self) -> None:
+        approved = {"repository.candidate.push"}
+        current = set(approved)
+        effective_observations: list[set[str]] = []
+        path, content = planner_message(self.work_id, 1)
+
+        def advance() -> None:
+            current.clear()
+            current.update({"pull_request.create", "pull_request.merge"})
+            self._append_instruction(99)
+
+        def revalidate(context: TransitionContext) -> None:
+            effective = approved & current
+            effective_observations.append(effective)
+            if "pull_request.merge" in effective:
+                raise AssertionError("looser current policy widened approved authority")
+            if "repository.candidate.push" not in effective:
+                raise MailboxTransitionRejected("current policy removed candidate push")
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "current policy removed candidate push",
+        ):
+            self.writer(runner=AdvanceBeforeFirstPush(advance)).publish(
+                "publish under effective authority",
+                revalidate=revalidate,
+                plan=lambda context: TransitionPlan(
+                    "publish under effective authority",
+                    (FileChange(path, content),),
+                ),
+            )
+        self.assertEqual(effective_observations, [approved, set()])
+
+    def test_pull_request_head_drift_blocks_retry_after_contention(self) -> None:
+        delivered_head = fixtures.SHA_A
+        live = {"head": delivered_head}
+        path, content = planner_message(self.work_id, 1)
+
+        def advance() -> None:
+            live["head"] = fixtures.SHA_B
+            self._append_instruction(99)
+
+        def revalidate(context: TransitionContext) -> None:
+            if live["head"] != delivered_head:
+                raise MailboxTransitionRejected("pull request head changed")
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "pull request head changed",
+        ):
+            self.writer(runner=AdvanceBeforeFirstPush(advance)).publish(
+                "publish against delivered head",
+                revalidate=revalidate,
+                plan=lambda context: TransitionPlan(
+                    "publish against delivered head",
+                    (FileChange(path, content),),
+                ),
+            )
 
     def test_invalid_transition_fails_closed_before_push(self) -> None:
         path = f"work/{fixtures.identifier('wrk', 9)}/work.md"
@@ -518,8 +717,23 @@ class GitMailboxWriteContract(unittest.TestCase):
             )
         self.assertEqual(self.remote_head(), before)
 
-    def _claim(self) -> dict[str, str]:
-        claim_value = fixtures.claim(self.repository, 1, with_candidate=False)
+    def _append_instruction(self, number: int) -> None:
+        path, content = planner_message(self.work_id, number)
+        self.writer().publish(
+            f"append instruction {number}",
+            revalidate=lambda context: None,
+            plan=lambda context: TransitionPlan(
+                f"append instruction {number}",
+                (FileChange(path, content),),
+            ),
+        )
+
+    def _claim(self, *, with_candidate: bool = False) -> dict[str, Any]:
+        claim_value = fixtures.claim(
+            self.repository,
+            1,
+            with_candidate=with_candidate,
+        )
 
         def plan(context: TransitionContext) -> TransitionPlan:
             work = read_markdown(context.checkout / f"work/{self.work_id}/work.md")
@@ -535,4 +749,4 @@ class GitMailboxWriteContract(unittest.TestCase):
             revalidate=lambda context: None,
             plan=plan,
         )
-        return {"claim_id": claim_value["id"]}
+        return claim_value

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -1077,6 +1077,69 @@ class GitMailboxWriteContract(unittest.TestCase):
                     )
                 self.assertEqual(self.remote_head(), before)
 
+    def test_same_claim_cannot_rebind_authority_or_batch_checkpoints(self) -> None:
+        self._claim(with_candidate=False)
+        batched_claim = fixtures.claim(self.repository, 1, with_candidate=True)
+        before = self.remote_head()
+
+        def mutate_claim(
+            context: TransitionContext,
+            mutation: str,
+        ) -> TransitionPlan:
+            path = f"work/{self.work_id}/work.md"
+            work = read_markdown(context.checkout / path)
+            if mutation == "rebind":
+                work["claim"]["ticket_observation_digest"] = "sha256:" + ("f" * 64)
+            else:
+                work["claim"] = copy.deepcopy(batched_claim)
+            return TransitionPlan(
+                f"{mutation} current claim",
+                (FileChange(path, markdown(work)),),
+            )
+
+        expectations = {
+            "rebind": "current claim authority bindings are immutable",
+            "batch": "one transition may advance only one checkpoint sequence",
+        }
+        for mutation, message in expectations.items():
+            with self.subTest(mutation=mutation):
+                with self.assertRaisesRegex(MailboxTransitionRejected, message):
+                    self.writer().publish(
+                        f"{mutation} current claim",
+                        revalidate=lambda context: None,
+                        plan=lambda context, mutation=mutation: mutate_claim(
+                            context,
+                            mutation,
+                        ),
+                    )
+                self.assertEqual(self.remote_head(), before)
+
+    def test_takeover_must_preserve_verified_candidate(self) -> None:
+        original_claim = self._claim(with_candidate=True)
+        self.assertIsNotNone(original_claim["candidate"])
+        replacement_claim = fixtures.claim(self.repository, 2, with_candidate=False)
+        path = f"work/{self.work_id}/work.md"
+        before = self.remote_head()
+
+        def drop_candidate(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / path)
+            work["claim"] = copy.deepcopy(replacement_claim)
+            return TransitionPlan(
+                "take over without candidate",
+                (FileChange(path, markdown(work)),),
+            )
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "takeover must preserve the prior claim candidate",
+        ):
+            self.writer().publish(
+                "take over without candidate",
+                revalidate=lambda context: None,
+                plan=drop_candidate,
+            )
+        self.assertEqual(self.remote_head(), before)
+
     def test_option_looking_remote_is_rejected_before_git_runs(self) -> None:
         calls: list[tuple[str, ...]] = []
 

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -1254,6 +1254,85 @@ class GitMailboxWriteContract(unittest.TestCase):
             )
         self.assertEqual(self.remote_head(), released_head)
 
+    def test_claim_and_run_identities_are_fenced_across_work_history(self) -> None:
+        second_work_id = fixtures.identifier("wrk", 2)
+        second_path = f"work/{second_work_id}/work.md"
+
+        def add_second_work(context: TransitionContext) -> TransitionPlan:
+            current = read_markdown(
+                context.checkout / f"work/{self.work_id}/work.md"
+            )
+            second = fixtures.base_work(
+                second_work_id,
+                current["project_id"],
+                2,
+            )
+            second["status"] = "approved"
+            second["approval"] = fixtures.approval(self.repository)
+            second["native_ticket"]["url"] = (
+                current["native_ticket"]["url"].rsplit("/", 1)[0] + "/2"
+            )
+            return TransitionPlan(
+                "add second approved work",
+                (FileChange(second_path, markdown(second)),),
+            )
+
+        self.writer().publish(
+            "add second approved work",
+            revalidate=lambda context: None,
+            plan=add_second_work,
+        )
+        released_claim = self._claim(with_candidate=False)
+        first_path = f"work/{self.work_id}/work.md"
+
+        def release_first(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / first_path)
+            work["status"] = "approved"
+            work["claim"] = None
+            return TransitionPlan(
+                "release first work claim",
+                (FileChange(first_path, markdown(work)),),
+            )
+
+        self.writer().publish(
+            "release first work claim",
+            revalidate=lambda context: None,
+            plan=release_first,
+        )
+        before = self.remote_head()
+
+        for identity in ("claim", "worker_run"):
+            reused = fixtures.claim(self.repository, 2, with_candidate=False)
+            if identity == "claim":
+                reused["id"] = released_claim["id"]
+            else:
+                reused["worker_run_id"] = released_claim["worker_run_id"]
+
+            def reuse_on_second(
+                context: TransitionContext,
+                reused: dict[str, Any] = reused,
+                identity: str = identity,
+            ) -> TransitionPlan:
+                work = read_markdown(context.checkout / second_path)
+                work["status"] = "active"
+                work["claim"] = copy.deepcopy(reused)
+                return TransitionPlan(
+                    f"reuse {identity} identity on second work",
+                    (FileChange(second_path, markdown(work)),),
+                )
+
+            with self.subTest(identity=identity):
+                with self.assertRaisesRegex(
+                    MailboxTransitionRejected,
+                    "released or replaced claim identities cannot become current again",
+                ):
+                    self.writer().publish(
+                        f"reuse {identity} identity on second work",
+                        revalidate=lambda context: None,
+                        plan=reuse_on_second,
+                    )
+                self.assertEqual(self.remote_head(), before)
+
     def test_same_claim_candidate_rebinding_requires_publication_checkpoint(self) -> None:
         self._claim(with_candidate=True)
         path = f"work/{self.work_id}/work.md"

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -931,6 +931,45 @@ class GitMailboxWriteContract(unittest.TestCase):
                     ).stdout.strip()
                     self.assertEqual(head, before)
 
+    def test_same_claim_checkpoint_ledger_cannot_be_rewritten_or_truncated(self) -> None:
+        self._claim(with_candidate=True)
+        before = self.remote_head()
+
+        def mutate_checkpoint(
+            context: TransitionContext,
+            mutation: str,
+        ) -> TransitionPlan:
+            path = f"work/{self.work_id}/work.md"
+            work = read_markdown(context.checkout / path)
+            checkpoint = work["claim"]["checkpoint"]
+            if mutation == "truncate":
+                checkpoint["authorizations"] = checkpoint["authorizations"][:-1]
+                checkpoint["sequence"] -= 1
+            else:
+                checkpoint["authorizations"][-1]["proposed_effect_digest"] = (
+                    "sha256:" + ("f" * 64)
+                )
+            return TransitionPlan(
+                f"{mutation} checkpoint ledger",
+                (FileChange(path, markdown(work)),),
+            )
+
+        for mutation in ("truncate", "rewrite"):
+            with self.subTest(mutation=mutation):
+                with self.assertRaisesRegex(
+                    MailboxTransitionRejected,
+                    "checkpoint authorization ledger is append-only",
+                ):
+                    self.writer().publish(
+                        f"{mutation} checkpoint ledger",
+                        revalidate=lambda context: None,
+                        plan=lambda context, mutation=mutation: mutate_checkpoint(
+                            context,
+                            mutation,
+                        ),
+                    )
+                self.assertEqual(self.remote_head(), before)
+
     def test_option_looking_remote_is_rejected_before_git_runs(self) -> None:
         calls: list[tuple[str, ...]] = []
 

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -715,6 +715,28 @@ class GitMailboxWriteContract(unittest.TestCase):
             )
         self.assertEqual(self.remote_head(), before)
 
+    def test_declared_non_mailbox_paths_fail_before_push(self) -> None:
+        before = self.remote_head()
+        for path in (
+            "unexpected.txt",
+            f"work/{self.work_id}/cache.json",
+            f"projects/{fixtures.identifier('prj', 1)}/unexpected.md",
+        ):
+            with self.subTest(path=path):
+                with self.assertRaisesRegex(
+                    MailboxTransitionRejected,
+                    "unsafe mailbox path",
+                ):
+                    self.writer().publish(
+                        "declare non-mailbox file",
+                        revalidate=lambda context: None,
+                        plan=lambda context, path=path: TransitionPlan(
+                            "declare non-mailbox file",
+                            (FileChange(path, "not mailbox state\n"),),
+                        ),
+                    )
+                self.assertEqual(self.remote_head(), before)
+
     def test_callback_mutation_is_rejected_before_commit(self) -> None:
         before = self.remote_head()
 

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -878,6 +878,59 @@ class GitMailboxWriteContract(unittest.TestCase):
             )
         self.assertEqual(self.remote_head(), before)
 
+    def test_existing_messages_and_receipts_are_append_only(self) -> None:
+        remote = self.root / "append-only-mailbox.git"
+        seed = self.root / "append-only-seed"
+        git(None, "init", "--bare", "--initial-branch=main", str(remote))
+        git(None, "clone", str(remote), str(seed))
+        mailbox = fixtures.MailboxFixture(seed)
+        work_id = mailbox.add_work(2, "blocked")
+        git(seed, "add", "-A")
+        git(
+            seed,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "-m",
+            "seed append-only artifacts",
+        )
+        git(seed, "push", "origin", "HEAD:main")
+        before = git(seed, "rev-parse", "HEAD").stdout.strip()
+        message_id = next(iter(mailbox.messages[work_id]))
+        receipt_id = next(iter(mailbox.receipts[work_id]))
+        paths = (
+            f"work/{work_id}/messages/{message_id}.md",
+            f"work/{work_id}/receipts/{receipt_id}.md",
+        )
+        writer = GitMailboxWriter(str(remote), "main")
+
+        for path in paths:
+            original = (seed / path).read_text(encoding="utf-8")
+            for content in (original.replace("Fixture.", "Rewritten."), None):
+                with self.subTest(path=path, deletion=content is None):
+                    with self.assertRaisesRegex(
+                        MailboxTransitionRejected,
+                        "append-only mailbox document",
+                    ):
+                        writer.publish(
+                            "mutate append-only artifact",
+                            revalidate=lambda context: None,
+                            plan=lambda context, path=path, content=content: TransitionPlan(
+                                "mutate append-only artifact",
+                                (FileChange(path, content),),
+                            ),
+                        )
+                    head = git(
+                        None,
+                        "--git-dir",
+                        str(remote),
+                        "rev-parse",
+                        "main",
+                    ).stdout.strip()
+                    self.assertEqual(head, before)
+
     def test_option_looking_remote_is_rejected_before_git_runs(self) -> None:
         calls: list[tuple[str, ...]] = []
 

--- a/contract_tests/test_git_mailbox.py
+++ b/contract_tests/test_git_mailbox.py
@@ -18,6 +18,7 @@ from skills.atelier.scripts.git_mailbox import (
     FileChange,
     GitMailboxWriter,
     MailboxPersistenceUnknown,
+    MailboxReadBackError,
     MailboxRemoteUnavailable,
     MailboxTransitionRejected,
     PendingWrite,
@@ -438,6 +439,56 @@ class GitMailboxWriteContract(unittest.TestCase):
             ),
         )
         self.assertEqual(ancestor.returncode, 0)
+
+    def test_ambiguous_recovery_fails_closed_after_canonical_divergence(self) -> None:
+        path, content = planner_message(self.work_id, 1)
+        writer = self.writer(runner=LostPushResponse())
+        with self.assertRaises(MailboxPersistenceUnknown) as raised:
+            writer.publish(
+                "append before recovery divergence",
+                revalidate=lambda context: None,
+                plan=lambda context: TransitionPlan(
+                    "append before recovery divergence",
+                    (FileChange(path, content),),
+                ),
+            )
+        pending = raised.exception.pending
+        tree = git(
+            None,
+            "--git-dir",
+            str(self.remote),
+            "rev-parse",
+            f"{pending.base_revision}^{{tree}}",
+        ).stdout.strip()
+        divergent = git(
+            None,
+            "--git-dir",
+            str(self.remote),
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit-tree",
+            tree,
+            "-m",
+            "divergent canonical root",
+        ).stdout.strip()
+        git(
+            None,
+            "--git-dir",
+            str(self.remote),
+            "update-ref",
+            "refs/heads/main",
+            divergent,
+            pending.commit,
+        )
+
+        with self.assertRaisesRegex(
+            MailboxReadBackError,
+            "could not verify canonical branch continuity",
+        ):
+            self.writer().recover(pending)
+        self.assertEqual(self.remote_head(), divergent)
 
     def test_timeout_after_success_enters_exact_read_back_recovery(self) -> None:
         path, content = planner_message(self.work_id, 1)
@@ -1140,6 +1191,95 @@ class GitMailboxWriteContract(unittest.TestCase):
             )
         self.assertEqual(self.remote_head(), before)
 
+    def test_new_claim_requires_empty_checkpoint_and_fresh_identities(self) -> None:
+        path = f"work/{self.work_id}/work.md"
+        prepopulated = fixtures.claim(self.repository, 1, with_candidate=True)
+        before = self.remote_head()
+
+        def install_prepopulated(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / path)
+            work["status"] = "active"
+            work["claim"] = copy.deepcopy(prepopulated)
+            return TransitionPlan(
+                "install prepopulated claim",
+                (FileChange(path, markdown(work)),),
+            )
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "new claim must begin with an empty checkpoint ledger",
+        ):
+            self.writer().publish(
+                "install prepopulated claim",
+                revalidate=lambda context: None,
+                plan=install_prepopulated,
+            )
+        self.assertEqual(self.remote_head(), before)
+
+        released_claim = self._claim(with_candidate=False)
+
+        def release_without_replacement(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / path)
+            work["status"] = "approved"
+            work["claim"] = None
+            return TransitionPlan(
+                "release current claim",
+                (FileChange(path, markdown(work)),),
+            )
+
+        self.writer().publish(
+            "release current claim",
+            revalidate=lambda context: None,
+            plan=release_without_replacement,
+        )
+        released_head = self.remote_head()
+
+        def reuse_released_identity(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / path)
+            work["status"] = "active"
+            work["claim"] = copy.deepcopy(released_claim)
+            return TransitionPlan(
+                "reuse released claim identity",
+                (FileChange(path, markdown(work)),),
+            )
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "released or replaced claim identities cannot become current again",
+        ):
+            self.writer().publish(
+                "reuse released claim identity",
+                revalidate=lambda context: None,
+                plan=reuse_released_identity,
+            )
+        self.assertEqual(self.remote_head(), released_head)
+
+    def test_same_claim_candidate_rebinding_requires_publication_checkpoint(self) -> None:
+        self._claim(with_candidate=True)
+        path = f"work/{self.work_id}/work.md"
+        before = self.remote_head()
+
+        def rebind_candidate(context: TransitionContext) -> TransitionPlan:
+            work = read_markdown(context.checkout / path)
+            work["claim"]["candidate"]["remote_ref"] = (
+                "refs/heads/scott/rebound-candidate"
+            )
+            return TransitionPlan(
+                "rebind candidate without checkpoint",
+                (FileChange(path, markdown(work)),),
+            )
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "candidate changes require one publication checkpoint",
+        ):
+            self.writer().publish(
+                "rebind candidate without checkpoint",
+                revalidate=lambda context: None,
+                plan=rebind_candidate,
+            )
+        self.assertEqual(self.remote_head(), before)
+
     def test_option_looking_remote_is_rejected_before_git_runs(self) -> None:
         calls: list[tuple[str, ...]] = []
 
@@ -1173,7 +1313,7 @@ class GitMailboxWriteContract(unittest.TestCase):
         claim_value = fixtures.claim(
             self.repository,
             1,
-            with_candidate=with_candidate,
+            with_candidate=False,
         )
 
         def plan(context: TransitionContext) -> TransitionPlan:
@@ -1190,4 +1330,44 @@ class GitMailboxWriteContract(unittest.TestCase):
             revalidate=lambda context: None,
             plan=plan,
         )
+        if not with_candidate:
+            return claim_value
+
+        published_claim = fixtures.claim(self.repository, 1, with_candidate=True)
+        for authorization in published_claim["checkpoint"]["authorizations"]:
+            claim_value["checkpoint"]["authorizations"].append(copy.deepcopy(authorization))
+            claim_value["checkpoint"]["sequence"] = authorization["sequence"]
+            claim_value["checkpoint"]["continuation_token"] = (
+                f"token-1-{authorization['sequence']}"
+            )
+            if authorization["phase"] == "candidate_published":
+                claim_value["candidate"] = copy.deepcopy(published_claim["candidate"])
+
+            checkpoint_claim = copy.deepcopy(claim_value)
+            checkpoint_number = authorization["sequence"]
+
+            def checkpoint(
+                context: TransitionContext,
+                checkpoint_claim: dict[str, Any] = checkpoint_claim,
+                checkpoint_number: int = checkpoint_number,
+            ) -> TransitionPlan:
+                work = read_markdown(
+                    context.checkout / f"work/{self.work_id}/work.md"
+                )
+                work["claim"] = copy.deepcopy(checkpoint_claim)
+                return TransitionPlan(
+                    f"advance checkpoint {checkpoint_number}",
+                    (
+                        FileChange(
+                            f"work/{self.work_id}/work.md",
+                            markdown(work),
+                        ),
+                    ),
+                )
+
+            self.writer().publish(
+                f"advance checkpoint {checkpoint_number}",
+                revalidate=lambda context: None,
+                plan=checkpoint,
+            )
         return claim_value

--- a/docs/mailbox-protocol-validation.md
+++ b/docs/mailbox-protocol-validation.md
@@ -9,6 +9,14 @@ The experiment is implemented in `experiments/mailbox_protocol_v0.py` and runs
 entirely against temporary local bare Git repositories and independent clones.
 It removes those repositories after each run.
 
+The production persistence boundary is implemented in
+`skills/atelier/scripts/git_mailbox.py`. Its executable contracts live in
+`contract_tests/test_git_mailbox.py` and repeat the write-critical scenarios
+through that helper: claim races, independent append retry, atomic
+multi-document transitions, external-state drift after contention, ambiguous
+push recovery after later commits, unavailable remotes, malformed transitions,
+fresh-clone reconstruction, and exact historical read-back.
+
 ## Command
 
 ```text

--- a/docs/mailbox-protocol-validation.md
+++ b/docs/mailbox-protocol-validation.md
@@ -13,8 +13,9 @@ The production persistence boundary is implemented in
 `skills/atelier/scripts/git_mailbox.py`. Its executable contracts live in
 `contract_tests/test_git_mailbox.py` and repeat the write-critical scenarios
 through that helper: claim races, independent append retry, atomic
-multi-document transitions, external-state drift after contention, ambiguous
-push recovery after later commits, unavailable remotes, malformed transitions,
+multi-document transitions, takeover fencing, release and takeover candidate
+handoff, policy, ticket, and pull-request drift after contention, ambiguous push
+recovery after later commits, unavailable remotes, malformed transitions,
 fresh-clone reconstruction, and exact historical read-back.
 
 ## Command

--- a/skills/atelier/SKILL.md
+++ b/skills/atelier/SKILL.md
@@ -60,17 +60,21 @@ An explicit host-readiness request may complete the read-only host preflight and
 return its exact compatibility or failure result. That does not make any
 production mode available.
 
-## Mailbox document boundary
+## Mailbox boundary
 
 The strict v1 mailbox schema and fresh-clone reconstruction helper are
-implemented, but canonical Git writes and every production mode remain
-unavailable. Before interpreting mailbox documents, read
-`references/mailbox-validation.md` and use its read-only helper.
+implemented. Verified fast-forward canonical writes are also implemented, but
+every production mode remains unavailable. Before interpreting mailbox
+documents, read `references/mailbox-validation.md` and use its read-only helper.
+Before persisting a transition, read `references/git-mailbox-writes.md` and use
+its isolated compare-and-swap writer.
 
 Fail closed on every unsupported schema, unknown normative field, invalid
 lifecycle combination, contradictory reference, or missing external readiness
 gate. The reconstructed snapshot is invocation-local and must never be written
-back as a manifest, cache, index, or projection.
+back as a manifest, cache, index, or projection. A caller must supply fresh
+operation-specific lifecycle, policy, ticket, claim, candidate, and authority
+checks; the Git writer supplies persistence, not permission.
 
 ## Invariants
 

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -21,10 +21,13 @@ deletions and cannot mutate its checkout directly. Message and receipt
 documents are append-only: a plan cannot delete them or target an identifier
 that already exists in the fetched mailbox. While a claim remains current, its
 checkpoint authorization ledger must retain the fetched ledger as an exact
-prefix, and its sequence and continuation token advance together. Release,
-takeover, and a new claim remain distinct lifecycle transitions. In particular,
-one plan cannot both append the current claim's release receipt and install a
-different claim.
+prefix. One transition may append exactly one entry while incrementing the
+sequence once and rotating the continuation token; otherwise all three remain
+unchanged. The current claim's worker, revision, approval, policy, ticket, time,
+and host bindings are immutable. Release, takeover, and a new claim remain
+distinct lifecycle transitions. A takeover preserves the replaced claim's exact
+candidate, and one plan cannot both append the current claim's release receipt
+and install a different claim.
 
 Git commands are noninteractive and have a finite timeout. A mailbox remote
 must be a repository operand and cannot begin with `-`. Fetch timeouts fail as

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -19,15 +19,22 @@ commit, reconstructs current state, and invokes both callbacks again. A
 transition callback is read-only; it returns complete UTF-8 replacements or
 deletions and cannot mutate its checkout directly.
 
+Git commands are noninteractive and have a finite timeout. A mailbox remote
+must be a repository operand and cannot begin with `-`. Fetch timeouts fail as
+unavailable current state. Push timeouts enter the same exact read-back and
+recovery path as any other ambiguous push result.
+
 Each successful operation:
 
 1. starts from the fetched canonical commit in an isolated temporary checkout;
 2. validates current mailbox documents and caller-owned external preconditions;
 3. applies and validates one declared semantic transition;
 4. creates one ordinary Git commit;
-5. pushes that exact commit to the canonical branch without force;
-6. fetches the branch again; and
-7. verifies that the commit is an ancestor of the remote head and that its
+5. verifies that the commit is the single child of the fetched base and contains
+   exactly the declared paths and bytes;
+6. pushes that exact commit to the canonical branch without force;
+7. fetches the branch again; and
+8. verifies that the commit is an ancestor of the remote head and that its
    historical tree contains the exact declared content.
 
 Retries are bounded. A non-fast-forward result is not mechanically rebased:

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -37,7 +37,8 @@ Each successful operation:
 4. creates one ordinary Git commit;
 5. verifies that the commit is the single child of the fetched base and contains
    exactly the declared paths and bytes;
-6. pushes that exact commit to the canonical branch without force;
+6. pushes that exact commit with an expected-old-ref lease equal to the fetched
+   base;
 7. fetches the branch again; and
 8. verifies that the commit is an ancestor of the remote head and that its
    historical tree contains the exact declared content.
@@ -46,7 +47,9 @@ Retries are bounded. A non-fast-forward result is not mechanically rebased:
 the operation is replanned only after fresh semantic revalidation. Callers
 reject losing claims, changed approvals, resolved questions, stale checkpoints,
 policy or ticket drift, and any other invalidated transition with
-`MailboxTransitionRejected`.
+`MailboxTransitionRejected`. A deleted, rewound, or divergent canonical ref
+cannot satisfy the lease; deletion remains unavailable, while rewind or
+divergence fails closed instead of becoming a new retry base.
 
 If a push response is lost and read-back is unavailable,
 `MailboxPersistenceUnknown` exposes a `PendingWrite`. Preserve it and call

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -19,8 +19,10 @@ commit, reconstructs current state, and invokes both callbacks again. A
 transition callback is read-only; it returns complete UTF-8 replacements or
 deletions and cannot mutate its checkout directly. Callbacks receive a
 document-only snapshot with no Git administrative state; the writer keeps its
-transport checkout private and rejects any snapshot mutation. Message and
-receipt documents are append-only: a plan cannot delete them or target an identifier
+transport checkout private, seals its Git environment before either callback,
+discards environment-level Git configuration injection, and rejects any
+snapshot mutation. Message and receipt documents are append-only: a plan cannot
+delete them or target an identifier
 that already exists in the fetched mailbox. While a claim remains current, its
 checkpoint authorization ledger must retain the fetched ledger as an exact
 prefix. One transition may append exactly one entry while incrementing the

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -17,7 +17,9 @@ The writer always reconstructs and validates the fetched mailbox before either
 callback runs. After contention it fetches again, discards the stale local
 commit, reconstructs current state, and invokes both callbacks again. A
 transition callback is read-only; it returns complete UTF-8 replacements or
-deletions and cannot mutate its checkout directly.
+deletions and cannot mutate its checkout directly. Message and receipt
+documents are append-only: a plan cannot delete them or target an identifier
+that already exists in the fetched mailbox.
 
 Git commands are noninteractive and have a finite timeout. A mailbox remote
 must be a repository operand and cannot begin with `-`. Fetch timeouts fail as

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -1,0 +1,49 @@
+# Canonical Git mailbox writes
+
+Issue #776 provides the production persistence boundary for mailbox transitions.
+It does not implement `plan`, `work`, `audit`, or any transition-specific
+authority decision.
+
+Import `GitMailboxWriter` from `scripts/git_mailbox.py`. A caller supplies:
+
+- the mailbox remote and canonical branch;
+- one stable operation name;
+- a `revalidate(context)` callback that rereads every applicable current policy,
+  native-ticket, claim, candidate, and authority precondition; and
+- a `plan(context)` callback returning the complete document set for one
+  semantic transition.
+
+The writer always reconstructs and validates the fetched mailbox before either
+callback runs. After contention it fetches again, discards the stale local
+commit, reconstructs current state, and invokes both callbacks again. A
+transition callback is read-only; it returns complete UTF-8 replacements or
+deletions and cannot mutate its checkout directly.
+
+Each successful operation:
+
+1. starts from the fetched canonical commit in an isolated temporary checkout;
+2. validates current mailbox documents and caller-owned external preconditions;
+3. applies and validates one declared semantic transition;
+4. creates one ordinary Git commit;
+5. pushes that exact commit to the canonical branch without force;
+6. fetches the branch again; and
+7. verifies that the commit is an ancestor of the remote head and that its
+   historical tree contains the exact declared content.
+
+Retries are bounded. A non-fast-forward result is not mechanically rebased:
+the operation is replanned only after fresh semantic revalidation. Callers
+reject losing claims, changed approvals, resolved questions, stale checkpoints,
+policy or ticket drift, and any other invalidated transition with
+`MailboxTransitionRejected`.
+
+If a push response is lost and read-back is unavailable,
+`MailboxPersistenceUnknown` exposes a `PendingWrite`. Preserve it and call
+`recover(pending)` when the remote is readable. Recovery checks ancestry and
+exact historical content, so a successful push is not duplicated even when
+later mailbox commits have advanced the branch. A missing commit returns
+`None`; the caller may then start a new publication attempt, which performs all
+preconditions again.
+
+The helper never force-pushes, merges mailbox histories, writes a cache or
+projection, starts a background process, or treats an unverified local commit
+as shared state.

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -27,7 +27,15 @@ unchanged. The current claim's worker, revision, approval, policy, ticket, time,
 and host bindings are immutable. Release, takeover, and a new claim remain
 distinct lifecycle transitions. A takeover preserves the replaced claim's exact
 candidate, and one plan cannot both append the current claim's release receipt
-and install a different claim.
+and install a different claim. Every installed claim starts at checkpoint zero
+with an empty ledger and claim/run identities absent from the work document's
+canonical Git history.
+
+A same-claim candidate change consumes exactly one checkpoint whose
+`candidate_published` entry acknowledges the new exact head. Recovery returns a
+retryable absence when the commit is absent and the readable canonical head
+still descends from the pending write's base. A detectable rewind or divergence
+behind that base fails closed.
 
 Git commands are noninteractive and have a finite timeout. A mailbox remote
 must be a repository operand and cannot begin with `-`. Fetch timeouts fail as

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -19,7 +19,10 @@ commit, reconstructs current state, and invokes both callbacks again. A
 transition callback is read-only; it returns complete UTF-8 replacements or
 deletions and cannot mutate its checkout directly. Message and receipt
 documents are append-only: a plan cannot delete them or target an identifier
-that already exists in the fetched mailbox.
+that already exists in the fetched mailbox. While a claim remains current, its
+checkpoint authorization ledger must retain the fetched ledger as an exact
+prefix, and its sequence and continuation token advance together. Release,
+takeover, and a new claim remain distinct lifecycle transitions.
 
 Git commands are noninteractive and have a finite timeout. A mailbox remote
 must be a repository operand and cannot begin with `-`. Fetch timeouts fail as

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -21,8 +21,9 @@ deletions and cannot mutate its checkout directly. Callbacks receive a
 document-only snapshot with no Git administrative state; the writer keeps its
 transport checkout private, seals its Git environment before either callback,
 discards environment-level Git configuration injection, and rejects any
-snapshot mutation. Message and receipt documents are append-only: a plan cannot
-delete them or target an identifier
+snapshot mutation. A transition cannot change the manifest's canonical branch.
+Message and receipt documents are append-only: a plan cannot delete them or
+target an identifier
 that already exists in the fetched mailbox. While a claim remains current, its
 checkpoint authorization ledger must retain the fetched ledger as an exact
 prefix. One transition may append exactly one entry while incrementing the

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -62,7 +62,9 @@ reject losing claims, changed approvals, resolved questions, stale checkpoints,
 policy or ticket drift, and any other invalidated transition with
 `MailboxTransitionRejected`. A deleted, rewound, or divergent canonical ref
 cannot satisfy the lease; deletion remains unavailable, while rewind or
-divergence fails closed instead of becoming a new retry base.
+divergence fails closed instead of becoming a new retry base. The writer retains
+the latest canonical revision observed during the operation and requires every
+later retry fetch to descend from it.
 
 If a push response is lost and read-back is unavailable,
 `MailboxPersistenceUnknown` exposes a `PendingWrite`. Preserve it and call

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -17,8 +17,10 @@ The writer always reconstructs and validates the fetched mailbox before either
 callback runs. After contention it fetches again, discards the stale local
 commit, reconstructs current state, and invokes both callbacks again. A
 transition callback is read-only; it returns complete UTF-8 replacements or
-deletions and cannot mutate its checkout directly. Message and receipt
-documents are append-only: a plan cannot delete them or target an identifier
+deletions and cannot mutate its checkout directly. Callbacks receive a
+document-only snapshot with no Git administrative state; the writer keeps its
+transport checkout private and rejects any snapshot mutation. Message and
+receipt documents are append-only: a plan cannot delete them or target an identifier
 that already exists in the fetched mailbox. While a claim remains current, its
 checkpoint authorization ledger must retain the fetched ledger as an exact
 prefix. One transition may append exactly one entry while incrementing the

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -28,8 +28,8 @@ and host bindings are immutable. Release, takeover, and a new claim remain
 distinct lifecycle transitions. A takeover preserves the replaced claim's exact
 candidate, and one plan cannot both append the current claim's release receipt
 and install a different claim. Every installed claim starts at checkpoint zero
-with an empty ledger and claim/run identities absent from the work document's
-canonical Git history.
+with an empty ledger and claim/run identities absent from every work document
+version in canonical Git history.
 
 A same-claim candidate change consumes exactly one checkpoint whose
 `candidate_published` entry acknowledges the new exact head. Recovery returns a

--- a/skills/atelier/references/git-mailbox-writes.md
+++ b/skills/atelier/references/git-mailbox-writes.md
@@ -22,7 +22,9 @@ documents are append-only: a plan cannot delete them or target an identifier
 that already exists in the fetched mailbox. While a claim remains current, its
 checkpoint authorization ledger must retain the fetched ledger as an exact
 prefix, and its sequence and continuation token advance together. Release,
-takeover, and a new claim remain distinct lifecycle transitions.
+takeover, and a new claim remain distinct lifecycle transitions. In particular,
+one plan cannot both append the current claim's release receipt and install a
+different claim.
 
 Git commands are noninteractive and have a finite timeout. A mailbox remote
 must be a repository operand and cannot begin with `-`. Fetch timeouts fail as

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -215,8 +215,16 @@ class GitMailboxWriter:
         with tempfile.TemporaryDirectory(prefix="atelier-mailbox-write-") as temporary:
             checkout = Path(temporary) / "mailbox"
             self._initialize(checkout)
+            latest_observed_revision: str | None = None
             for attempt in range(1, self.max_attempts + 1):
                 base_revision = self._fetch_current(checkout)
+                if latest_observed_revision is not None:
+                    self._require_canonical_descendant(
+                        checkout,
+                        base_revision=latest_observed_revision,
+                        operation=operation,
+                    )
+                latest_observed_revision = base_revision
                 self._reset(checkout)
                 snapshot = reconstruct_mailbox(checkout)
                 if snapshot["canonical_branch"] != self.branch:
@@ -286,6 +294,11 @@ class GitMailboxWriter:
                     checkout,
                     base_revision=base_revision,
                     operation=operation,
+                )
+                latest_observed_revision = self._output(
+                    checkout,
+                    ("rev-parse", READBACK_REF),
+                    "resolve observed canonical mailbox head",
                 )
                 if attempt == self.max_attempts:
                     raise MailboxRetryExhausted(

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -258,6 +258,7 @@ class GitMailboxWriter:
                         (
                             "push",
                             "--porcelain",
+                            f"--force-with-lease=refs/heads/{self.branch}:{base_revision}",
                             self.remote,
                             f"{commit}:refs/heads/{self.branch}",
                         ),
@@ -281,6 +282,11 @@ class GitMailboxWriter:
                     raise MailboxReadBackError(
                         f"{operation}: successful push omitted commit {commit} from remote history"
                     )
+                self._require_canonical_descendant(
+                    checkout,
+                    base_revision=base_revision,
+                    operation=operation,
+                )
                 if attempt == self.max_attempts:
                     raise MailboxRetryExhausted(
                         f"{operation}: remote contention exceeded {self.max_attempts} attempts"
@@ -566,6 +572,26 @@ class GitMailboxWriter:
                     f"{pending.operation}: {change.path} differs in the verified commit"
                 )
         return True
+
+    def _require_canonical_descendant(
+        self,
+        checkout: Path,
+        *,
+        base_revision: str,
+        operation: str,
+    ) -> None:
+        ancestry = self._run(
+            checkout,
+            ("merge-base", "--is-ancestor", base_revision, READBACK_REF),
+        )
+        if ancestry.returncode == 1:
+            raise MailboxTransitionRejected(
+                f"{operation}: canonical mailbox branch moved backwards or diverged"
+            )
+        if ancestry.returncode != 0:
+            raise MailboxReadBackError(
+                f"{operation}: could not verify canonical branch continuity"
+            )
 
     def _output(self, cwd: Path, arguments: Sequence[str], purpose: str) -> str:
         result = self._run(cwd, arguments)

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -15,6 +15,7 @@ from typing import Any, Protocol
 from .mailbox import reconstruct_mailbox
 
 READBACK_REF = "refs/remotes/atelier/canonical"
+GIT_COMMAND_TIMEOUT_SECONDS = 30
 
 
 class MailboxWriteError(RuntimeError):
@@ -162,6 +163,8 @@ def run_git(
             "GIT_PREFIX",
         }
     }
+    environment["GIT_TERMINAL_PROMPT"] = "0"
+    environment["GCM_INTERACTIVE"] = "Never"
     return subprocess.run(
         ["git", *arguments],
         cwd=cwd,
@@ -169,6 +172,7 @@ def run_git(
         check=False,
         capture_output=True,
         text=True,
+        timeout=GIT_COMMAND_TIMEOUT_SECONDS,
     )
 
 
@@ -185,6 +189,8 @@ class GitMailboxWriter:
     ):
         if not remote:
             raise ValueError("remote must not be empty")
+        if remote.startswith("-"):
+            raise ValueError("remote must not begin with '-'")
         if max_attempts < 1:
             raise ValueError("max_attempts must be at least one")
         self.remote = remote
@@ -244,12 +250,20 @@ class GitMailboxWriter:
                     base_revision=base_revision,
                     changes=changes,
                 )
-                pushed = self._run(
-                    checkout,
-                    ("push", "--porcelain", self.remote, f"{commit}:refs/heads/{self.branch}"),
-                )
                 try:
-                    recovered = pushed.returncode != 0
+                    pushed = self._run(
+                        checkout,
+                        (
+                            "push",
+                            "--porcelain",
+                            self.remote,
+                            f"{commit}:refs/heads/{self.branch}",
+                        ),
+                    )
+                except subprocess.TimeoutExpired:
+                    pushed = None
+                try:
+                    recovered = pushed is None or pushed.returncode != 0
                     if self._read_back(checkout, pending):
                         return WriteResult(
                             operation=operation,
@@ -261,7 +275,7 @@ class GitMailboxWriter:
                         )
                 except MailboxRemoteUnavailable as error:
                     raise MailboxPersistenceUnknown(pending) from error
-                if pushed.returncode == 0:
+                if pushed is not None and pushed.returncode == 0:
                     raise MailboxReadBackError(
                         f"{operation}: successful push omitted commit {commit} from remote history"
                     )
@@ -297,15 +311,20 @@ class GitMailboxWriter:
             raise MailboxWriteError("could not initialize isolated mailbox checkout")
 
     def _fetch_current(self, checkout: Path) -> str:
-        fetched = self._run(
-            checkout,
-            (
-                "fetch",
-                "--no-tags",
-                self.remote,
-                f"+refs/heads/{self.branch}:{READBACK_REF}",
-            ),
-        )
+        try:
+            fetched = self._run(
+                checkout,
+                (
+                    "fetch",
+                    "--no-tags",
+                    self.remote,
+                    f"+refs/heads/{self.branch}:{READBACK_REF}",
+                ),
+            )
+        except subprocess.TimeoutExpired as error:
+            raise MailboxRemoteUnavailable(
+                f"canonical mailbox branch {self.branch!r} timed out"
+            ) from error
         if fetched.returncode != 0:
             raise MailboxRemoteUnavailable(
                 f"canonical mailbox branch {self.branch!r} is unavailable"
@@ -437,6 +456,17 @@ class GitMailboxWriter:
             raise MailboxTransitionRejected(
                 "committed mailbox transition differs from its declared document set"
             )
+        for change in changes:
+            shown = self._run(checkout, ("show", f"{commit}:{change.path}"))
+            if change.content is None:
+                if shown.returncode == 0:
+                    raise MailboxTransitionRejected(
+                        f"committed mailbox transition retained deleted path {change.path}"
+                    )
+            elif shown.returncode != 0 or shown.stdout != change.content:
+                raise MailboxTransitionRejected(
+                    f"committed mailbox content differs from declaration for {change.path}"
+                )
 
     def _read_back(self, checkout: Path, pending: PendingWrite) -> bool:
         self._fetch_current(checkout)

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -198,6 +198,12 @@ class GitMailboxWriter:
                 reconstruct_mailbox(checkout)
                 self._stage_exact_changes(checkout, changes)
                 commit = self._commit(checkout, transition.commit_message)
+                self._verify_commit_shape(
+                    checkout,
+                    commit=commit,
+                    base_revision=base_revision,
+                    changes=changes,
+                )
                 pending = PendingWrite(
                     operation=operation,
                     branch=self.branch,
@@ -370,8 +376,39 @@ class GitMailboxWriter:
             raise MailboxWriteError("could not commit mailbox transition")
         return self._output(checkout, ("rev-parse", "HEAD"), "resolve mailbox commit")
 
+    def _verify_commit_shape(
+        self,
+        checkout: Path,
+        *,
+        commit: str,
+        base_revision: str,
+        changes: tuple[FileChange, ...],
+    ) -> None:
+        lineage = self._output(
+            checkout,
+            ("rev-list", "--parents", "-n", "1", commit),
+            "inspect mailbox commit lineage",
+        ).split()
+        if lineage != [commit, base_revision]:
+            raise MailboxTransitionRejected(
+                "mailbox transition must be one commit directly atop the fetched base"
+            )
+        changed = self._output_lines(
+            checkout,
+            ("diff-tree", "--no-commit-id", "--name-only", "-r", commit),
+            "inspect committed mailbox transition",
+        )
+        declared = sorted(change.path for change in changes)
+        if changed != declared:
+            raise MailboxTransitionRejected(
+                "committed mailbox transition differs from its declared document set"
+            )
+
     def _read_back(self, checkout: Path, pending: PendingWrite) -> bool:
         self._fetch_current(checkout)
+        exists = self._run(checkout, ("cat-file", "-e", f"{pending.commit}^{{commit}}"))
+        if exists.returncode != 0:
+            return False
         ancestry = self._run(
             checkout,
             ("merge-base", "--is-ancestor", pending.commit, READBACK_REF),

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -1,0 +1,413 @@
+#!/usr/bin/env python3
+"""Persist one verified semantic transition to an Atelier Git mailbox."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Protocol
+
+from .mailbox import reconstruct_mailbox
+
+READBACK_REF = "refs/remotes/atelier/canonical"
+
+
+class MailboxWriteError(RuntimeError):
+    """A mailbox write cannot safely report success."""
+
+
+class MailboxRemoteUnavailable(MailboxWriteError):
+    """The canonical mailbox branch could not be fetched before mutation."""
+
+
+class MailboxTransitionRejected(MailboxWriteError):
+    """Fresh semantic preconditions reject the proposed transition."""
+
+
+class MailboxReadBackError(MailboxWriteError):
+    """Remote history does not contain the exact content attributed to a commit."""
+
+
+class MailboxRetryExhausted(MailboxWriteError):
+    """Contention persisted beyond the bounded retry budget."""
+
+
+@dataclass(frozen=True)
+class FileChange:
+    """One complete UTF-8 document replacement or deletion."""
+
+    path: str
+    content: str | None
+
+
+@dataclass(frozen=True)
+class TransitionPlan:
+    """The complete durable effect of one semantic transition."""
+
+    commit_message: str
+    changes: tuple[FileChange, ...]
+
+
+@dataclass(frozen=True)
+class TransitionContext:
+    """Fresh mailbox state supplied to precondition and planning callbacks."""
+
+    checkout: Path
+    base_revision: str
+    snapshot: Mapping[str, Any]
+    attempt: int
+
+
+@dataclass(frozen=True)
+class PendingWrite:
+    """A pushed commit whose remote outcome could not yet be verified."""
+
+    operation: str
+    branch: str
+    commit: str
+    base_revision: str
+    changes: tuple[FileChange, ...]
+
+
+class MailboxPersistenceUnknown(MailboxWriteError):
+    """A push may have succeeded, but exact remote read-back was unavailable."""
+
+    def __init__(self, pending: PendingWrite):
+        self.pending = pending
+        super().__init__(
+            f"{pending.operation}: persistence outcome is unknown for commit {pending.commit}"
+        )
+
+
+@dataclass(frozen=True)
+class WriteResult:
+    """Verified remote identity for one published transition."""
+
+    operation: str
+    branch: str
+    commit: str
+    base_revision: str
+    attempts: int
+    recovered: bool
+
+
+class GitRunner(Protocol):
+    """Injectable Git command boundary used by production code and fault tests."""
+
+    def __call__(
+        self,
+        cwd: Path | None,
+        arguments: Sequence[str],
+    ) -> subprocess.CompletedProcess[str]: ...
+
+
+Revalidate = Callable[[TransitionContext], None]
+PlanTransition = Callable[[TransitionContext], TransitionPlan]
+
+
+def run_git(
+    cwd: Path | None,
+    arguments: Sequence[str],
+) -> subprocess.CompletedProcess[str]:
+    """Run Git without inheriting repository-scoped environment variables."""
+
+    environment = {
+        key: value
+        for key, value in os.environ.items()
+        if key
+        not in {
+            "GIT_DIR",
+            "GIT_WORK_TREE",
+            "GIT_INDEX_FILE",
+            "GIT_OBJECT_DIRECTORY",
+            "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+            "GIT_PREFIX",
+        }
+    }
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=cwd,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+class GitMailboxWriter:
+    """Fast-forward, compare-and-swap writer for one canonical mailbox branch."""
+
+    def __init__(
+        self,
+        remote: str,
+        branch: str,
+        *,
+        max_attempts: int = 3,
+        runner: GitRunner = run_git,
+    ):
+        if not remote:
+            raise ValueError("remote must not be empty")
+        if max_attempts < 1:
+            raise ValueError("max_attempts must be at least one")
+        self.remote = remote
+        self.branch = branch
+        self.max_attempts = max_attempts
+        self._run = runner
+        branch_check = self._run(None, ("check-ref-format", "--branch", branch))
+        if branch_check.returncode != 0:
+            raise ValueError(f"invalid canonical branch: {branch}")
+
+    def publish(
+        self,
+        operation: str,
+        *,
+        revalidate: Revalidate,
+        plan: PlanTransition,
+    ) -> WriteResult:
+        """Publish one transition, replanning only after fresh revalidation."""
+
+        if not operation.strip():
+            raise ValueError("operation must not be empty")
+        with tempfile.TemporaryDirectory(prefix="atelier-mailbox-write-") as temporary:
+            checkout = Path(temporary) / "mailbox"
+            self._initialize(checkout)
+            for attempt in range(1, self.max_attempts + 1):
+                base_revision = self._fetch_current(checkout)
+                self._reset(checkout)
+                snapshot = reconstruct_mailbox(checkout)
+                if snapshot["canonical_branch"] != self.branch:
+                    raise MailboxTransitionRejected(
+                        f"{operation}: manifest canonical branch "
+                        f"{snapshot['canonical_branch']!r} does not match {self.branch!r}"
+                    )
+                context = TransitionContext(
+                    checkout=checkout,
+                    base_revision=base_revision,
+                    snapshot=snapshot,
+                    attempt=attempt,
+                )
+                revalidate(context)
+                transition = plan(context)
+                changes = self._normalize_plan(checkout, transition)
+                self._apply(checkout, changes)
+                reconstruct_mailbox(checkout)
+                self._stage_exact_changes(checkout, changes)
+                commit = self._commit(checkout, transition.commit_message)
+                pending = PendingWrite(
+                    operation=operation,
+                    branch=self.branch,
+                    commit=commit,
+                    base_revision=base_revision,
+                    changes=changes,
+                )
+                pushed = self._run(
+                    checkout,
+                    ("push", "--porcelain", self.remote, f"{commit}:refs/heads/{self.branch}"),
+                )
+                try:
+                    recovered = pushed.returncode != 0
+                    if self._read_back(checkout, pending):
+                        return WriteResult(
+                            operation=operation,
+                            branch=self.branch,
+                            commit=commit,
+                            base_revision=base_revision,
+                            attempts=attempt,
+                            recovered=recovered,
+                        )
+                except MailboxRemoteUnavailable as error:
+                    raise MailboxPersistenceUnknown(pending) from error
+                if pushed.returncode == 0:
+                    raise MailboxReadBackError(
+                        f"{operation}: successful push omitted commit {commit} from remote history"
+                    )
+                if attempt == self.max_attempts:
+                    raise MailboxRetryExhausted(
+                        f"{operation}: remote contention exceeded {self.max_attempts} attempts"
+                    )
+            raise AssertionError("bounded mailbox write loop terminated unexpectedly")
+
+    def recover(self, pending: PendingWrite) -> WriteResult | None:
+        """Resolve an ambiguous push through ancestry and exact historical content."""
+
+        if pending.branch != self.branch:
+            raise ValueError("pending write belongs to a different canonical branch")
+        with tempfile.TemporaryDirectory(prefix="atelier-mailbox-recover-") as temporary:
+            checkout = Path(temporary) / "mailbox"
+            self._initialize(checkout)
+            if not self._read_back(checkout, pending):
+                return None
+        return WriteResult(
+            operation=pending.operation,
+            branch=pending.branch,
+            commit=pending.commit,
+            base_revision=pending.base_revision,
+            attempts=0,
+            recovered=True,
+        )
+
+    def _initialize(self, checkout: Path) -> None:
+        checkout.mkdir(parents=True)
+        initialized = self._run(checkout, ("init", "--quiet"))
+        if initialized.returncode != 0:
+            raise MailboxWriteError("could not initialize isolated mailbox checkout")
+
+    def _fetch_current(self, checkout: Path) -> str:
+        fetched = self._run(
+            checkout,
+            (
+                "fetch",
+                "--no-tags",
+                self.remote,
+                f"+refs/heads/{self.branch}:{READBACK_REF}",
+            ),
+        )
+        if fetched.returncode != 0:
+            raise MailboxRemoteUnavailable(
+                f"canonical mailbox branch {self.branch!r} is unavailable"
+            )
+        return self._output(checkout, ("rev-parse", READBACK_REF), "resolve canonical mailbox head")
+
+    def _reset(self, checkout: Path) -> None:
+        reset = self._run(checkout, ("reset", "--hard", "--quiet", READBACK_REF))
+        cleaned = self._run(checkout, ("clean", "-ffdqx"))
+        if reset.returncode != 0 or cleaned.returncode != 0:
+            raise MailboxWriteError("could not reset isolated checkout to the fetched mailbox")
+
+    def _normalize_plan(
+        self,
+        checkout: Path,
+        transition: TransitionPlan,
+    ) -> tuple[FileChange, ...]:
+        if not transition.commit_message.strip():
+            raise MailboxTransitionRejected("transition commit message must not be empty")
+        dirty = self._run(checkout, ("status", "--porcelain", "--untracked-files=all"))
+        if dirty.returncode != 0 or dirty.stdout:
+            raise MailboxTransitionRejected("transition callback mutated its read-only context")
+        if not transition.changes:
+            raise MailboxTransitionRejected("transition must change at least one document")
+        by_path: dict[str, FileChange] = {}
+        for change in transition.changes:
+            pure = PurePosixPath(change.path)
+            if (
+                pure.is_absolute()
+                or not change.path
+                or change.path != pure.as_posix()
+                or ".." in pure.parts
+                or ".git" in pure.parts
+            ):
+                raise MailboxTransitionRejected(f"unsafe mailbox path: {change.path!r}")
+            if change.path in by_path:
+                raise MailboxTransitionRejected(f"duplicate mailbox path: {change.path}")
+            if change.content is not None:
+                try:
+                    change.content.encode("utf-8")
+                except UnicodeEncodeError as error:
+                    raise MailboxTransitionRejected(
+                        f"{change.path}: mailbox documents must be UTF-8"
+                    ) from error
+            by_path[change.path] = change
+        return tuple(by_path[path] for path in sorted(by_path))
+
+    def _apply(self, checkout: Path, changes: tuple[FileChange, ...]) -> None:
+        for change in changes:
+            target = checkout / change.path
+            if change.content is None:
+                if target.exists():
+                    if not target.is_file() or target.is_symlink():
+                        raise MailboxTransitionRejected(
+                            f"{change.path}: only ordinary document files may be deleted"
+                        )
+                    target.unlink()
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if target.exists() and (not target.is_file() or target.is_symlink()):
+                raise MailboxTransitionRejected(
+                    f"{change.path}: only ordinary document files may be replaced"
+                )
+            target.write_text(change.content, encoding="utf-8")
+
+    def _stage_exact_changes(
+        self,
+        checkout: Path,
+        changes: tuple[FileChange, ...],
+    ) -> None:
+        staged = self._run(checkout, ("add", "-A"))
+        if staged.returncode != 0:
+            raise MailboxWriteError("could not stage mailbox transition")
+        changed = self._output_lines(
+            checkout,
+            ("diff", "--cached", "--name-only", "--diff-filter=ACDMRTUXB"),
+            "inspect staged mailbox transition",
+        )
+        declared = sorted(change.path for change in changes)
+        if changed != declared:
+            raise MailboxTransitionRejected(
+                "staged mailbox transition differs from its declared document set"
+            )
+
+    def _commit(self, checkout: Path, message: str) -> str:
+        committed = self._run(
+            checkout,
+            (
+                "-c",
+                "user.name=Atelier",
+                "-c",
+                "user.email=atelier@invalid",
+                "commit",
+                "--quiet",
+                "--no-gpg-sign",
+                "-m",
+                message,
+            ),
+        )
+        if committed.returncode != 0:
+            raise MailboxWriteError("could not commit mailbox transition")
+        return self._output(checkout, ("rev-parse", "HEAD"), "resolve mailbox commit")
+
+    def _read_back(self, checkout: Path, pending: PendingWrite) -> bool:
+        self._fetch_current(checkout)
+        ancestry = self._run(
+            checkout,
+            ("merge-base", "--is-ancestor", pending.commit, READBACK_REF),
+        )
+        if ancestry.returncode == 1:
+            return False
+        if ancestry.returncode != 0:
+            raise MailboxReadBackError(
+                f"{pending.operation}: could not verify commit ancestry"
+            )
+        for change in pending.changes:
+            shown = self._run(checkout, ("show", f"{pending.commit}:{change.path}"))
+            if change.content is None:
+                if shown.returncode == 0:
+                    raise MailboxReadBackError(
+                        f"{pending.operation}: {change.path} exists in the verified commit"
+                    )
+            elif shown.returncode != 0 or shown.stdout != change.content:
+                raise MailboxReadBackError(
+                    f"{pending.operation}: {change.path} differs in the verified commit"
+                )
+        return True
+
+    def _output(self, cwd: Path, arguments: Sequence[str], purpose: str) -> str:
+        result = self._run(cwd, arguments)
+        if result.returncode != 0:
+            raise MailboxWriteError(f"could not {purpose}")
+        return result.stdout.strip()
+
+    def _output_lines(self, cwd: Path, arguments: Sequence[str], purpose: str) -> list[str]:
+        output = self._output(cwd, arguments, purpose)
+        return sorted(line for line in output.splitlines() if line)
+
+
+def require_git() -> None:
+    """Raise an exact bootstrap error when Git is unavailable."""
+
+    if shutil.which("git") is None:
+        raise MailboxWriteError("Git is required for canonical mailbox writes")

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -363,6 +363,19 @@ class GitMailboxWriter:
                 raise MailboxTransitionRejected(f"unsafe mailbox path: {change.path!r}")
             if change.path in by_path:
                 raise MailboxTransitionRejected(f"duplicate mailbox path: {change.path}")
+            append_only = (
+                len(pure.parts) == 4
+                and pure.parts[0] == "work"
+                and pure.parts[2] in {"messages", "receipts"}
+            )
+            if append_only and change.content is None:
+                raise MailboxTransitionRejected(
+                    f"{change.path}: append-only mailbox documents cannot be deleted"
+                )
+            if append_only and (checkout / change.path).exists():
+                raise MailboxTransitionRejected(
+                    f"{change.path}: append-only mailbox document already exists"
+                )
             if change.content is not None:
                 try:
                     change.content.encode("utf-8")

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -248,11 +248,7 @@ class GitMailboxWriter:
                 latest_observed_revision = base_revision
                 self._reset(checkout)
                 snapshot = reconstruct_mailbox(checkout)
-                if snapshot["canonical_branch"] != self.branch:
-                    raise MailboxTransitionRejected(
-                        f"{operation}: manifest canonical branch "
-                        f"{snapshot['canonical_branch']!r} does not match {self.branch!r}"
-                    )
+                self._require_canonical_branch(snapshot, operation=operation)
                 with tempfile.TemporaryDirectory(
                     prefix="atelier-mailbox-context-"
                 ) as context_temporary:
@@ -279,7 +275,8 @@ class GitMailboxWriter:
                 changes = self._normalize_plan(checkout, transition)
                 prior_claims = self._read_prior_claims(checkout, changes)
                 self._apply(checkout, changes)
-                reconstruct_mailbox(checkout)
+                updated_snapshot = reconstruct_mailbox(checkout)
+                self._require_canonical_branch(updated_snapshot, operation=operation)
                 self._verify_claim_history(checkout, prior_claims, changes)
                 self._stage_exact_changes(checkout, changes)
                 commit = self._commit(checkout, transition.commit_message)
@@ -398,6 +395,18 @@ class GitMailboxWriter:
         cleaned = self._run(checkout, ("clean", "-ffdqx"))
         if reset.returncode != 0 or cleaned.returncode != 0:
             raise MailboxWriteError("could not reset isolated checkout to the fetched mailbox")
+
+    def _require_canonical_branch(
+        self,
+        snapshot: Mapping[str, Any],
+        *,
+        operation: str,
+    ) -> None:
+        if snapshot["canonical_branch"] != self.branch:
+            raise MailboxTransitionRejected(
+                f"{operation}: manifest canonical branch "
+                f"{snapshot['canonical_branch']!r} does not match {self.branch!r}"
+            )
 
     def _normalize_plan(
         self,

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -110,6 +110,39 @@ Revalidate = Callable[[TransitionContext], None]
 PlanTransition = Callable[[TransitionContext], TransitionPlan]
 
 
+def _valid_mailbox_document_path(path: PurePosixPath) -> bool:
+    parts = path.parts
+    if parts == ("atelier.yaml",):
+        return True
+    if len(parts) == 3:
+        collection, identifier, document = parts
+        return (
+            collection == "projects"
+            and identifier.startswith("prj_")
+            and document == "project.md"
+        ) or (
+            collection == "initiatives"
+            and identifier.startswith("ini_")
+            and document == "initiative.md"
+        ) or (
+            collection == "work"
+            and identifier.startswith("wrk_")
+            and document == "work.md"
+        )
+    if len(parts) == 4 and parts[0] == "work" and parts[1].startswith("wrk_"):
+        collection, document = parts[2:]
+        return (
+            collection == "messages"
+            and document.startswith("msg_")
+            and document.endswith(".md")
+        ) or (
+            collection == "receipts"
+            and document.startswith("rcp_")
+            and document.endswith(".md")
+        )
+    return False
+
+
 def run_git(
     cwd: Path | None,
     arguments: Sequence[str],
@@ -306,6 +339,7 @@ class GitMailboxWriter:
                 or change.path != pure.as_posix()
                 or ".." in pure.parts
                 or ".git" in pure.parts
+                or not _valid_mailbox_document_path(pure)
             ):
                 raise MailboxTransitionRejected(f"unsafe mailbox path: {change.path!r}")
             if change.path in by_path:

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol
 
-from .mailbox import reconstruct_mailbox
+from .mailbox import _read_yaml, reconstruct_mailbox
 
 READBACK_REF = "refs/remotes/atelier/canonical"
 GIT_COMMAND_TIMEOUT_SECONDS = 30
@@ -233,8 +233,10 @@ class GitMailboxWriter:
                 revalidate(context)
                 transition = plan(context)
                 changes = self._normalize_plan(checkout, transition)
+                prior_claims = self._read_prior_claims(checkout, changes)
                 self._apply(checkout, changes)
                 reconstruct_mailbox(checkout)
+                self._verify_claim_history(checkout, prior_claims)
                 self._stage_exact_changes(checkout, changes)
                 commit = self._commit(checkout, transition.commit_message)
                 self._verify_commit_shape(
@@ -385,6 +387,62 @@ class GitMailboxWriter:
                     ) from error
             by_path[change.path] = change
         return tuple(by_path[path] for path in sorted(by_path))
+
+    def _read_prior_claims(
+        self,
+        checkout: Path,
+        changes: tuple[FileChange, ...],
+    ) -> dict[str, Mapping[str, Any] | None]:
+        prior_claims: dict[str, Mapping[str, Any] | None] = {}
+        for change in changes:
+            pure = PurePosixPath(change.path)
+            if (
+                len(pure.parts) != 3
+                or pure.parts[0] != "work"
+                or pure.parts[2] != "work.md"
+                or change.content is None
+            ):
+                continue
+            target = checkout / change.path
+            if target.exists():
+                document, _ = _read_yaml(target, frontmatter=True, label=change.path)
+                prior_claims[change.path] = document["claim"]
+        return prior_claims
+
+    def _verify_claim_history(
+        self,
+        checkout: Path,
+        prior_claims: Mapping[str, Mapping[str, Any] | None],
+    ) -> None:
+        for path, prior_claim in prior_claims.items():
+            if prior_claim is None:
+                continue
+            document, _ = _read_yaml(checkout / path, frontmatter=True, label=path)
+            current_claim = document["claim"]
+            if current_claim is None or current_claim["id"] != prior_claim["id"]:
+                continue
+            prior_checkpoint = prior_claim["checkpoint"]
+            current_checkpoint = current_claim["checkpoint"]
+            prior_ledger = prior_checkpoint["authorizations"]
+            current_ledger = current_checkpoint["authorizations"]
+            if (
+                current_checkpoint["sequence"] < prior_checkpoint["sequence"]
+                or current_ledger[: len(prior_ledger)] != prior_ledger
+            ):
+                raise MailboxTransitionRejected(
+                    f"{path}: checkpoint authorization ledger is append-only"
+                )
+            sequence_advanced = (
+                current_checkpoint["sequence"] > prior_checkpoint["sequence"]
+            )
+            token_rotated = (
+                current_checkpoint["continuation_token"]
+                != prior_checkpoint["continuation_token"]
+            )
+            if sequence_advanced != token_rotated:
+                raise MailboxTransitionRejected(
+                    f"{path}: checkpoint sequence and continuation token must advance together"
+                )
 
     def _apply(self, checkout: Path, changes: tuple[FileChange, ...]) -> None:
         for change in changes:

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import stat
 import subprocess
 import tempfile
 from collections.abc import Callable, Mapping, Sequence
@@ -232,14 +233,29 @@ class GitMailboxWriter:
                         f"{operation}: manifest canonical branch "
                         f"{snapshot['canonical_branch']!r} does not match {self.branch!r}"
                     )
-                context = TransitionContext(
-                    checkout=checkout,
-                    base_revision=base_revision,
-                    snapshot=snapshot,
-                    attempt=attempt,
-                )
-                revalidate(context)
-                transition = plan(context)
+                with tempfile.TemporaryDirectory(
+                    prefix="atelier-mailbox-context-"
+                ) as context_temporary:
+                    context_checkout = Path(context_temporary) / "mailbox"
+                    shutil.copytree(
+                        checkout,
+                        context_checkout,
+                        ignore=shutil.ignore_patterns(".git"),
+                        symlinks=True,
+                    )
+                    context_fingerprint = self._context_fingerprint(context_checkout)
+                    context = TransitionContext(
+                        checkout=context_checkout,
+                        base_revision=base_revision,
+                        snapshot=snapshot,
+                        attempt=attempt,
+                    )
+                    revalidate(context)
+                    transition = plan(context)
+                    self._require_context_unchanged(
+                        context_checkout,
+                        expected=context_fingerprint,
+                    )
                 changes = self._normalize_plan(checkout, transition)
                 prior_claims = self._read_prior_claims(checkout, changes)
                 self._apply(checkout, changes)
@@ -370,9 +386,6 @@ class GitMailboxWriter:
     ) -> tuple[FileChange, ...]:
         if not transition.commit_message.strip():
             raise MailboxTransitionRejected("transition commit message must not be empty")
-        dirty = self._run(checkout, ("status", "--porcelain", "--untracked-files=all"))
-        if dirty.returncode != 0 or dirty.stdout:
-            raise MailboxTransitionRejected("transition callback mutated its read-only context")
         if not transition.changes:
             raise MailboxTransitionRejected("transition must change at least one document")
         by_path: dict[str, FileChange] = {}
@@ -411,6 +424,46 @@ class GitMailboxWriter:
                     ) from error
             by_path[change.path] = change
         return tuple(by_path[path] for path in sorted(by_path))
+
+    def _context_fingerprint(
+        self,
+        root: Path,
+    ) -> tuple[tuple[str, int, bytes | str | None], ...]:
+        entries: list[tuple[str, int, bytes | str | None]] = []
+
+        def visit(path: Path) -> None:
+            mode = path.lstat().st_mode
+            relative = "." if path == root else path.relative_to(root).as_posix()
+            if stat.S_ISLNK(mode):
+                entries.append((relative, mode, os.readlink(path)))
+                return
+            if stat.S_ISREG(mode):
+                entries.append((relative, mode, path.read_bytes()))
+                return
+            entries.append((relative, mode, None))
+            if stat.S_ISDIR(mode):
+                for child in sorted(path.iterdir(), key=lambda item: item.name):
+                    visit(child)
+
+        visit(root)
+        return tuple(entries)
+
+    def _require_context_unchanged(
+        self,
+        checkout: Path,
+        *,
+        expected: tuple[tuple[str, int, bytes | str | None], ...],
+    ) -> None:
+        try:
+            current = self._context_fingerprint(checkout)
+        except OSError as error:
+            raise MailboxTransitionRejected(
+                "transition callback mutated its read-only context"
+            ) from error
+        if current != expected:
+            raise MailboxTransitionRejected(
+                "transition callback mutated its read-only context"
+            )
 
     def _read_prior_claims(
         self,

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -236,7 +236,7 @@ class GitMailboxWriter:
                 prior_claims = self._read_prior_claims(checkout, changes)
                 self._apply(checkout, changes)
                 reconstruct_mailbox(checkout)
-                self._verify_claim_history(checkout, prior_claims)
+                self._verify_claim_history(checkout, prior_claims, changes)
                 self._stage_exact_changes(checkout, changes)
                 commit = self._commit(checkout, transition.commit_message)
                 self._verify_commit_shape(
@@ -419,13 +419,37 @@ class GitMailboxWriter:
         self,
         checkout: Path,
         prior_claims: Mapping[str, Mapping[str, Any] | None],
+        changes: tuple[FileChange, ...],
     ) -> None:
         for path, prior_claim in prior_claims.items():
             if prior_claim is None:
                 continue
             document, _ = _read_yaml(checkout / path, frontmatter=True, label=path)
             current_claim = document["claim"]
-            if current_claim is None or current_claim["id"] != prior_claim["id"]:
+            if current_claim is None:
+                continue
+            if current_claim["id"] != prior_claim["id"]:
+                work_id = PurePosixPath(path).parts[1]
+                for change in changes:
+                    receipt_path = PurePosixPath(change.path)
+                    if (
+                        change.content is None
+                        or len(receipt_path.parts) != 4
+                        or receipt_path.parts[:3] != ("work", work_id, "receipts")
+                    ):
+                        continue
+                    receipt, _ = _read_yaml(
+                        checkout / change.path,
+                        frontmatter=True,
+                        label=change.path,
+                    )
+                    if (
+                        receipt["outcome"] == "released"
+                        and receipt["claim_id"] == prior_claim["id"]
+                    ):
+                        raise MailboxTransitionRejected(
+                            f"{path}: release and new claim require distinct transitions"
+                        )
                 continue
             prior_checkpoint = prior_claim["checkpoint"]
             current_checkpoint = current_claim["checkpoint"]

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -429,6 +429,10 @@ class GitMailboxWriter:
             if current_claim is None:
                 continue
             if current_claim["id"] != prior_claim["id"]:
+                if current_claim["candidate"] != prior_claim["candidate"]:
+                    raise MailboxTransitionRejected(
+                        f"{path}: takeover must preserve the prior claim candidate"
+                    )
                 work_id = PurePosixPath(path).parts[1]
                 for change in changes:
                     receipt_path = PurePosixPath(change.path)
@@ -451,25 +455,42 @@ class GitMailboxWriter:
                             f"{path}: release and new claim require distinct transitions"
                         )
                 continue
+            binding_fields = (
+                "worker_run_id",
+                "work_revision",
+                "approved_commit",
+                "policy_commit",
+                "ticket_observation_digest",
+                "claimed_at",
+                "host",
+            )
+            if any(current_claim[field] != prior_claim[field] for field in binding_fields):
+                raise MailboxTransitionRejected(
+                    f"{path}: current claim authority bindings are immutable"
+                )
             prior_checkpoint = prior_claim["checkpoint"]
             current_checkpoint = current_claim["checkpoint"]
             prior_ledger = prior_checkpoint["authorizations"]
             current_ledger = current_checkpoint["authorizations"]
-            if (
-                current_checkpoint["sequence"] < prior_checkpoint["sequence"]
-                or current_ledger[: len(prior_ledger)] != prior_ledger
-            ):
+            sequence_delta = current_checkpoint["sequence"] - prior_checkpoint["sequence"]
+            if current_ledger[: len(prior_ledger)] != prior_ledger:
                 raise MailboxTransitionRejected(
                     f"{path}: checkpoint authorization ledger is append-only"
                 )
-            sequence_advanced = (
-                current_checkpoint["sequence"] > prior_checkpoint["sequence"]
-            )
+            if sequence_delta not in {0, 1}:
+                raise MailboxTransitionRejected(
+                    f"{path}: one transition may advance only one checkpoint sequence"
+                )
+            expected_ledger_size = len(prior_ledger) + sequence_delta
+            if len(current_ledger) != expected_ledger_size:
+                raise MailboxTransitionRejected(
+                    f"{path}: one checkpoint sequence requires one authorization entry"
+                )
             token_rotated = (
                 current_checkpoint["continuation_token"]
                 != prior_checkpoint["continuation_token"]
             )
-            if sequence_advanced != token_rotated:
+            if (sequence_delta == 1) != token_rotated:
                 raise MailboxTransitionRejected(
                     f"{path}: checkpoint sequence and continuation token must advance together"
                 )

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -148,12 +148,15 @@ def _valid_mailbox_document_path(path: PurePosixPath) -> bool:
 def run_git(
     cwd: Path | None,
     arguments: Sequence[str],
+    *,
+    environment: Mapping[str, str] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run Git without inheriting repository-scoped environment variables."""
 
+    source_environment = os.environ if environment is None else environment
     environment = {
         key: value
-        for key, value in os.environ.items()
+        for key, value in source_environment.items()
         if key
         not in {
             "GIT_DIR",
@@ -162,7 +165,9 @@ def run_git(
             "GIT_OBJECT_DIRECTORY",
             "GIT_ALTERNATE_OBJECT_DIRECTORIES",
             "GIT_PREFIX",
+            "GIT_CONFIG_PARAMETERS",
         }
+        and not key.startswith("GIT_CONFIG_")
     }
     environment["GIT_TERMINAL_PROMPT"] = "0"
     environment["GCM_INTERACTIVE"] = "Never"
@@ -197,7 +202,22 @@ class GitMailboxWriter:
         self.remote = remote
         self.branch = branch
         self.max_attempts = max_attempts
-        self._run = runner
+        if runner is run_git:
+            sealed_environment = dict(os.environ)
+
+            def sealed_runner(
+                cwd: Path | None,
+                arguments: Sequence[str],
+            ) -> subprocess.CompletedProcess[str]:
+                return run_git(
+                    cwd,
+                    arguments,
+                    environment=sealed_environment,
+                )
+
+            self._run = sealed_runner
+        else:
+            self._run = runner
         branch_check = self._run(None, ("check-ref-format", "--branch", branch))
         if branch_check.returncode != 0:
             raise ValueError(f"invalid canonical branch: {branch}")

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path, PurePosixPath
 from typing import Any, Protocol
 
-from .mailbox import _read_yaml, reconstruct_mailbox
+from .mailbox import _parse_yaml, _read_yaml, reconstruct_mailbox
 
 READBACK_REF = "refs/remotes/atelier/canonical"
 GIT_COMMAND_TIMEOUT_SECONDS = 30
@@ -302,6 +302,11 @@ class GitMailboxWriter:
             checkout = Path(temporary) / "mailbox"
             self._initialize(checkout)
             if not self._read_back(checkout, pending):
+                self._require_canonical_descendant(
+                    checkout,
+                    base_revision=pending.base_revision,
+                    operation=pending.operation,
+                )
                 return None
         return WriteResult(
             operation=pending.operation,
@@ -413,6 +418,8 @@ class GitMailboxWriter:
             if target.exists():
                 document, _ = _read_yaml(target, frontmatter=True, label=change.path)
                 prior_claims[change.path] = document["claim"]
+            else:
+                prior_claims[change.path] = None
         return prior_claims
 
     def _verify_claim_history(
@@ -422,17 +429,19 @@ class GitMailboxWriter:
         changes: tuple[FileChange, ...],
     ) -> None:
         for path, prior_claim in prior_claims.items():
-            if prior_claim is None:
-                continue
             document, _ = _read_yaml(checkout / path, frontmatter=True, label=path)
             current_claim = document["claim"]
             if current_claim is None:
+                continue
+            if prior_claim is None:
+                self._verify_new_claim(checkout, path, current_claim)
                 continue
             if current_claim["id"] != prior_claim["id"]:
                 if current_claim["candidate"] != prior_claim["candidate"]:
                     raise MailboxTransitionRejected(
                         f"{path}: takeover must preserve the prior claim candidate"
                     )
+                self._verify_new_claim(checkout, path, current_claim)
                 work_id = PurePosixPath(path).parts[1]
                 for change in changes:
                     receipt_path = PurePosixPath(change.path)
@@ -494,6 +503,75 @@ class GitMailboxWriter:
                 raise MailboxTransitionRejected(
                     f"{path}: checkpoint sequence and continuation token must advance together"
                 )
+            if current_claim["candidate"] != prior_claim["candidate"]:
+                if sequence_delta != 1 or current_claim["candidate"] is None:
+                    raise MailboxTransitionRejected(
+                        f"{path}: candidate changes require one publication checkpoint"
+                    )
+                publication = current_ledger[-1]
+                candidate_head = current_claim["candidate"]["head_revision"]
+                if (
+                    publication["phase"] != "candidate_published"
+                    or publication["candidate_head"] != candidate_head
+                    or publication["acknowledged_candidate_head"] != candidate_head
+                ):
+                    raise MailboxTransitionRejected(
+                        f"{path}: candidate publication checkpoint does not match candidate"
+                    )
+
+    def _verify_new_claim(
+        self,
+        checkout: Path,
+        path: str,
+        claim: Mapping[str, Any],
+    ) -> None:
+        checkpoint = claim["checkpoint"]
+        if checkpoint["sequence"] != 0 or checkpoint["authorizations"]:
+            raise MailboxTransitionRejected(
+                f"{path}: a new claim must begin with an empty checkpoint ledger"
+            )
+        historical_claims, historical_runs = self._historical_claim_identities(checkout, path)
+        if claim["id"] in historical_claims or claim["worker_run_id"] in historical_runs:
+            raise MailboxTransitionRejected(
+                f"{path}: released or replaced claim identities cannot become current again"
+            )
+
+    def _historical_claim_identities(
+        self,
+        checkout: Path,
+        path: str,
+    ) -> tuple[set[str], set[str]]:
+        revisions = self._output_lines(
+            checkout,
+            ("log", "--format=%H", READBACK_REF, "--", path),
+            "inspect historical claim identities",
+        )
+        claim_ids: set[str] = set()
+        worker_run_ids: set[str] = set()
+        for revision in revisions:
+            shown = self._run(checkout, ("show", f"{revision}:{path}"))
+            if shown.returncode != 0:
+                continue
+            lines = shown.stdout.splitlines()
+            if not lines or lines[0] != "---":
+                raise MailboxTransitionRejected(
+                    f"{path}: historical work document has invalid frontmatter"
+                )
+            try:
+                end = lines.index("---", 1)
+            except ValueError as error:
+                raise MailboxTransitionRejected(
+                    f"{path}: historical work document has invalid frontmatter"
+                ) from error
+            document = _parse_yaml(
+                "\n".join(lines[1:end]),
+                f"{path}@{revision}",
+            )
+            historical_claim = document["claim"]
+            if historical_claim is not None:
+                claim_ids.add(historical_claim["id"])
+                worker_run_ids.add(historical_claim["worker_run_id"])
+        return claim_ids, worker_run_ids
 
     def _apply(self, checkout: Path, changes: tuple[FileChange, ...]) -> None:
         for change in changes:

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -530,7 +530,7 @@ class GitMailboxWriter:
             raise MailboxTransitionRejected(
                 f"{path}: a new claim must begin with an empty checkpoint ledger"
             )
-        historical_claims, historical_runs = self._historical_claim_identities(checkout, path)
+        historical_claims, historical_runs = self._historical_claim_identities(checkout)
         if claim["id"] in historical_claims or claim["worker_run_id"] in historical_runs:
             raise MailboxTransitionRejected(
                 f"{path}: released or replaced claim identities cannot become current again"
@@ -539,38 +539,53 @@ class GitMailboxWriter:
     def _historical_claim_identities(
         self,
         checkout: Path,
-        path: str,
     ) -> tuple[set[str], set[str]]:
+        work_pathspec = ":(glob)work/*/work.md"
         revisions = self._output_lines(
             checkout,
-            ("log", "--format=%H", READBACK_REF, "--", path),
+            ("log", "--format=%H", READBACK_REF, "--", work_pathspec),
             "inspect historical claim identities",
         )
         claim_ids: set[str] = set()
         worker_run_ids: set[str] = set()
         for revision in revisions:
-            shown = self._run(checkout, ("show", f"{revision}:{path}"))
-            if shown.returncode != 0:
-                continue
-            lines = shown.stdout.splitlines()
-            if not lines or lines[0] != "---":
-                raise MailboxTransitionRejected(
-                    f"{path}: historical work document has invalid frontmatter"
-                )
-            try:
-                end = lines.index("---", 1)
-            except ValueError as error:
-                raise MailboxTransitionRejected(
-                    f"{path}: historical work document has invalid frontmatter"
-                ) from error
-            document = _parse_yaml(
-                "\n".join(lines[1:end]),
-                f"{path}@{revision}",
+            changed_paths = self._output_lines(
+                checkout,
+                (
+                    "diff-tree",
+                    "--root",
+                    "--no-commit-id",
+                    "--name-only",
+                    "-r",
+                    revision,
+                    "--",
+                    work_pathspec,
+                ),
+                "inspect historical work document paths",
             )
-            historical_claim = document["claim"]
-            if historical_claim is not None:
-                claim_ids.add(historical_claim["id"])
-                worker_run_ids.add(historical_claim["worker_run_id"])
+            for path in changed_paths:
+                shown = self._run(checkout, ("show", f"{revision}:{path}"))
+                if shown.returncode != 0:
+                    continue
+                lines = shown.stdout.splitlines()
+                if not lines or lines[0] != "---":
+                    raise MailboxTransitionRejected(
+                        f"{path}: historical work document has invalid frontmatter"
+                    )
+                try:
+                    end = lines.index("---", 1)
+                except ValueError as error:
+                    raise MailboxTransitionRejected(
+                        f"{path}: historical work document has invalid frontmatter"
+                    ) from error
+                document = _parse_yaml(
+                    "\n".join(lines[1:end]),
+                    f"{path}@{revision}",
+                )
+                historical_claim = document["claim"]
+                if historical_claim is not None:
+                    claim_ids.add(historical_claim["id"])
+                    worker_run_ids.add(historical_claim["worker_run_id"])
         return claim_ids, worker_run_ids
 
     def _apply(self, checkout: Path, changes: tuple[FileChange, ...]) -> None:


### PR DESCRIPTION
## TL;DR

Adds fail-closed verified Git mailbox writes that publish one semantic transition through exact-ref compare-and-swap and confirm canonical remote persistence.

## Summary

- Introduces the production Git mailbox writer with bounded, noninteractive fetch, revalidation, commit, exact-lease push, and remote read-back.
- Recovers ambiguous push outcomes idempotently while rejecting canonical history loss, stale authority, conflicting transitions, and unverifiable persistence.
- Preserves append-only messages, receipts, checkpoint history, claim identity, candidate handoff, and canonical branch identity across retries and lifecycle changes.
- Isolates planning callbacks from Git transport state and seals transport configuration against callback redirection.
- Documents the production write boundary and exercises the required disposable mailbox protocol scenarios.

## Validation

- `just lint`
- `just test` — 107 tests and all 16 disposable protocol scenarios passed
- Repository-owned correctness and code-simplicity review clean at `2ad3d522e2d71c466c6f1c60300e2031f9783083`

## Tickets

Fixes #776
