### PR TITLE
feat(plan): promote approved assignments

### DIFF
--- a/contract_tests/test_planning.py
+++ b/contract_tests/test_planning.py
@@ -1,0 +1,509 @@
+"""Executable contract for one explicitly approved GitHub-backed assignment."""
+
+from __future__ import annotations
+
+import copy
+import json
+import subprocess
+import tempfile
+import unittest
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from contract_tests import test_mailbox as fixtures
+from skills.atelier.scripts.git_mailbox import MailboxTransitionRejected
+from skills.atelier.scripts.mailbox import _read_yaml, reconstruct_mailbox
+from skills.atelier.scripts.planning import (
+    ApprovalEnvelope,
+    AssignmentDraft,
+    InitiativeDraft,
+    Planner,
+    PlanningError,
+    PolicyTarget,
+    new_identifier,
+)
+
+OBSERVED_AT = datetime(2026, 7, 28, 4, tzinfo=UTC)
+AUTHORITY = (
+    "repository.candidate.create",
+    "repository.candidate.push",
+    "pull_request.create",
+    "pull_request.update",
+    "review.reply",
+    "review.resolve",
+)
+EVIDENCE = (
+    "candidate-remote-reachable",
+    "pull-request-head-current",
+    "pull-request-open",
+    "pull-request-mergeable",
+    "required-checks-pass",
+    "required-validation-reported",
+    "independent-review-current",
+    "unresolved-feedback-zero",
+)
+
+
+def git(cwd: Path | None, *arguments: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def write_json(path: Path, value: object) -> None:
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def issue_reference(number: int, *, state: str = "OPEN") -> dict[str, object]:
+    return {
+        "id": f"issue-{number}",
+        "number": number,
+        "title": f"Issue {number}",
+        "state": state,
+        "url": f"https://github.com/example/project-1/issues/{number}",
+    }
+
+
+def observation(*, blocked: bool = False, with_pull_request: bool = False) -> dict[str, Any]:
+    issue = issue_reference(777)
+    issue.update(
+        {
+            "body": "Implement one complete planning assignment.",
+            "updated_at": "2026-07-28T04:00:00Z",
+            "parent": issue_reference(772),
+            "sub_issues": [],
+            "blocked_by": [issue_reference(776, state="OPEN" if blocked else "CLOSED")],
+            "blocking": [issue_reference(778)],
+        }
+    )
+    pull_request = None
+    if with_pull_request:
+        pull_request = {
+            "id": "pull-request-900",
+            "number": 900,
+            "title": "Existing implementation",
+            "body": "Refs #777",
+            "url": "https://github.com/example/project-1/pull/900",
+            "state": "OPEN",
+            "is_draft": False,
+            "merged": False,
+            "mergeable": "MERGEABLE",
+            "merge_state_status": "CLEAN",
+            "review_decision": None,
+            "base": {
+                "repository": "example/project-1",
+                "ref": "refs/heads/main",
+                "sha": "a" * 40,
+            },
+            "head": {
+                "repository": "example/project-1",
+                "ref": "refs/heads/feature",
+                "sha": "b" * 40,
+            },
+            "updated_at": "2026-07-28T04:00:00Z",
+        }
+    return {
+        "schema": "atelier.github-observation/v1",
+        "observed_at": "2026-07-28T04:00:00Z",
+        "repository": {
+            "id": "repository-project-1",
+            "name_with_owner": "example/project-1",
+            "url": "https://github.com/example/project-1",
+        },
+        "issue": issue,
+        "issue_comments": [],
+        "pull_request": pull_request,
+        "pull_request_comments": [],
+        "reviews": [],
+        "checks": [],
+        "threads": [],
+        "completeness": {
+            "issue": True,
+            "issue_comments": True,
+            "issue_relationships": True,
+            "pull_request": True,
+            "pull_request_comments": True,
+            "reviews": True,
+            "checks": True,
+            "threads": True,
+        },
+    }
+
+
+class PlanningContract(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="atelier-planning-test-")
+        self.root = Path(self.temporary.name)
+        self.mailbox_remote = self.root / "mailbox.git"
+        git(None, "init", "--bare", "--initial-branch=main", str(self.mailbox_remote))
+        mailbox_seed = self.root / "mailbox-seed"
+        git(None, "clone", str(self.mailbox_remote), str(mailbox_seed))
+        mailbox = fixtures.MailboxFixture(mailbox_seed)
+        self.project_id, self.repository = mailbox.add_project(1)
+        git(mailbox_seed, "add", "-A")
+        git(
+            mailbox_seed,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "-m",
+            "seed mailbox",
+        )
+        git(mailbox_seed, "push", "origin", "HEAD:main")
+
+        self.project_remote = self.root / "project.git"
+        git(None, "init", "--bare", "--initial-branch=main", str(self.project_remote))
+        self.project_checkout = self.root / "project"
+        git(None, "clone", str(self.project_remote), str(self.project_checkout))
+        self.policy_path = self.project_checkout / ".atelier/policy.yaml"
+        self.policy_path.parent.mkdir(parents=True)
+        self.write_policy()
+        git(self.project_checkout, "add", "-A")
+        git(
+            self.project_checkout,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "-m",
+            "add project policy",
+        )
+        git(self.project_checkout, "push", "origin", "HEAD:main")
+        self.policy_commit = git(self.project_checkout, "rev-parse", "HEAD").stdout.strip()
+
+        self.observation_path = self.root / "observation.json"
+        write_json(self.observation_path, observation())
+        self.work_id = fixtures.identifier("wrk", 777)
+        self.initiative_id = fixtures.identifier("ini", 777)
+        self.planner = Planner(str(self.mailbox_remote), "main")
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_policy(self, *, repository: str | None = None) -> None:
+        value = {
+            "schema": "atelier.project-policy/v1",
+            "mailbox": {
+                "remote": str(self.mailbox_remote),
+                "realm_id": "personal",
+                "canonical_branch": "main",
+                "project_id": self.project_id,
+            },
+            "repository": {
+                "identity": repository or self.repository,
+                "canonical_ref": "refs/heads/main",
+            },
+            "ticket": {
+                "provider": "github",
+                "allowed_states": ["open"],
+                "require_no_blockers": True,
+                "material_fields": ["body", "state", "relationships"],
+            },
+            "execution": {
+                "capability": "agent-scripts.implement-ticket/delegated-execution/v1",
+                "delivery_outcome": "ready_pr",
+                "parallel_assignments": False,
+            },
+            "authority": {"allow": list(AUTHORITY)},
+            "validation": {"required_commands": ["just test", "just lint"]},
+            "acceptance": {"actor": "operator", "evidence": list(EVIDENCE)},
+        }
+        fixtures.write_yaml(self.policy_path, value)
+
+    def assignment(self, *, intent: str = "Produce durable approved intent.") -> AssignmentDraft:
+        return AssignmentDraft(
+            id=self.work_id,
+            title="Plan one assignment",
+            project_id=self.project_id,
+            initiative_id=self.initiative_id,
+            dependencies=(),
+            replaces=(),
+            ticket_number=777,
+            ticket_url="https://github.com/example/project-1/issues/777",
+            intent=intent,
+            rationale="A fresh worker needs a complete contract.",
+            scope="Create, revise, preview, and explicitly promote one assignment.",
+            non_goals="Do not claim work or implement the linked ticket.",
+            constraints="Use the Git mailbox as the only shared state.",
+            edge_cases="Reject stale tickets, policies, revisions, and previews.",
+            related_context="The initiative may describe a cross-project outcome.",
+            done_definition="The approved revision is independently understandable.",
+            verification_expectations="Run the repository contract tests.",
+            review_shape_guidance="Keep this as one human-shaped ready-PR change.",
+        )
+
+    def initiative(
+        self,
+        *,
+        outcome: str = "Coordinate one accountable outcome.",
+    ) -> InitiativeDraft:
+        return InitiativeDraft(
+            id=self.initiative_id,
+            title="Accountable planning",
+            intent="Preserve intent across planner and worker tasks.",
+            rationale="Host transcripts are not durable coordination.",
+            non_goals="Do not grant execution authority.",
+            constraints="Assignments remain repository-specific.",
+            edge_cases="A later project may join without changing approved work.",
+            related_context="The first assignment belongs to example/project-1.",
+            outcome=outcome,
+        )
+
+    def policy_target(self) -> PolicyTarget:
+        return PolicyTarget(
+            checkout=self.project_checkout,
+            remote="origin",
+            canonical_ref="refs/heads/main",
+            path=".atelier/policy.yaml",
+        )
+
+    def envelope(self) -> ApprovalEnvelope:
+        return ApprovalEnvelope(AUTHORITY, EVIDENCE)
+
+    def mailbox_clone(self) -> Path:
+        checkout = self.root / f"read-{new_identifier('wrk')}"
+        git(None, "clone", str(self.mailbox_remote), str(checkout))
+        return checkout
+
+    def create(self) -> None:
+        self.planner.create_draft(
+            self.assignment(),
+            initiative=self.initiative(),
+            observation_path=self.observation_path,
+            observation_not_before=OBSERVED_AT,
+            now=OBSERVED_AT + timedelta(seconds=30),
+        )
+
+    def preview(self):
+        return self.planner.preview_approval(
+            self.work_id,
+            expected_revision=1,
+            envelope=self.envelope(),
+            policy_target=self.policy_target(),
+            observation_path=self.observation_path,
+            observation_not_before=OBSERVED_AT,
+            now=OBSERVED_AT + timedelta(seconds=30),
+        )
+
+    def refresh_observation_after_approval(self) -> datetime:
+        approved_at = OBSERVED_AT + timedelta(minutes=1)
+        refreshed = observation()
+        refreshed["observed_at"] = "2026-07-28T04:01:00Z"
+        write_json(self.observation_path, refreshed)
+        return approved_at
+
+    def test_create_publishes_one_non_executable_initiative_and_assignment(self) -> None:
+        result = self.planner.create_draft(
+            self.assignment(),
+            initiative=self.initiative(),
+            observation_path=self.observation_path,
+            observation_not_before=OBSERVED_AT,
+            now=OBSERVED_AT + timedelta(seconds=30),
+        )
+
+        checkout = self.mailbox_clone()
+        work, body = _read_yaml(
+            checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+        )
+        initiative, initiative_body = _read_yaml(
+            checkout / f"initiatives/{self.initiative_id}/initiative.md",
+            frontmatter=True,
+        )
+        snapshot = reconstruct_mailbox(checkout)
+        self.assertEqual(result.commit, git(checkout, "rev-parse", "HEAD").stdout.strip())
+        self.assertEqual(work["status"], "draft")
+        self.assertEqual(work["revision"], 1)
+        self.assertIsNone(work["approval"])
+        self.assertIsNone(work["claim"])
+        self.assertIn("## Verification Expectations", body)
+        self.assertEqual(initiative["id"], self.initiative_id)
+        self.assertIn("## Outcome", initiative_body)
+        self.assertNotIn(self.work_id, snapshot["views"]["ready"])
+
+    def test_revision_changes_exact_draft_and_keeps_it_non_executable(self) -> None:
+        self.create()
+        result = self.planner.revise_draft(
+            self.assignment(intent="Revise the durable intent."),
+            expected_revision=1,
+            initiative=self.initiative(outcome="Revise the cross-project explanation."),
+            observation_path=self.observation_path,
+            observation_not_before=OBSERVED_AT,
+            now=OBSERVED_AT + timedelta(seconds=30),
+        )
+
+        checkout = self.mailbox_clone()
+        work, body = _read_yaml(
+            checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+        )
+        self.assertEqual(result.revision, 2)
+        self.assertEqual(work["revision"], 2)
+        self.assertEqual(work["status"], "draft")
+        self.assertIsNone(work["approval"])
+        self.assertIn("Revise the durable intent.", body)
+
+    def test_only_explicit_operator_confirmation_promotes_exact_preview(self) -> None:
+        self.create()
+        preview = self.preview()
+        before = git(
+            None,
+            "--git-dir",
+            str(self.mailbox_remote),
+            "rev-parse",
+            "main",
+        ).stdout.strip()
+
+        with self.assertRaisesRegex(PlanningError, "explicit operator approval"):
+            self.planner.approve(
+                preview,
+                approved_by="planner",
+                approved_at=OBSERVED_AT + timedelta(minutes=1),
+                policy_target=self.policy_target(),
+                observation_path=self.observation_path,
+                observation_not_before=OBSERVED_AT,
+                now=OBSERVED_AT + timedelta(seconds=30),
+            )
+        self.assertEqual(
+            before,
+            git(None, "--git-dir", str(self.mailbox_remote), "rev-parse", "main").stdout.strip(),
+        )
+
+        approved_at = self.refresh_observation_after_approval()
+        result = self.planner.approve(
+            preview,
+            approved_by="operator",
+            approved_at=approved_at,
+            policy_target=self.policy_target(),
+            observation_path=self.observation_path,
+            observation_not_before=approved_at,
+            now=approved_at + timedelta(seconds=30),
+        )
+        checkout = self.mailbox_clone()
+        work, _ = _read_yaml(
+            checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+        )
+        self.assertEqual(result.status, "approved")
+        self.assertEqual(work["status"], "approved")
+        self.assertEqual(work["approval"]["revision"], 1)
+        self.assertEqual(work["approval"]["policy"]["commit"], self.policy_commit)
+        self.assertEqual(work["approval"]["authority_ceiling"], list(AUTHORITY))
+        self.assertEqual(
+            work["approval"]["acceptance"]["required_evidence"],
+            list(EVIDENCE),
+        )
+        self.assertIsNone(work["claim"])
+
+    def test_promotion_rejects_stale_or_ineligible_ticket_state(self) -> None:
+        self.create()
+        preview = self.preview()
+        stale = observation()
+        stale["observed_at"] = "2026-07-28T03:00:00Z"
+        write_json(self.observation_path, stale)
+        with self.assertRaisesRegex(PlanningError, "live-read boundary"):
+            self.planner.approve(
+                preview,
+                approved_by="operator",
+                approved_at=OBSERVED_AT,
+                policy_target=self.policy_target(),
+                observation_path=self.observation_path,
+                observation_not_before=OBSERVED_AT,
+                now=OBSERVED_AT + timedelta(seconds=30),
+            )
+
+        write_json(self.observation_path, observation(blocked=True))
+        with self.assertRaisesRegex(PlanningError, "unresolved blockers"):
+            self.preview()
+
+        write_json(self.observation_path, observation(with_pull_request=True))
+        with self.assertRaisesRegex(PlanningError, "pull-request observation"):
+            self.preview()
+
+    def test_promotion_rejects_policy_and_draft_drift_after_preview(self) -> None:
+        self.create()
+        preview = self.preview()
+        self.write_policy(repository="github:example/other")
+        git(self.project_checkout, "add", "-A")
+        git(
+            self.project_checkout,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "-m",
+            "change policy identity",
+        )
+        git(self.project_checkout, "push", "origin", "HEAD:main")
+        approved_at = self.refresh_observation_after_approval()
+        with self.assertRaisesRegex(PlanningError, "does not match project"):
+            self.planner.approve(
+                preview,
+                approved_by="operator",
+                approved_at=approved_at,
+                policy_target=self.policy_target(),
+                observation_path=self.observation_path,
+                observation_not_before=approved_at,
+                now=approved_at + timedelta(seconds=30),
+            )
+
+        git(self.project_checkout, "reset", "--hard", self.policy_commit)
+        git(self.project_checkout, "push", "--force", "origin", "HEAD:main")
+        self.planner.revise_draft(
+            self.assignment(intent="A later unapproved revision."),
+            expected_revision=1,
+            initiative=self.initiative(),
+            observation_path=self.observation_path,
+            observation_not_before=approved_at,
+            now=approved_at + timedelta(seconds=30),
+        )
+        with self.assertRaisesRegex(
+            (PlanningError, MailboxTransitionRejected),
+            "expected revision 1|previewed work",
+        ):
+            self.planner.approve(
+                preview,
+                approved_by="operator",
+                approved_at=approved_at,
+                policy_target=self.policy_target(),
+                observation_path=self.observation_path,
+                observation_not_before=approved_at,
+                now=approved_at + timedelta(seconds=30),
+            )
+
+    def test_preview_digest_ignores_attribution_only_title_drift(self) -> None:
+        self.create()
+        first = self.preview()
+        updated = copy.deepcopy(observation())
+        updated["issue"]["title"] = "Renamed ticket"
+        write_json(self.observation_path, updated)
+        second = self.preview()
+        self.assertEqual(first.preview_digest, second.preview_digest)
+
+    def test_ids_are_uuidv7_and_invalid_or_incomplete_drafts_fail_closed(self) -> None:
+        self.assertRegex(
+            new_identifier("wrk"),
+            r"^wrk_[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+        )
+        incomplete = self.assignment(intent=" ")
+        with self.assertRaisesRegex(PlanningError, "assignment.intent"):
+            self.planner.create_draft(
+                incomplete,
+                initiative=self.initiative(),
+                observation_path=self.observation_path,
+                observation_not_before=OBSERVED_AT,
+                now=OBSERVED_AT + timedelta(seconds=30),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contract_tests/test_planning.py
+++ b/contract_tests/test_planning.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import Any
 
 from contract_tests import test_mailbox as fixtures
-from skills.atelier.scripts.git_mailbox import MailboxTransitionRejected
+from skills.atelier.scripts.git_mailbox import MailboxTransitionRejected, TransitionContext
 from skills.atelier.scripts.mailbox import _read_yaml, reconstruct_mailbox
 from skills.atelier.scripts.planning import (
     ApprovalEnvelope,
@@ -188,12 +188,17 @@ class PlanningContract(unittest.TestCase):
     def tearDown(self) -> None:
         self.temporary.cleanup()
 
-    def write_policy(self, *, repository: str | None = None) -> None:
+    def write_policy(
+        self,
+        *,
+        repository: str | None = None,
+        realm_id: str = "personal",
+    ) -> None:
         value = {
             "schema": "atelier.project-policy/v1",
             "mailbox": {
                 "remote": str(self.mailbox_remote),
-                "realm_id": "personal",
+                "realm_id": realm_id,
                 "canonical_branch": "main",
                 "project_id": self.project_id,
             },
@@ -479,6 +484,88 @@ class PlanningContract(unittest.TestCase):
                 observation_not_before=approved_at,
                 now=approved_at + timedelta(seconds=30),
             )
+
+    def test_plan_time_reread_rejects_drift_after_revalidation(self) -> None:
+        self.create()
+        preview = self.preview()
+        checkout = self.mailbox_clone()
+        base_revision = git(checkout, "rev-parse", "HEAD").stdout.strip()
+        before = git(
+            None,
+            "--git-dir",
+            str(self.mailbox_remote),
+            "rev-parse",
+            "main",
+        ).stdout.strip()
+
+        def mutate_observation() -> None:
+            changed = observation()
+            changed["issue"]["body"] = "Material body drift after revalidation."
+            write_json(self.observation_path, changed)
+
+        class InterleavingWriter:
+            def publish(self, operation, *, revalidate, plan):
+                context = TransitionContext(
+                    checkout=checkout,
+                    base_revision=base_revision,
+                    snapshot=reconstruct_mailbox(checkout),
+                    attempt=1,
+                )
+                revalidate(context)
+                mutate_observation()
+                plan(context)
+                raise AssertionError(f"{operation}: drift was not rejected")
+
+        planner = Planner(
+            str(self.mailbox_remote),
+            "main",
+            writer=InterleavingWriter(),
+        )
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "previewed work, policy, ticket, or authority changed",
+        ):
+            planner.approve(
+                preview,
+                approved_by="operator",
+                approved_at=OBSERVED_AT,
+                policy_target=self.policy_target(),
+                observation_path=self.observation_path,
+                observation_not_before=OBSERVED_AT,
+                now=OBSERVED_AT + timedelta(seconds=30),
+            )
+        self.assertEqual(
+            before,
+            git(
+                None,
+                "--git-dir",
+                str(self.mailbox_remote),
+                "rev-parse",
+                "main",
+            ).stdout.strip(),
+        )
+
+    def test_preview_rejects_policy_from_another_mailbox_realm(self) -> None:
+        self.create()
+        self.write_policy(realm_id="other")
+        git(self.project_checkout, "add", "-A")
+        git(
+            self.project_checkout,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "-m",
+            "change policy realm",
+        )
+        git(self.project_checkout, "push", "origin", "HEAD:main")
+
+        with self.assertRaisesRegex(
+            PlanningError,
+            "realm does not match the canonical mailbox",
+        ):
+            self.preview()
 
     def test_preview_digest_ignores_attribution_only_title_drift(self) -> None:
         self.create()

--- a/contract_tests/test_planning.py
+++ b/contract_tests/test_planning.py
@@ -283,6 +283,14 @@ class PlanningContract(unittest.TestCase):
         git(None, "clone", str(self.mailbox_remote), str(checkout))
         return checkout
 
+    def initiative_digest(self) -> str:
+        checkout = self.mailbox_clone()
+        content = (
+            checkout
+            / f"initiatives/{self.initiative_id}/initiative.md"
+        ).read_bytes()
+        return f"sha256:{hashlib.sha256(content).hexdigest()}"
+
     def create(self) -> None:
         self.planner.create_draft(
             self.assignment(),
@@ -378,6 +386,7 @@ class PlanningContract(unittest.TestCase):
             self.assignment(intent="Revise the durable intent."),
             expected_revision=1,
             initiative=self.initiative(outcome="Revise the cross-project explanation."),
+            expected_initiative_digest=self.initiative_digest(),
             observation_path=self.observation_path,
             observation_not_before=OBSERVED_AT,
             now=OBSERVED_AT + timedelta(seconds=30),
@@ -525,6 +534,35 @@ class PlanningContract(unittest.TestCase):
                 self.assertEqual(completed.returncode, 1, completed.stdout)
                 self.assertIn(expected_error, completed.stderr)
 
+    def test_approval_tolerates_unrelated_mailbox_advance(self) -> None:
+        self.create()
+        preview = self.preview()
+        unrelated = replace(
+            self.assignment(),
+            id=new_identifier("wrk"),
+            initiative_id=None,
+            intent="An unrelated draft must not invalidate the preview.",
+        )
+        self.planner.create_draft(
+            unrelated,
+            observation_path=self.observation_path,
+            observation_not_before=OBSERVED_AT,
+            now=OBSERVED_AT + timedelta(seconds=30),
+        )
+        approved_at = self.refresh_observation_after_approval()
+
+        result = self.planner.approve(
+            preview,
+            approved_by="operator",
+            approved_at=approved_at,
+            policy_target=self.policy_target(),
+            observation_path=self.observation_path,
+            observation_not_before=approved_at,
+            now=approved_at + timedelta(seconds=30),
+        )
+
+        self.assertEqual(result.status, "approved")
+
     def test_promotion_rejects_stale_or_ineligible_ticket_state(self) -> None:
         self.create()
         preview = self.preview()
@@ -584,6 +622,7 @@ class PlanningContract(unittest.TestCase):
             self.assignment(intent="A later unapproved revision."),
             expected_revision=1,
             initiative=self.initiative(),
+            expected_initiative_digest=self.initiative_digest(),
             observation_path=self.observation_path,
             observation_not_before=approved_at,
             now=approved_at + timedelta(seconds=30),
@@ -676,6 +715,7 @@ class PlanningContract(unittest.TestCase):
             replace(second, intent="Revise the shared planning context."),
             expected_revision=1,
             initiative=self.initiative(outcome="A different, unapproved outcome."),
+            expected_initiative_digest=self.initiative_digest(),
             observation_path=self.observation_path,
             observation_not_before=OBSERVED_AT,
             now=OBSERVED_AT + timedelta(seconds=30),
@@ -695,6 +735,60 @@ class PlanningContract(unittest.TestCase):
                 observation_not_before=approved_at,
                 now=approved_at + timedelta(seconds=30),
             )
+
+    def test_shared_initiative_revision_rejects_stale_digest(self) -> None:
+        self.create()
+        second = replace(self.assignment(), id=new_identifier("wrk"))
+        self.planner.create_draft(
+            second,
+            observation_path=self.observation_path,
+            observation_not_before=OBSERVED_AT,
+            now=OBSERVED_AT + timedelta(seconds=30),
+        )
+        stale_digest = self.initiative_digest()
+        with self.assertRaisesRegex(
+            PlanningError,
+            "requires its expected lowercase SHA-256 digest",
+        ):
+            self.planner.revise_draft(
+                self.assignment(intent="An unfenced initiative revision."),
+                expected_revision=1,
+                initiative=self.initiative(outcome="An unfenced shared outcome."),
+                observation_path=self.observation_path,
+                observation_not_before=OBSERVED_AT,
+                now=OBSERVED_AT + timedelta(seconds=30),
+            )
+        self.planner.revise_draft(
+            replace(second, intent="Publish the newer shared context."),
+            expected_revision=1,
+            initiative=self.initiative(outcome="The newer shared outcome."),
+            expected_initiative_digest=stale_digest,
+            observation_path=self.observation_path,
+            observation_not_before=OBSERVED_AT,
+            now=OBSERVED_AT + timedelta(seconds=30),
+        )
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "expected initiative digest",
+        ):
+            self.planner.revise_draft(
+                self.assignment(intent="A stale assignment revision."),
+                expected_revision=1,
+                initiative=self.initiative(outcome="The stale shared outcome."),
+                expected_initiative_digest=stale_digest,
+                observation_path=self.observation_path,
+                observation_not_before=OBSERVED_AT,
+                now=OBSERVED_AT + timedelta(seconds=30),
+            )
+
+        checkout = self.mailbox_clone()
+        initiative = (
+            checkout
+            / f"initiatives/{self.initiative_id}/initiative.md"
+        ).read_text(encoding="utf-8")
+        self.assertIn("The newer shared outcome.", initiative)
+        self.assertNotIn("The stale shared outcome.", initiative)
 
     def test_preview_rejects_policy_from_another_mailbox_realm(self) -> None:
         self.create()

--- a/contract_tests/test_planning.py
+++ b/contract_tests/test_planning.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import json
 import subprocess
 import tempfile
 import unittest
-from dataclasses import replace
+from dataclasses import asdict, replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -22,6 +23,8 @@ from skills.atelier.scripts.planning import (
     Planner,
     PlanningError,
     PolicyTarget,
+    _digest_json,
+    _preview_token_value,
     new_identifier,
 )
 
@@ -44,6 +47,7 @@ EVIDENCE = (
     "independent-review-current",
     "unresolved-feedback-zero",
 )
+PLANNING_SCRIPT = Path(__file__).parents[1] / "skills/atelier/scripts/planning.py"
 
 
 def git(cwd: Path | None, *arguments: str) -> subprocess.CompletedProcess[str]:
@@ -306,6 +310,39 @@ class PlanningContract(unittest.TestCase):
         write_json(self.observation_path, refreshed)
         return approved_at
 
+    def cli_common_request(self, observed_at: datetime) -> dict[str, Any]:
+        observed_at_text = observed_at.astimezone(UTC).isoformat().replace("+00:00", "Z")
+        refreshed = observation()
+        refreshed["observed_at"] = observed_at_text
+        write_json(self.observation_path, refreshed)
+        return {
+            "mailbox": {
+                "remote": str(self.mailbox_remote),
+                "canonical_branch": "main",
+            },
+            "observation": {
+                "path": str(self.observation_path),
+                "not_before": observed_at_text,
+            },
+            "policy": {
+                "checkout": str(self.project_checkout),
+                "remote": "origin",
+                "canonical_ref": "refs/heads/main",
+                "path": ".atelier/policy.yaml",
+            },
+        }
+
+    def run_cli(self, command: str, request: dict[str, Any]) -> subprocess.CompletedProcess[str]:
+        request_path = self.root / f"{command}-{new_identifier('wrk')}.json"
+        write_json(request_path, request)
+        return subprocess.run(
+            ["python3", str(PLANNING_SCRIPT), command, str(request_path)],
+            cwd=Path(__file__).parents[1],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
     def test_create_publishes_one_non_executable_initiative_and_assignment(self) -> None:
         result = self.planner.create_draft(
             self.assignment(),
@@ -408,6 +445,85 @@ class PlanningContract(unittest.TestCase):
             list(EVIDENCE),
         )
         self.assertIsNone(work["claim"])
+
+    def test_preview_cli_displays_and_binds_complete_approval_content(self) -> None:
+        self.create()
+        request = self.cli_common_request(datetime.now(UTC))
+        request.update(
+            {
+                "work_id": self.work_id,
+                "expected_revision": 1,
+                "envelope": {
+                    "authority_ceiling": list(AUTHORITY),
+                    "required_evidence": list(EVIDENCE),
+                },
+            }
+        )
+
+        completed = self.run_cli("preview", request)
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        preview = json.loads(completed.stdout)
+        self.assertIn("Produce durable approved intent.", preview["rendered_assignment"])
+        self.assertIn("Coordinate one accountable outcome.", preview["rendered_initiative"])
+        self.assertEqual(preview["ticket_repository"], "example/project-1")
+        self.assertEqual(preview["ticket_number"], 777)
+        self.assertEqual(
+            preview["ticket_url"],
+            "https://github.com/example/project-1/issues/777",
+        )
+        self.assertEqual(
+            preview["work_digest"],
+            f"sha256:{hashlib.sha256(preview['rendered_assignment'].encode()).hexdigest()}",
+        )
+        self.assertEqual(
+            preview["initiative_digest"],
+            f"sha256:{hashlib.sha256(preview['rendered_initiative'].encode()).hexdigest()}",
+        )
+
+    def test_approval_cli_rejects_noncanonical_or_contradictory_preview(self) -> None:
+        self.create()
+        preview = self.preview()
+        observed_at = datetime.now(UTC)
+        common = self.cli_common_request(observed_at)
+        approved_at = observed_at.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+        preview_values: list[tuple[str, dict[str, Any], str]] = []
+        unknown = asdict(preview)
+        unknown["future_authority"] = "unsupported"
+        preview_values.append(("unknown", unknown, "preview fields do not match"))
+        unsupported = asdict(preview)
+        unsupported["schema"] = "atelier.plan-preview/v999"
+        preview_values.append(("schema", unsupported, "unsupported preview schema"))
+        malformed = asdict(preview)
+        malformed["preview_digest"] = "not-a-digest"
+        preview_values.append(("digest", malformed, "lowercase SHA-256 digest"))
+        contradictory = replace(preview, policy_commit="0" * 40, preview_digest="")
+        contradictory = replace(
+            contradictory,
+            preview_digest=_digest_json(_preview_token_value(contradictory)),
+        )
+        preview_values.append(
+            (
+                "contradictory",
+                asdict(contradictory),
+                "previewed work, policy, ticket, or authority changed",
+            )
+        )
+
+        for label, preview_value, expected_error in preview_values:
+            with self.subTest(label=label):
+                request = copy.deepcopy(common)
+                request.update(
+                    {
+                        "preview": preview_value,
+                        "approved_by": "operator",
+                        "approved_at": approved_at,
+                    }
+                )
+                completed = self.run_cli("approve", request)
+                self.assertEqual(completed.returncode, 1, completed.stdout)
+                self.assertIn(expected_error, completed.stderr)
 
     def test_promotion_rejects_stale_or_ineligible_ticket_state(self) -> None:
         self.create()

--- a/contract_tests/test_planning.py
+++ b/contract_tests/test_planning.py
@@ -821,6 +821,44 @@ class PlanningContract(unittest.TestCase):
         second = self.preview()
         self.assertEqual(first.preview_digest, second.preview_digest)
 
+    def test_boolean_revision_identity_is_rejected_without_mailbox_write(self) -> None:
+        self.create()
+        before = git(
+            None,
+            "--git-dir",
+            str(self.mailbox_remote),
+            "rev-parse",
+            "main",
+        ).stdout.strip()
+
+        with self.assertRaisesRegex(PlanningError, "positive integer"):
+            self.planner.revise_draft(
+                self.assignment(intent="A malformed revision must not write."),
+                expected_revision=True,
+                observation_path=self.observation_path,
+                observation_not_before=OBSERVED_AT,
+                now=OBSERVED_AT + timedelta(seconds=30),
+            )
+        with self.assertRaisesRegex(PlanningError, "positive integer"):
+            self.planner.preview_approval(
+                self.work_id,
+                expected_revision=True,
+                envelope=self.envelope(),
+                policy_target=self.policy_target(),
+                observation_path=self.observation_path,
+                observation_not_before=OBSERVED_AT,
+                now=OBSERVED_AT + timedelta(seconds=30),
+            )
+
+        after = git(
+            None,
+            "--git-dir",
+            str(self.mailbox_remote),
+            "rev-parse",
+            "main",
+        ).stdout.strip()
+        self.assertEqual(after, before)
+
     def test_ids_are_uuidv7_and_invalid_or_incomplete_drafts_fail_closed(self) -> None:
         self.assertRegex(
             new_identifier("wrk"),

--- a/contract_tests/test_planning.py
+++ b/contract_tests/test_planning.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import tempfile
 import unittest
+from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -544,6 +545,40 @@ class PlanningContract(unittest.TestCase):
                 "main",
             ).stdout.strip(),
         )
+
+    def test_promotion_rejects_shared_initiative_drift_after_preview(self) -> None:
+        self.create()
+        preview = self.preview()
+        second = replace(self.assignment(), id=new_identifier("wrk"))
+        self.planner.create_draft(
+            second,
+            observation_path=self.observation_path,
+            observation_not_before=OBSERVED_AT,
+            now=OBSERVED_AT + timedelta(seconds=30),
+        )
+        self.planner.revise_draft(
+            replace(second, intent="Revise the shared planning context."),
+            expected_revision=1,
+            initiative=self.initiative(outcome="A different, unapproved outcome."),
+            observation_path=self.observation_path,
+            observation_not_before=OBSERVED_AT,
+            now=OBSERVED_AT + timedelta(seconds=30),
+        )
+        approved_at = self.refresh_observation_after_approval()
+
+        with self.assertRaisesRegex(
+            (PlanningError, MailboxTransitionRejected),
+            "previewed work, policy, ticket, or authority changed",
+        ):
+            self.planner.approve(
+                preview,
+                approved_by="operator",
+                approved_at=approved_at,
+                policy_target=self.policy_target(),
+                observation_path=self.observation_path,
+                observation_not_before=approved_at,
+                now=approved_at + timedelta(seconds=30),
+            )
 
     def test_preview_rejects_policy_from_another_mailbox_realm(self) -> None:
         self.create()

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -82,8 +82,8 @@ def validate_skill(errors: list[str]) -> None:
         errors.append("Atelier skill frontmatter must include a description")
     if "[TODO:" in text:
         errors.append("Atelier skill contains a TODO placeholder")
-    if "not implemented yet" not in text:
-        errors.append("reset skill must state that production modes are unavailable")
+    if "The `work` and `audit` modes are not implemented yet" not in text:
+        errors.append("skill must state that work and audit modes are unavailable")
 
 
 def validate_reset_boundary(errors: list[str]) -> None:

--- a/skills/atelier/SKILL.md
+++ b/skills/atelier/SKILL.md
@@ -39,19 +39,22 @@ observation is missing or mismatched. Never scan for a substitute skill, use a
 copied workflow, treat cached prose as native state, or cross into a provider
 mutation.
 
-## Reset scaffold
+## Available modes
 
-This release is the post-CLI reset scaffold. Production `plan`, `work`, and
-`audit` behavior is not implemented yet. Do not emulate missing Atelier behavior
-with ad hoc orchestration, hidden local state, copied Agent Scripts workflows,
-or tracker mutations.
+Production `plan` behavior is implemented only for one GitHub-backed assignment.
+Before planning, read `references/planning.md` and follow its draft, revision,
+preview, explicit operator approval, and promotion boundary. Use
+`scripts/planning.py`; do not emulate a second persistence or approval path.
 
-When invoked before the required mode is implemented:
+The `work` and `audit` modes are not implemented yet. Do not emulate missing
+Atelier behavior with ad hoc orchestration, hidden local state, copied Agent
+Scripts workflows, or tracker mutations.
 
-1. Identify the requested mode: `plan`, `work`, or `audit`.
+When either unavailable mode is requested:
+
+1. Identify the requested mode: `work` or `audit`.
 1. Report that the mode is unavailable in the reset scaffold.
 1. Link the owning issue:
-   - `plan`: shaug/atelier#777
    - `work`: shaug/atelier#778 and shaug/atelier#779
    - `audit`: shaug/atelier#780
 1. Make no mailbox, repository, ticket, pull-request, or acceptance mutation.
@@ -63,9 +66,9 @@ production mode available.
 ## Mailbox boundary
 
 The strict v1 mailbox schema and fresh-clone reconstruction helper are
-implemented. Verified fast-forward canonical writes are also implemented, but
-every production mode remains unavailable. Before interpreting mailbox
-documents, read `references/mailbox-validation.md` and use its read-only helper.
+implemented. Verified fast-forward canonical writes and the bounded plan-mode
+transitions are also implemented. Before interpreting mailbox documents, read
+`references/mailbox-validation.md` and use its read-only helper.
 Before persisting a transition, read `references/git-mailbox-writes.md` and use
 its isolated compare-and-swap writer.
 

--- a/skills/atelier/references/planning.md
+++ b/skills/atelier/references/planning.md
@@ -4,8 +4,8 @@ Issue #777 implements only planning for one GitHub-backed assignment:
 
 - create one non-executable draft assignment and an optional initiative;
 - revise one exact draft revision;
-- preview the exact assignment, live ticket observation, current project policy,
-  authority ceiling, and acceptance evidence;
+- preview the exact assignment and referenced initiative, live ticket
+  observation, current project policy, authority ceiling, and acceptance evidence;
 - wait for explicit operator approval; and
 - promote only that previewed revision to `approved`.
 
@@ -197,9 +197,10 @@ Run:
 python3 scripts/planning.py approve /host/path/approve.json
 ```
 
-Approval rereads the canonical mailbox, current policy ref, and fresh GitHub
-observation. Any material ticket, policy, draft, revision, repository,
-authority, evidence, or preview drift rejects the transition. An
+Approval rereads the canonical mailbox, referenced initiative, current policy
+ref, and fresh GitHub observation. Any material ticket, policy, initiative,
+draft, revision, repository, authority, evidence, or preview drift rejects the
+transition. An
 attribution-only ticket-title change does not invalidate a policy material-field
 digest. A successful transition records:
 

--- a/skills/atelier/references/planning.md
+++ b/skills/atelier/references/planning.md
@@ -96,8 +96,11 @@ The transition writes one `draft` work document with `approval: null` and
 the initiative and work document are published in the same verified mailbox
 commit.
 
-`revise` uses the same shape plus `expected_revision`. It requires the work to
-remain `draft`, requires the exact expected revision, and increments it once:
+`revise` uses the same shape plus `expected_revision`. When it also replaces the
+referenced initiative, include `expected_initiative_digest` with the
+`sha256:<hex>` digest of the exact current initiative document. The transition
+requires the work to remain `draft`, requires both expected identities to remain
+current, and increments the work revision once:
 
 ```text
 python3 scripts/planning.py revise /host/path/revise.json

--- a/skills/atelier/references/planning.md
+++ b/skills/atelier/references/planning.md
@@ -171,8 +171,10 @@ The preview fails closed unless:
 
 Show the operator the complete rendered initiative and assignment, revision,
 ticket identity, policy commit and path, authority ceiling, acceptance evidence,
-and returned `preview_digest`. Do not treat a request to draft, revise, preview,
-or continue as approval.
+and returned `preview_digest`. The preview JSON carries the exact rendered
+documents and canonical GitHub repository, issue number, and URL; those displayed
+values are part of the digest. Do not treat a request to draft, revise, preview, or
+continue as approval.
 
 ## Explicit promotion
 
@@ -191,6 +193,9 @@ Copy the complete preview result into a separate approval request and add:
 Retain the same `mailbox`, use a newly captured `observation`, and repeat the
 same `policy` target. The observation live-read boundary must be at or after the
 operator confirmation timestamp; a preview-time observation cannot be reused.
+The `preview` object is strict: unknown fields, missing fields, unsupported schema
+versions, malformed identities or digests, and internally contradictory content
+are rejected before promotion.
 Run:
 
 ```text

--- a/skills/atelier/references/planning.md
+++ b/skills/atelier/references/planning.md
@@ -1,0 +1,215 @@
+# Plan-mode boundary
+
+Issue #777 implements only planning for one GitHub-backed assignment:
+
+- create one non-executable draft assignment and an optional initiative;
+- revise one exact draft revision;
+- preview the exact assignment, live ticket observation, current project policy,
+  authority ceiling, and acceptance evidence;
+- wait for explicit operator approval; and
+- promote only that previewed revision to `approved`.
+
+It does not claim work, choose a worker, invoke Agent Scripts, create or update a
+pull request, accept delivery, mutate a native ticket, merge, deploy, or clean up.
+
+## Required live inputs
+
+Before any command, complete the host preflight in `host-boundary.md`. The
+planner requires:
+
+- one complete `atelier.github-observation/v1` JSON document captured at or
+  after a caller-recorded live-read boundary;
+- one explicitly selected mailbox remote and canonical branch;
+- the stable active mailbox project identifier;
+- a managed-project checkout, remote, canonical full branch ref, and project
+  policy path; and
+- stable `ini_...` and `wrk_...` UUIDv7 identifiers generated before the first
+  create attempt.
+
+Generate identifiers once and retain them across ambiguous retries:
+
+```text
+python3 scripts/planning.py new-id ini
+python3 scripts/planning.py new-id wrk
+```
+
+The helper accepts one JSON request for each phase. Host-local paths occur only
+in the invocation request; they are never written to the mailbox.
+
+## Draft and revision
+
+`create` requires a complete `assignment`, an optional `initiative`, and the
+live observation boundary:
+
+```json
+{
+  "mailbox": {
+    "remote": "git@github.com:example/atelier-mailbox.git",
+    "canonical_branch": "main"
+  },
+  "observation": {
+    "path": "/host/path/github-observation.json",
+    "not_before": "2026-07-28T04:00:00Z"
+  },
+  "initiative": {
+    "id": "ini_019f9a9e-0000-7000-8000-000000000001",
+    "title": "Accountable outcome",
+    "intent": "Why this initiative exists.",
+    "rationale": "Why the outcome matters.",
+    "non_goals": "What the initiative excludes.",
+    "constraints": "Durable initiative constraints.",
+    "edge_cases": "Known cross-project edges.",
+    "related_context": "Context later assignments need.",
+    "outcome": "The initiative-level result."
+  },
+  "assignment": {
+    "id": "wrk_019f9a9e-0000-7000-8000-000000000001",
+    "title": "One reviewable change",
+    "project_id": "prj_019f9a9e-0000-7000-8000-000000000001",
+    "initiative_id": "ini_019f9a9e-0000-7000-8000-000000000001",
+    "dependencies": [],
+    "replaces": [],
+    "ticket_number": 123,
+    "ticket_url": "https://github.com/example/project/issues/123",
+    "intent": "The exact intended behavior.",
+    "rationale": "Why the project needs it.",
+    "scope": "The complete bounded implementation scope.",
+    "non_goals": "Named exclusions.",
+    "constraints": "Architecture and authority constraints.",
+    "edge_cases": "Known behavior at the boundary.",
+    "related_context": "Context that survives the planner task.",
+    "done_definition": "Observable completion criteria.",
+    "verification_expectations": "Required validation evidence.",
+    "review_shape_guidance": "How to keep the change human-shaped."
+  }
+}
+```
+
+Run:
+
+```text
+python3 scripts/planning.py create /host/path/create.json
+```
+
+The transition writes one `draft` work document with `approval: null` and
+`claim: null`. It creates no executable authority. If `initiative` is present,
+the initiative and work document are published in the same verified mailbox
+commit.
+
+`revise` uses the same shape plus `expected_revision`. It requires the work to
+remain `draft`, requires the exact expected revision, and increments it once:
+
+```text
+python3 scripts/planning.py revise /host/path/revise.json
+```
+
+Never silently fill a missing worker-contract section. Ask the operator for the
+missing intent, non-goal, constraint, edge case, done definition, verification
+expectation, or review-shape decision before creating or revising the draft.
+
+## Preview
+
+Build a preview request after the draft is complete:
+
+```json
+{
+  "mailbox": {
+    "remote": "git@github.com:example/atelier-mailbox.git",
+    "canonical_branch": "main"
+  },
+  "observation": {
+    "path": "/host/path/fresh-github-observation.json",
+    "not_before": "2026-07-28T04:05:00Z"
+  },
+  "work_id": "wrk_019f9a9e-0000-7000-8000-000000000001",
+  "expected_revision": 2,
+  "policy": {
+    "checkout": "/host/path/managed-project",
+    "remote": "origin",
+    "canonical_ref": "refs/heads/main",
+    "path": ".atelier/policy.yaml"
+  },
+  "envelope": {
+    "authority_ceiling": [
+      "repository.candidate.create",
+      "repository.candidate.push",
+      "pull_request.create",
+      "pull_request.update"
+    ],
+    "required_evidence": [
+      "candidate-remote-reachable",
+      "pull-request-head-current",
+      "pull-request-open",
+      "pull-request-mergeable",
+      "required-checks-pass",
+      "required-validation-reported",
+      "independent-review-current",
+      "unresolved-feedback-zero"
+    ]
+  }
+}
+```
+
+Run:
+
+```text
+python3 scripts/planning.py preview /host/path/preview.json
+```
+
+The preview fails closed unless:
+
+- the exact draft revision exists;
+- the project is active and repository-specific;
+- the complete GitHub observation is fresh;
+- the ticket link, repository, and observed identity agree;
+- the ticket state is allowed and every native blocker is closed;
+- no canonical pull-request observation already owns the ticket;
+- the current project policy is fetched from its canonical ref;
+- the project, mailbox, repository, policy path, and policy identities agree;
+- requested authority is a subset of current policy; and
+- proposed evidence includes everything current policy requires.
+
+Show the operator the complete rendered initiative and assignment, revision,
+ticket identity, policy commit and path, authority ceiling, acceptance evidence,
+and returned `preview_digest`. Do not treat a request to draft, revise, preview,
+or continue as approval.
+
+## Explicit promotion
+
+Pause after preview and ask the operator to approve that exact revision and
+envelope. Only a new, explicit operator confirmation authorizes `approve`.
+
+Copy the complete preview result into a separate approval request and add:
+
+```json
+{
+  "approved_by": "operator",
+  "approved_at": "2026-07-28T04:10:00Z"
+}
+```
+
+Retain the same `mailbox`, use a newly captured `observation`, and repeat the
+same `policy` target. The observation live-read boundary must be at or after the
+operator confirmation timestamp; a preview-time observation cannot be reused.
+Run:
+
+```text
+python3 scripts/planning.py approve /host/path/approve.json
+```
+
+Approval rereads the canonical mailbox, current policy ref, and fresh GitHub
+observation. Any material ticket, policy, draft, revision, repository,
+authority, evidence, or preview drift rejects the transition. An
+attribution-only ticket-title change does not invalidate a policy material-field
+digest. A successful transition records:
+
+- `status: approved`;
+- the exact approved work revision;
+- `approved_by: operator` and the explicit approval timestamp;
+- the exact current policy repository, commit, and path;
+- the approved authority ceiling; and
+- operator-only acceptance mode with the required evidence.
+
+It leaves `claim`, candidate, receipt, delivery, and acceptance state empty.
+Worker eligibility, claiming, checkpointing, and delegation belong to later
+graph issues.

--- a/skills/atelier/scripts/planning.py
+++ b/skills/atelier/scripts/planning.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 import time
 from collections.abc import Mapping, Sequence
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, fields, replace
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -67,6 +67,7 @@ ID_PATTERN = re.compile(
     r"[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
 )
 SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
 GITHUB_ISSUE_URL = re.compile(
     r"^https://github\.com/(?P<owner>[^/]+)/(?P<repository>[^/]+)/issues/(?P<number>[1-9][0-9]*)$"
 )
@@ -161,9 +162,14 @@ class PlanPreview:
     schema: str
     work_id: str
     revision: int
+    rendered_assignment: str
+    rendered_initiative: str | None
     work_digest: str
     initiative_digest: str | None
     ticket_observation_digest: str
+    ticket_repository: str
+    ticket_number: int
+    ticket_url: str
     policy_repository: str
     policy_commit: str
     policy_path: str
@@ -566,7 +572,9 @@ def _build_preview(
         envelope=envelope,
     )
     ticket_digest = _ticket_material_digest(observation["issue"], policy.value)
-    work_digest = _digest_bytes(work_path.read_bytes())
+    rendered_assignment = work_path.read_text(encoding="utf-8")
+    work_digest = _digest_bytes(rendered_assignment.encode())
+    rendered_initiative = None
     initiative_digest = None
     initiative_id = work["initiative_id"]
     if initiative_id is not None:
@@ -574,37 +582,30 @@ def _build_preview(
         initiative, _ = _read_document(initiative_path)
         if initiative["id"] != initiative_id:
             raise PlanningError(f"{initiative_id}: initiative document identity mismatch")
-        initiative_digest = _digest_bytes(initiative_path.read_bytes())
-    token_value = {
-        "schema": "atelier.plan-preview/v1",
-        "work_id": work_id,
-        "revision": expected_revision,
-        "work_digest": work_digest,
-        "initiative_digest": initiative_digest,
-        "ticket_observation_digest": ticket_digest,
-        "policy": {
-            "repository": policy.repository,
-            "commit": policy.commit,
-            "path": policy.path,
-        },
-        "authority_ceiling": list(envelope.authority_ceiling),
-        "required_evidence": list(envelope.required_evidence),
-    }
-    return PlanPreview(
+        rendered_initiative = initiative_path.read_text(encoding="utf-8")
+        initiative_digest = _digest_bytes(rendered_initiative.encode())
+    issue = observation["issue"]
+    preview = PlanPreview(
         schema="atelier.plan-preview/v1",
         work_id=work_id,
         revision=expected_revision,
+        rendered_assignment=rendered_assignment,
+        rendered_initiative=rendered_initiative,
         work_digest=work_digest,
         initiative_digest=initiative_digest,
         ticket_observation_digest=ticket_digest,
+        ticket_repository=observation["repository"]["name_with_owner"],
+        ticket_number=issue["number"],
+        ticket_url=issue["url"],
         policy_repository=policy.repository,
         policy_commit=policy.commit,
         policy_path=policy.path,
         authority_ceiling=envelope.authority_ceiling,
         required_evidence=envelope.required_evidence,
-        preview_digest=_digest_json(token_value),
+        preview_digest="",
         mailbox_commit=mailbox_commit,
     )
+    return replace(preview, preview_digest=_digest_json(_preview_token_value(preview)))
 
 
 def _require_project_and_ticket(
@@ -784,10 +785,101 @@ def _require_same_observation(
 
 
 def _require_preview_match(expected: PlanPreview, current: PlanPreview) -> None:
-    if current.preview_digest != expected.preview_digest:
+    _validate_preview(expected)
+    if current != expected:
         raise MailboxTransitionRejected(
             f"{expected.work_id}: previewed work, policy, ticket, or authority changed"
         )
+
+
+def _preview_token_value(preview: PlanPreview) -> dict[str, Any]:
+    return {
+        "schema": preview.schema,
+        "work_id": preview.work_id,
+        "revision": preview.revision,
+        "rendered_assignment": preview.rendered_assignment,
+        "rendered_initiative": preview.rendered_initiative,
+        "work_digest": preview.work_digest,
+        "initiative_digest": preview.initiative_digest,
+        "ticket_observation_digest": preview.ticket_observation_digest,
+        "ticket": {
+            "repository": preview.ticket_repository,
+            "number": preview.ticket_number,
+            "url": preview.ticket_url,
+        },
+        "policy": {
+            "repository": preview.policy_repository,
+            "commit": preview.policy_commit,
+            "path": preview.policy_path,
+        },
+        "authority_ceiling": list(preview.authority_ceiling),
+        "required_evidence": list(preview.required_evidence),
+        "mailbox_commit": preview.mailbox_commit,
+    }
+
+
+def _validate_preview(preview: PlanPreview) -> None:
+    if preview.schema != "atelier.plan-preview/v1":
+        raise PlanningError(f"unsupported preview schema {preview.schema!r}")
+    if not isinstance(preview.work_id, str):
+        raise PlanningError("preview work_id must be a string")
+    _require_identifier(preview.work_id, "wrk")
+    if type(preview.revision) is not int or preview.revision < 1:
+        raise PlanningError("preview revision must be a positive integer")
+    _require_text("preview.rendered_assignment", preview.rendered_assignment)
+    if (preview.rendered_initiative is None) != (preview.initiative_digest is None):
+        raise PlanningError("preview initiative content and digest must both be null or present")
+    if preview.rendered_initiative is not None:
+        _require_text("preview.rendered_initiative", preview.rendered_initiative)
+    for name in (
+        "work_digest",
+        "ticket_observation_digest",
+        "preview_digest",
+    ):
+        value = getattr(preview, name)
+        if not isinstance(value, str) or DIGEST_PATTERN.fullmatch(value) is None:
+            raise PlanningError(f"preview {name} must be a lowercase SHA-256 digest")
+    if (
+        preview.initiative_digest is not None
+        and (
+            not isinstance(preview.initiative_digest, str)
+            or DIGEST_PATTERN.fullmatch(preview.initiative_digest) is None
+        )
+    ):
+        raise PlanningError("preview initiative_digest must be a lowercase SHA-256 digest")
+    for name in ("policy_commit", "mailbox_commit"):
+        value = getattr(preview, name)
+        if not isinstance(value, str) or SHA_PATTERN.fullmatch(value) is None:
+            raise PlanningError(f"preview {name} must be a lowercase Git SHA")
+    _require_text("preview.ticket_repository", preview.ticket_repository)
+    if type(preview.ticket_number) is not int or preview.ticket_number < 1:
+        raise PlanningError("preview ticket_number must be a positive integer")
+    ticket_match = (
+        GITHUB_ISSUE_URL.fullmatch(preview.ticket_url)
+        if isinstance(preview.ticket_url, str)
+        else None
+    )
+    if (
+        ticket_match is None
+        or f"{ticket_match.group('owner')}/{ticket_match.group('repository')}"
+        != preview.ticket_repository
+        or int(ticket_match.group("number")) != preview.ticket_number
+    ):
+        raise PlanningError("preview ticket identity is contradictory")
+    _require_text("preview.policy_repository", preview.policy_repository)
+    _require_text("preview.policy_path", preview.policy_path)
+    _validate_envelope(
+        ApprovalEnvelope(preview.authority_ceiling, preview.required_evidence)
+    )
+    if _digest_bytes(preview.rendered_assignment.encode()) != preview.work_digest:
+        raise PlanningError("preview rendered assignment does not match work_digest")
+    if (
+        preview.rendered_initiative is not None
+        and _digest_bytes(preview.rendered_initiative.encode()) != preview.initiative_digest
+    ):
+        raise PlanningError("preview rendered initiative does not match initiative_digest")
+    if _digest_json(_preview_token_value(preview)) != preview.preview_digest:
+        raise PlanningError("preview digest does not match the complete preview")
 
 
 def _ticket_material_digest(
@@ -1065,13 +1157,35 @@ def _policy_target(value: Mapping[str, Any]) -> PolicyTarget:
 
 
 def _preview(value: Mapping[str, Any]) -> PlanPreview:
-    return PlanPreview(
+    expected_fields = {field.name for field in fields(PlanPreview)}
+    actual_fields = set(value)
+    if actual_fields != expected_fields:
+        missing = sorted(expected_fields - actual_fields)
+        unknown = sorted(actual_fields - expected_fields)
+        raise PlanningError(
+            f"preview fields do not match atelier.plan-preview/v1; "
+            f"missing={missing}, unknown={unknown}"
+        )
+    if not isinstance(value["authority_ceiling"], list) or not all(
+        isinstance(item, str) for item in value["authority_ceiling"]
+    ):
+        raise PlanningError("preview authority_ceiling must be an array of strings")
+    if not isinstance(value["required_evidence"], list) or not all(
+        isinstance(item, str) for item in value["required_evidence"]
+    ):
+        raise PlanningError("preview required_evidence must be an array of strings")
+    preview = PlanPreview(
         schema=value["schema"],
         work_id=value["work_id"],
         revision=value["revision"],
+        rendered_assignment=value["rendered_assignment"],
+        rendered_initiative=value["rendered_initiative"],
         work_digest=value["work_digest"],
         initiative_digest=value["initiative_digest"],
         ticket_observation_digest=value["ticket_observation_digest"],
+        ticket_repository=value["ticket_repository"],
+        ticket_number=value["ticket_number"],
+        ticket_url=value["ticket_url"],
         policy_repository=value["policy_repository"],
         policy_commit=value["policy_commit"],
         policy_path=value["policy_path"],
@@ -1080,6 +1194,8 @@ def _preview(value: Mapping[str, Any]) -> PlanPreview:
         preview_digest=value["preview_digest"],
         mailbox_commit=value["mailbox_commit"],
     )
+    _validate_preview(preview)
+    return preview
 
 
 def _common_request(value: Mapping[str, Any]) -> tuple[Planner, Path, datetime]:

--- a/skills/atelier/scripts/planning.py
+++ b/skills/atelier/scripts/planning.py
@@ -316,8 +316,7 @@ class Planner:
     ) -> PlanningResult:
         """Replace one exact draft revision and increment its revision once."""
 
-        if expected_revision < 1:
-            raise PlanningError("expected revision must be at least one")
+        _require_expected_revision(expected_revision)
         _validate_assignment_input(assignment)
         _validate_initiative_input(initiative, assignment.initiative_id)
         if initiative is None:
@@ -414,6 +413,7 @@ class Planner:
         """Read live state and return the exact proposal an operator may approve."""
 
         _require_identifier(work_id, "wrk")
+        _require_expected_revision(expected_revision)
         _validate_envelope(envelope)
         with tempfile.TemporaryDirectory(prefix="atelier-plan-preview-") as temporary:
             checkout, _ = self._read_mailbox(Path(temporary))
@@ -1042,6 +1042,11 @@ def _require_identifier(value: str, prefix: str) -> None:
     match = ID_PATTERN.fullmatch(value)
     if match is None or match.group("prefix") != prefix:
         raise PlanningError(f"{value!r} is not a valid {prefix} identifier")
+
+
+def _require_expected_revision(value: Any) -> None:
+    if type(value) is not int or value < 1:
+        raise PlanningError("expected revision must be a positive integer")
 
 
 def _require_text(label: str, value: str) -> None:

--- a/skills/atelier/scripts/planning.py
+++ b/skills/atelier/scripts/planning.py
@@ -162,6 +162,7 @@ class PlanPreview:
     work_id: str
     revision: int
     work_digest: str
+    initiative_digest: str | None
     ticket_observation_digest: str
     policy_repository: str
     policy_commit: str
@@ -566,11 +567,20 @@ def _build_preview(
     )
     ticket_digest = _ticket_material_digest(observation["issue"], policy.value)
     work_digest = _digest_bytes(work_path.read_bytes())
+    initiative_digest = None
+    initiative_id = work["initiative_id"]
+    if initiative_id is not None:
+        initiative_path = checkout / _initiative_path(initiative_id)
+        initiative, _ = _read_document(initiative_path)
+        if initiative["id"] != initiative_id:
+            raise PlanningError(f"{initiative_id}: initiative document identity mismatch")
+        initiative_digest = _digest_bytes(initiative_path.read_bytes())
     token_value = {
         "schema": "atelier.plan-preview/v1",
         "work_id": work_id,
         "revision": expected_revision,
         "work_digest": work_digest,
+        "initiative_digest": initiative_digest,
         "ticket_observation_digest": ticket_digest,
         "policy": {
             "repository": policy.repository,
@@ -585,6 +595,7 @@ def _build_preview(
         work_id=work_id,
         revision=expected_revision,
         work_digest=work_digest,
+        initiative_digest=initiative_digest,
         ticket_observation_digest=ticket_digest,
         policy_repository=policy.repository,
         policy_commit=policy.commit,
@@ -1059,6 +1070,7 @@ def _preview(value: Mapping[str, Any]) -> PlanPreview:
         work_id=value["work_id"],
         revision=value["revision"],
         work_digest=value["work_digest"],
+        initiative_digest=value["initiative_digest"],
         ticket_observation_digest=value["ticket_observation_digest"],
         policy_repository=value["policy_repository"],
         policy_commit=value["policy_commit"],

--- a/skills/atelier/scripts/planning.py
+++ b/skills/atelier/scripts/planning.py
@@ -822,28 +822,9 @@ def _require_preview_match(expected: PlanPreview, current: PlanPreview) -> None:
 
 
 def _preview_token_value(preview: PlanPreview) -> dict[str, Any]:
-    return {
-        "schema": preview.schema,
-        "work_id": preview.work_id,
-        "revision": preview.revision,
-        "rendered_assignment": preview.rendered_assignment,
-        "rendered_initiative": preview.rendered_initiative,
-        "work_digest": preview.work_digest,
-        "initiative_digest": preview.initiative_digest,
-        "ticket_observation_digest": preview.ticket_observation_digest,
-        "ticket": {
-            "repository": preview.ticket_repository,
-            "number": preview.ticket_number,
-            "url": preview.ticket_url,
-        },
-        "policy": {
-            "repository": preview.policy_repository,
-            "commit": preview.policy_commit,
-            "path": preview.policy_path,
-        },
-        "authority_ceiling": list(preview.authority_ceiling),
-        "required_evidence": list(preview.required_evidence),
-    }
+    value = asdict(preview)
+    del value["preview_digest"]
+    return value
 
 
 def _validate_preview(preview: PlanPreview) -> None:
@@ -1203,25 +1184,10 @@ def _preview(value: Mapping[str, Any]) -> PlanPreview:
         isinstance(item, str) for item in value["required_evidence"]
     ):
         raise PlanningError("preview required_evidence must be an array of strings")
-    preview = PlanPreview(
-        schema=value["schema"],
-        work_id=value["work_id"],
-        revision=value["revision"],
-        rendered_assignment=value["rendered_assignment"],
-        rendered_initiative=value["rendered_initiative"],
-        work_digest=value["work_digest"],
-        initiative_digest=value["initiative_digest"],
-        ticket_observation_digest=value["ticket_observation_digest"],
-        ticket_repository=value["ticket_repository"],
-        ticket_number=value["ticket_number"],
-        ticket_url=value["ticket_url"],
-        policy_repository=value["policy_repository"],
-        policy_commit=value["policy_commit"],
-        policy_path=value["policy_path"],
-        authority_ceiling=tuple(value["authority_ceiling"]),
-        required_evidence=tuple(value["required_evidence"]),
-        preview_digest=value["preview_digest"],
-    )
+    normalized = dict(value)
+    normalized["authority_ceiling"] = tuple(value["authority_ceiling"])
+    normalized["required_evidence"] = tuple(value["required_evidence"])
+    preview = PlanPreview(**normalized)
     _validate_preview(preview)
     return preview
 

--- a/skills/atelier/scripts/planning.py
+++ b/skills/atelier/scripts/planning.py
@@ -176,7 +176,6 @@ class PlanPreview:
     authority_ceiling: tuple[str, ...]
     required_evidence: tuple[str, ...]
     preview_digest: str
-    mailbox_commit: str
 
 
 @dataclass(frozen=True)
@@ -312,6 +311,7 @@ class Planner:
         observation_path: Path,
         observation_not_before: datetime,
         initiative: InitiativeDraft | None = None,
+        expected_initiative_digest: str | None = None,
         now: datetime | None = None,
     ) -> PlanningResult:
         """Replace one exact draft revision and increment its revision once."""
@@ -320,6 +320,18 @@ class Planner:
             raise PlanningError("expected revision must be at least one")
         _validate_assignment_input(assignment)
         _validate_initiative_input(initiative, assignment.initiative_id)
+        if initiative is None:
+            if expected_initiative_digest is not None:
+                raise PlanningError(
+                    "expected_initiative_digest is allowed only when revising an initiative"
+                )
+        elif (
+            not isinstance(expected_initiative_digest, str)
+            or DIGEST_PATTERN.fullmatch(expected_initiative_digest) is None
+        ):
+            raise PlanningError(
+                "revising an initiative requires its expected lowercase SHA-256 digest"
+            )
         observation = _validated_observation(
             observation_path,
             not_before=observation_not_before,
@@ -344,17 +356,22 @@ class Planner:
                     f"{assignment.id}: expected revision {expected_revision}, "
                     f"found {current['revision']}"
                 )
-            if initiative is not None and not (
-                context.checkout / _initiative_path(initiative.id)
-            ).is_file():
-                raise MailboxTransitionRejected(
-                    f"{initiative.id}: revised initiative does not exist"
+            if initiative is not None:
+                _require_initiative_digest(
+                    context.checkout,
+                    initiative.id,
+                    expected_initiative_digest,
                 )
 
         def plan(context: TransitionContext) -> TransitionPlan:
             changes: list[FileChange] = []
             if initiative is not None:
                 initiative_path = _initiative_path(initiative.id)
+                _require_initiative_digest(
+                    context.checkout,
+                    initiative.id,
+                    expected_initiative_digest,
+                )
                 initiative_content = _render_initiative(initiative)
                 if (context.checkout / initiative_path).read_text(
                     encoding="utf-8"
@@ -399,10 +416,9 @@ class Planner:
         _require_identifier(work_id, "wrk")
         _validate_envelope(envelope)
         with tempfile.TemporaryDirectory(prefix="atelier-plan-preview-") as temporary:
-            checkout, commit = self._read_mailbox(Path(temporary))
+            checkout, _ = self._read_mailbox(Path(temporary))
             return _build_preview(
                 checkout,
-                mailbox_commit=commit,
                 remote=self.remote,
                 branch=self.branch,
                 work_id=work_id,
@@ -444,10 +460,9 @@ class Planner:
         approved_at_text = _timestamp(approved_at)
 
         def current_preview(context: TransitionContext) -> PlanPreview:
-            return _build_preview(
-                context.checkout,
-                mailbox_commit=context.base_revision,
-                remote=self.remote,
+                return _build_preview(
+                    context.checkout,
+                    remote=self.remote,
                 branch=self.branch,
                 work_id=preview.work_id,
                 expected_revision=preview.revision,
@@ -533,7 +548,6 @@ class Planner:
 def _build_preview(
     checkout: Path,
     *,
-    mailbox_commit: str,
     remote: str,
     branch: str,
     work_id: str,
@@ -603,7 +617,6 @@ def _build_preview(
         authority_ceiling=envelope.authority_ceiling,
         required_evidence=envelope.required_evidence,
         preview_digest="",
-        mailbox_commit=mailbox_commit,
     )
     return replace(preview, preview_digest=_digest_json(_preview_token_value(preview)))
 
@@ -784,6 +797,22 @@ def _require_same_observation(
         raise MailboxTransitionRejected("GitHub observation changed during the transition")
 
 
+def _require_initiative_digest(
+    checkout: Path,
+    initiative_id: str,
+    expected_digest: str | None,
+) -> None:
+    path = checkout / _initiative_path(initiative_id)
+    if not path.is_file():
+        raise MailboxTransitionRejected(f"{initiative_id}: revised initiative does not exist")
+    current_digest = _digest_bytes(path.read_bytes())
+    if current_digest != expected_digest:
+        raise MailboxTransitionRejected(
+            f"{initiative_id}: expected initiative digest {expected_digest}, "
+            f"found {current_digest}"
+        )
+
+
 def _require_preview_match(expected: PlanPreview, current: PlanPreview) -> None:
     _validate_preview(expected)
     if current != expected:
@@ -814,7 +843,6 @@ def _preview_token_value(preview: PlanPreview) -> dict[str, Any]:
         },
         "authority_ceiling": list(preview.authority_ceiling),
         "required_evidence": list(preview.required_evidence),
-        "mailbox_commit": preview.mailbox_commit,
     }
 
 
@@ -847,10 +875,11 @@ def _validate_preview(preview: PlanPreview) -> None:
         )
     ):
         raise PlanningError("preview initiative_digest must be a lowercase SHA-256 digest")
-    for name in ("policy_commit", "mailbox_commit"):
-        value = getattr(preview, name)
-        if not isinstance(value, str) or SHA_PATTERN.fullmatch(value) is None:
-            raise PlanningError(f"preview {name} must be a lowercase Git SHA")
+    if (
+        not isinstance(preview.policy_commit, str)
+        or SHA_PATTERN.fullmatch(preview.policy_commit) is None
+    ):
+        raise PlanningError("preview policy_commit must be a lowercase Git SHA")
     _require_text("preview.ticket_repository", preview.ticket_repository)
     if type(preview.ticket_number) is not int or preview.ticket_number < 1:
         raise PlanningError("preview ticket_number must be a positive integer")
@@ -1192,7 +1221,6 @@ def _preview(value: Mapping[str, Any]) -> PlanPreview:
         authority_ceiling=tuple(value["authority_ceiling"]),
         required_evidence=tuple(value["required_evidence"]),
         preview_digest=value["preview_digest"],
-        mailbox_commit=value["mailbox_commit"],
     )
     _validate_preview(preview)
     return preview
@@ -1242,6 +1270,7 @@ def main() -> int:
                 _assignment(request["assignment"]),
                 expected_revision=request["expected_revision"],
                 initiative=_initiative(request.get("initiative")),
+                expected_initiative_digest=request.get("expected_initiative_digest"),
                 observation_path=observation_path,
                 observation_not_before=not_before,
             )

--- a/skills/atelier/scripts/planning.py
+++ b/skills/atelier/scripts/planning.py
@@ -36,6 +36,7 @@ from skills.atelier.scripts.host_boundary import HostBoundaryError, validate_obs
 from skills.atelier.scripts.mailbox import (
     MailboxValidationError,
     _read_yaml,
+    reconstruct_mailbox,
     validate_project_policy,
 )
 
@@ -452,13 +453,11 @@ class Planner:
 
         def revalidate(context: TransitionContext) -> None:
             candidate = current_preview(context)
-            if candidate.preview_digest != preview.preview_digest:
-                raise MailboxTransitionRejected(
-                    f"{preview.work_id}: previewed work, policy, ticket, or authority changed"
-                )
+            _require_preview_match(preview, candidate)
 
         def plan(context: TransitionContext) -> TransitionPlan:
             candidate = current_preview(context)
+            _require_preview_match(preview, candidate)
             work, body = _read_document(context.checkout / _work_path(preview.work_id))
             work["status"] = "approved"
             work["approval"] = {
@@ -538,6 +537,7 @@ def _build_preview(
     observation_not_before: datetime,
     now: datetime | None,
 ) -> PlanPreview:
+    mailbox = reconstruct_mailbox(checkout)
     work_path = checkout / _work_path(work_id)
     work, _ = _read_document(work_path)
     if work["status"] != "draft":
@@ -561,6 +561,7 @@ def _build_preview(
         observation=observation,
         mailbox_remote=remote,
         mailbox_branch=branch,
+        mailbox_realm=mailbox["realm_id"],
         envelope=envelope,
     )
     ticket_digest = _ticket_material_digest(observation["issue"], policy.value)
@@ -660,6 +661,7 @@ def _require_policy_matches(
     observation: Mapping[str, Any],
     mailbox_remote: str,
     mailbox_branch: str,
+    mailbox_realm: str,
     envelope: ApprovalEnvelope,
 ) -> None:
     value = policy.value
@@ -679,6 +681,8 @@ def _require_policy_matches(
         raise PlanningError("project policy mailbox remote does not match this planner")
     if value["mailbox"]["canonical_branch"] != mailbox_branch:
         raise PlanningError("project policy mailbox branch does not match this planner")
+    if value["mailbox"]["realm_id"] != mailbox_realm:
+        raise PlanningError("project policy realm does not match the canonical mailbox")
     if value["mailbox"]["project_id"] != work["project_id"]:
         raise PlanningError("project policy project identity does not match the assignment")
     if value["ticket"]["provider"] != "github":
@@ -766,6 +770,13 @@ def _require_same_observation(
 ) -> None:
     if _digest_json(expected) != _digest_json(current):
         raise MailboxTransitionRejected("GitHub observation changed during the transition")
+
+
+def _require_preview_match(expected: PlanPreview, current: PlanPreview) -> None:
+    if current.preview_digest != expected.preview_digest:
+        raise MailboxTransitionRejected(
+            f"{expected.work_id}: previewed work, policy, ticket, or authority changed"
+        )
 
 
 def _ticket_material_digest(

--- a/skills/atelier/scripts/planning.py
+++ b/skills/atelier/scripts/planning.py
@@ -1,0 +1,1143 @@
+#!/usr/bin/env python3
+"""Plan, revise, preview, and explicitly promote one Atelier assignment."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import secrets
+import sys
+import tempfile
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import yaml
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from skills.atelier.scripts.git_mailbox import (
+    FileChange,
+    GitMailboxWriter,
+    MailboxTransitionRejected,
+    MailboxWriteError,
+    TransitionContext,
+    TransitionPlan,
+    WriteResult,
+    run_git,
+)
+from skills.atelier.scripts.host_boundary import HostBoundaryError, validate_observation
+from skills.atelier.scripts.mailbox import (
+    MailboxValidationError,
+    _read_yaml,
+    validate_project_policy,
+)
+
+AUTHORITY_ACTIONS = frozenset(
+    {
+        "repository.candidate.create",
+        "repository.candidate.push",
+        "pull_request.create",
+        "pull_request.update",
+        "review.reply",
+        "review.resolve",
+    }
+)
+EVIDENCE_NAMES = frozenset(
+    {
+        "candidate-remote-reachable",
+        "pull-request-head-current",
+        "pull-request-open",
+        "pull-request-mergeable",
+        "required-checks-pass",
+        "required-validation-reported",
+        "independent-review-current",
+        "unresolved-feedback-zero",
+    }
+)
+ID_PATTERN = re.compile(
+    r"^(?P<prefix>prj|ini|wrk)_[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-"
+    r"[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+GITHUB_ISSUE_URL = re.compile(
+    r"^https://github\.com/(?P<owner>[^/]+)/(?P<repository>[^/]+)/issues/(?P<number>[1-9][0-9]*)$"
+)
+SECTION_NAMES = (
+    "intent",
+    "rationale",
+    "scope",
+    "non_goals",
+    "constraints",
+    "edge_cases",
+    "related_context",
+    "done_definition",
+    "verification_expectations",
+    "review_shape_guidance",
+)
+INITIATIVE_SECTION_NAMES = (
+    "intent",
+    "rationale",
+    "non_goals",
+    "constraints",
+    "edge_cases",
+    "related_context",
+    "outcome",
+)
+
+
+class PlanningError(RuntimeError):
+    """A planning transition cannot be trusted or safely applied."""
+
+
+@dataclass(frozen=True)
+class InitiativeDraft:
+    """One optional non-authoritative cross-project planning document."""
+
+    id: str
+    title: str
+    intent: str
+    rationale: str
+    non_goals: str
+    constraints: str
+    edge_cases: str
+    related_context: str
+    outcome: str
+
+
+@dataclass(frozen=True)
+class AssignmentDraft:
+    """The complete worker-readable contract for one project assignment."""
+
+    id: str
+    title: str
+    project_id: str
+    initiative_id: str | None
+    dependencies: tuple[str, ...]
+    replaces: tuple[str, ...]
+    ticket_number: int
+    ticket_url: str
+    intent: str
+    rationale: str
+    scope: str
+    non_goals: str
+    constraints: str
+    edge_cases: str
+    related_context: str
+    done_definition: str
+    verification_expectations: str
+    review_shape_guidance: str
+
+
+@dataclass(frozen=True)
+class PolicyTarget:
+    """A live project-policy read boundary."""
+
+    checkout: Path
+    remote: str
+    canonical_ref: str
+    path: str
+
+
+@dataclass(frozen=True)
+class ApprovalEnvelope:
+    """The exact durable authority and acceptance proposal shown to the operator."""
+
+    authority_ceiling: tuple[str, ...]
+    required_evidence: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PlanPreview:
+    """An exact preview token and the identities from which it was derived."""
+
+    schema: str
+    work_id: str
+    revision: int
+    work_digest: str
+    ticket_observation_digest: str
+    policy_repository: str
+    policy_commit: str
+    policy_path: str
+    authority_ceiling: tuple[str, ...]
+    required_evidence: tuple[str, ...]
+    preview_digest: str
+    mailbox_commit: str
+
+
+@dataclass(frozen=True)
+class PlanningResult:
+    """One verified canonical mailbox write."""
+
+    operation: str
+    work_id: str
+    revision: int
+    status: str
+    commit: str
+    base_revision: str
+    branch: str
+    attempts: int
+    recovered: bool
+
+
+@dataclass(frozen=True)
+class _CurrentPolicy:
+    value: dict[str, Any]
+    repository: str
+    commit: str
+    path: str
+
+
+def new_identifier(prefix: str) -> str:
+    """Generate one lowercase UUIDv7 identifier with the requested Atelier prefix."""
+
+    if prefix not in {"ini", "wrk"}:
+        raise PlanningError("planning identifiers support only ini and wrk prefixes")
+    milliseconds = int(time.time() * 1000)
+    if milliseconds >= 1 << 48:
+        raise PlanningError("current time exceeds the UUIDv7 timestamp range")
+    random_bits = secrets.randbits(74)
+    value = milliseconds << 80
+    value |= 0x7 << 76
+    value |= ((random_bits >> 62) & 0xFFF) << 64
+    value |= 0b10 << 62
+    value |= random_bits & ((1 << 62) - 1)
+    hexadecimal = f"{value:032x}"
+    uuid = (
+        f"{hexadecimal[:8]}-{hexadecimal[8:12]}-{hexadecimal[12:16]}-"
+        f"{hexadecimal[16:20]}-{hexadecimal[20:]}"
+    )
+    return f"{prefix}_{uuid}"
+
+
+class Planner:
+    """Production plan-mode transitions over one canonical Git mailbox."""
+
+    def __init__(
+        self,
+        remote: str,
+        branch: str,
+        *,
+        max_attempts: int = 3,
+        writer: GitMailboxWriter | None = None,
+    ):
+        if not remote or remote.startswith("-"):
+            raise PlanningError("mailbox remote must be nonempty and must not begin with '-'")
+        self.remote = remote
+        self.branch = branch
+        self.writer = writer or GitMailboxWriter(
+            remote,
+            branch,
+            max_attempts=max_attempts,
+        )
+
+    def create_draft(
+        self,
+        assignment: AssignmentDraft,
+        *,
+        observation_path: Path,
+        observation_not_before: datetime,
+        initiative: InitiativeDraft | None = None,
+        now: datetime | None = None,
+    ) -> PlanningResult:
+        """Create one non-executable assignment and optional initiative."""
+
+        _validate_assignment_input(assignment)
+        _validate_initiative_input(initiative, assignment.initiative_id)
+        observation = _validated_observation(
+            observation_path,
+            not_before=observation_not_before,
+            now=now,
+        )
+
+        def revalidate(context: TransitionContext) -> None:
+            current_observation = _validated_observation(
+                observation_path,
+                not_before=observation_not_before,
+                now=now,
+            )
+            _require_same_observation(observation, current_observation)
+            _require_project_and_ticket(context, assignment, current_observation)
+            work_path = _work_path(assignment.id)
+            if (context.checkout / work_path).exists():
+                raise MailboxTransitionRejected(f"{assignment.id}: work identifier already exists")
+            if initiative is not None and (
+                context.checkout / _initiative_path(initiative.id)
+            ).exists():
+                raise MailboxTransitionRejected(
+                    f"{initiative.id}: initiative identifier already exists"
+                )
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            changes: list[FileChange] = []
+            if initiative is not None:
+                changes.append(
+                    FileChange(
+                        _initiative_path(initiative.id),
+                        _render_initiative(initiative),
+                    )
+                )
+            changes.append(FileChange(_work_path(assignment.id), _render_work(assignment, 1)))
+            return TransitionPlan(
+                f"plan: create draft {assignment.id}",
+                tuple(changes),
+            )
+
+        result = self.writer.publish(
+            "plan.create-draft",
+            revalidate=revalidate,
+            plan=plan,
+        )
+        return _planning_result(result, assignment.id, 1, "draft")
+
+    def revise_draft(
+        self,
+        assignment: AssignmentDraft,
+        *,
+        expected_revision: int,
+        observation_path: Path,
+        observation_not_before: datetime,
+        initiative: InitiativeDraft | None = None,
+        now: datetime | None = None,
+    ) -> PlanningResult:
+        """Replace one exact draft revision and increment its revision once."""
+
+        if expected_revision < 1:
+            raise PlanningError("expected revision must be at least one")
+        _validate_assignment_input(assignment)
+        _validate_initiative_input(initiative, assignment.initiative_id)
+        observation = _validated_observation(
+            observation_path,
+            not_before=observation_not_before,
+            now=now,
+        )
+
+        def revalidate(context: TransitionContext) -> None:
+            current_observation = _validated_observation(
+                observation_path,
+                not_before=observation_not_before,
+                now=now,
+            )
+            _require_same_observation(observation, current_observation)
+            _require_project_and_ticket(context, assignment, current_observation)
+            current, _ = _read_document(context.checkout / _work_path(assignment.id))
+            if current["status"] != "draft":
+                raise MailboxTransitionRejected(
+                    f"{assignment.id}: only draft work may be revised"
+                )
+            if current["revision"] != expected_revision:
+                raise MailboxTransitionRejected(
+                    f"{assignment.id}: expected revision {expected_revision}, "
+                    f"found {current['revision']}"
+                )
+            if initiative is not None and not (
+                context.checkout / _initiative_path(initiative.id)
+            ).is_file():
+                raise MailboxTransitionRejected(
+                    f"{initiative.id}: revised initiative does not exist"
+                )
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            changes: list[FileChange] = []
+            if initiative is not None:
+                initiative_path = _initiative_path(initiative.id)
+                initiative_content = _render_initiative(initiative)
+                if (context.checkout / initiative_path).read_text(
+                    encoding="utf-8"
+                ) != initiative_content:
+                    changes.append(FileChange(initiative_path, initiative_content))
+            changes.append(
+                FileChange(
+                    _work_path(assignment.id),
+                    _render_work(assignment, expected_revision + 1),
+                )
+            )
+            return TransitionPlan(
+                f"plan: revise draft {assignment.id} to revision {expected_revision + 1}",
+                tuple(changes),
+            )
+
+        result = self.writer.publish(
+            "plan.revise-draft",
+            revalidate=revalidate,
+            plan=plan,
+        )
+        return _planning_result(
+            result,
+            assignment.id,
+            expected_revision + 1,
+            "draft",
+        )
+
+    def preview_approval(
+        self,
+        work_id: str,
+        *,
+        expected_revision: int,
+        envelope: ApprovalEnvelope,
+        policy_target: PolicyTarget,
+        observation_path: Path,
+        observation_not_before: datetime,
+        now: datetime | None = None,
+    ) -> PlanPreview:
+        """Read live state and return the exact proposal an operator may approve."""
+
+        _require_identifier(work_id, "wrk")
+        _validate_envelope(envelope)
+        with tempfile.TemporaryDirectory(prefix="atelier-plan-preview-") as temporary:
+            checkout, commit = self._read_mailbox(Path(temporary))
+            return _build_preview(
+                checkout,
+                mailbox_commit=commit,
+                remote=self.remote,
+                branch=self.branch,
+                work_id=work_id,
+                expected_revision=expected_revision,
+                envelope=envelope,
+                policy_target=policy_target,
+                observation_path=observation_path,
+                observation_not_before=observation_not_before,
+                now=now,
+            )
+
+    def approve(
+        self,
+        preview: PlanPreview,
+        *,
+        approved_by: str,
+        approved_at: datetime,
+        policy_target: PolicyTarget,
+        observation_path: Path,
+        observation_not_before: datetime,
+        now: datetime | None = None,
+    ) -> PlanningResult:
+        """Promote exactly one previewed draft after explicit operator confirmation."""
+
+        if approved_by != "operator":
+            raise PlanningError("only an explicit operator approval may promote work")
+        if approved_at.utcoffset() is None:
+            raise PlanningError("approval timestamp must include a UTC offset")
+        if observation_not_before < approved_at:
+            raise PlanningError(
+                "approval requires a GitHub live-read boundary at or after "
+                "the operator confirmation"
+            )
+        envelope = ApprovalEnvelope(
+            authority_ceiling=preview.authority_ceiling,
+            required_evidence=preview.required_evidence,
+        )
+        _validate_envelope(envelope)
+        approved_at_text = _timestamp(approved_at)
+
+        def current_preview(context: TransitionContext) -> PlanPreview:
+            return _build_preview(
+                context.checkout,
+                mailbox_commit=context.base_revision,
+                remote=self.remote,
+                branch=self.branch,
+                work_id=preview.work_id,
+                expected_revision=preview.revision,
+                envelope=envelope,
+                policy_target=policy_target,
+                observation_path=observation_path,
+                observation_not_before=observation_not_before,
+                now=now,
+            )
+
+        def revalidate(context: TransitionContext) -> None:
+            candidate = current_preview(context)
+            if candidate.preview_digest != preview.preview_digest:
+                raise MailboxTransitionRejected(
+                    f"{preview.work_id}: previewed work, policy, ticket, or authority changed"
+                )
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            candidate = current_preview(context)
+            work, body = _read_document(context.checkout / _work_path(preview.work_id))
+            work["status"] = "approved"
+            work["approval"] = {
+                "approved_by": "operator",
+                "approved_at": approved_at_text,
+                "revision": candidate.revision,
+                "policy": {
+                    "repository": candidate.policy_repository,
+                    "commit": candidate.policy_commit,
+                    "path": candidate.policy_path,
+                },
+                "authority_ceiling": list(candidate.authority_ceiling),
+                "acceptance": {
+                    "mode": "operator",
+                    "required_evidence": list(candidate.required_evidence),
+                },
+            }
+            return TransitionPlan(
+                f"plan: approve {preview.work_id} revision {candidate.revision}",
+                (
+                    FileChange(
+                        _work_path(preview.work_id),
+                        _render_document(work, body),
+                    ),
+                ),
+            )
+
+        result = self.writer.publish(
+            "plan.approve",
+            revalidate=revalidate,
+            plan=plan,
+        )
+        return _planning_result(
+            result,
+            preview.work_id,
+            preview.revision,
+            "approved",
+        )
+
+    def _read_mailbox(self, temporary: Path) -> tuple[Path, str]:
+        checkout = temporary / "mailbox"
+        initialized = run_git(None, ("init", str(checkout)))
+        _require_git(initialized, "initialize mailbox preview checkout")
+        added = run_git(checkout, ("remote", "add", "origin", self.remote))
+        _require_git(added, "configure mailbox preview remote")
+        fetched = run_git(
+            checkout,
+            (
+                "fetch",
+                "--no-tags",
+                "origin",
+                f"refs/heads/{self.branch}:refs/remotes/origin/{self.branch}",
+            ),
+        )
+        _require_git(fetched, "fetch canonical mailbox branch")
+        commit = _git_output(
+            checkout,
+            ("rev-parse", f"refs/remotes/origin/{self.branch}"),
+            "resolve canonical mailbox head",
+        )
+        checked_out = run_git(checkout, ("checkout", "--detach", commit))
+        _require_git(checked_out, "check out canonical mailbox head")
+        return checkout, commit
+
+
+def _build_preview(
+    checkout: Path,
+    *,
+    mailbox_commit: str,
+    remote: str,
+    branch: str,
+    work_id: str,
+    expected_revision: int,
+    envelope: ApprovalEnvelope,
+    policy_target: PolicyTarget,
+    observation_path: Path,
+    observation_not_before: datetime,
+    now: datetime | None,
+) -> PlanPreview:
+    work_path = checkout / _work_path(work_id)
+    work, _ = _read_document(work_path)
+    if work["status"] != "draft":
+        raise PlanningError(f"{work_id}: only draft work may be previewed for approval")
+    if work["revision"] != expected_revision:
+        raise PlanningError(
+            f"{work_id}: expected revision {expected_revision}, found {work['revision']}"
+        )
+    project = _read_project(checkout, work["project_id"])
+    observation = _validated_observation(
+        observation_path,
+        not_before=observation_not_before,
+        now=now,
+    )
+    _require_work_ticket(work, project, observation)
+    policy = _read_current_policy(policy_target)
+    _require_policy_matches(
+        policy,
+        project=project,
+        work=work,
+        observation=observation,
+        mailbox_remote=remote,
+        mailbox_branch=branch,
+        envelope=envelope,
+    )
+    ticket_digest = _ticket_material_digest(observation["issue"], policy.value)
+    work_digest = _digest_bytes(work_path.read_bytes())
+    token_value = {
+        "schema": "atelier.plan-preview/v1",
+        "work_id": work_id,
+        "revision": expected_revision,
+        "work_digest": work_digest,
+        "ticket_observation_digest": ticket_digest,
+        "policy": {
+            "repository": policy.repository,
+            "commit": policy.commit,
+            "path": policy.path,
+        },
+        "authority_ceiling": list(envelope.authority_ceiling),
+        "required_evidence": list(envelope.required_evidence),
+    }
+    return PlanPreview(
+        schema="atelier.plan-preview/v1",
+        work_id=work_id,
+        revision=expected_revision,
+        work_digest=work_digest,
+        ticket_observation_digest=ticket_digest,
+        policy_repository=policy.repository,
+        policy_commit=policy.commit,
+        policy_path=policy.path,
+        authority_ceiling=envelope.authority_ceiling,
+        required_evidence=envelope.required_evidence,
+        preview_digest=_digest_json(token_value),
+        mailbox_commit=mailbox_commit,
+    )
+
+
+def _require_project_and_ticket(
+    context: TransitionContext,
+    assignment: AssignmentDraft,
+    observation: Mapping[str, Any],
+) -> None:
+    project = _read_project(context.checkout, assignment.project_id)
+    work = {
+        "native_ticket": {
+            "provider": "github",
+            "id": str(assignment.ticket_number),
+            "url": assignment.ticket_url,
+        }
+    }
+    _require_work_ticket(work, project, observation)
+    for dependency in assignment.dependencies:
+        if not (context.checkout / _work_path(dependency)).is_file():
+            raise MailboxTransitionRejected(
+                f"{assignment.id}: dependency {dependency} does not exist"
+            )
+    for replaced in assignment.replaces:
+        if not (context.checkout / _work_path(replaced)).is_file():
+            raise MailboxTransitionRejected(
+                f"{assignment.id}: replacement target {replaced} does not exist"
+            )
+
+
+def _require_work_ticket(
+    work: Mapping[str, Any],
+    project: Mapping[str, Any],
+    observation: Mapping[str, Any],
+) -> None:
+    if project["status"] != "active":
+        raise PlanningError(f"{project['id']}: project is not active")
+    repository = observation["repository"]["name_with_owner"]
+    expected_repository = project["repository"].removeprefix("github:")
+    if repository != expected_repository:
+        raise PlanningError(
+            f"{project['id']}: project repository {expected_repository} "
+            f"does not match observed repository {repository}"
+        )
+    ticket = work["native_ticket"]
+    issue = observation["issue"]
+    if ticket is None:
+        raise PlanningError("assignment is not linked to a native ticket")
+    if ticket["provider"] != "github":
+        raise PlanningError("initial plan mode supports only GitHub tickets")
+    if ticket["id"] != str(issue["number"]) or ticket["url"] != issue["url"]:
+        raise PlanningError("assignment native ticket does not match the live observation")
+    match = GITHUB_ISSUE_URL.fullmatch(ticket["url"])
+    if (
+        match is None
+        or f"{match.group('owner')}/{match.group('repository')}" != repository
+        or int(match.group("number")) != issue["number"]
+    ):
+        raise PlanningError("assignment native ticket URL is not canonical for the project")
+
+
+def _require_policy_matches(
+    policy: _CurrentPolicy,
+    *,
+    project: Mapping[str, Any],
+    work: Mapping[str, Any],
+    observation: Mapping[str, Any],
+    mailbox_remote: str,
+    mailbox_branch: str,
+    envelope: ApprovalEnvelope,
+) -> None:
+    value = policy.value
+    expected_repository = project["repository"]
+    if policy.repository != expected_repository:
+        raise PlanningError(
+            f"policy repository {policy.repository} does not match project {expected_repository}"
+        )
+    if project["policy"] != {
+        "repository": policy.repository,
+        "path": policy.path,
+    }:
+        raise PlanningError("project policy locator contradicts the current policy target")
+    if value["repository"]["identity"] != expected_repository:
+        raise PlanningError("project policy repository identity contradicts the project")
+    if value["mailbox"]["remote"] != mailbox_remote:
+        raise PlanningError("project policy mailbox remote does not match this planner")
+    if value["mailbox"]["canonical_branch"] != mailbox_branch:
+        raise PlanningError("project policy mailbox branch does not match this planner")
+    if value["mailbox"]["project_id"] != work["project_id"]:
+        raise PlanningError("project policy project identity does not match the assignment")
+    if value["ticket"]["provider"] != "github":
+        raise PlanningError("project policy does not permit GitHub tickets")
+    issue = observation["issue"]
+    if issue["state"].lower() not in value["ticket"]["allowed_states"]:
+        raise PlanningError(f"ticket #{issue['number']} is not in an allowed state")
+    if value["ticket"]["require_no_blockers"]:
+        blockers = [item for item in issue["blocked_by"] if item["state"] != "CLOSED"]
+        if blockers:
+            numbers = ", ".join(f"#{item['number']}" for item in blockers)
+            raise PlanningError(f"ticket #{issue['number']} has unresolved blockers: {numbers}")
+    if observation["pull_request"] is not None:
+        raise PlanningError(
+            f"ticket #{issue['number']} already has a canonical pull-request observation"
+        )
+    policy_authority = set(value["authority"]["allow"])
+    if not set(envelope.authority_ceiling) <= policy_authority:
+        raise PlanningError("approval authority exceeds the current project policy")
+    policy_evidence = set(value["acceptance"]["evidence"])
+    if not policy_evidence <= set(envelope.required_evidence):
+        raise PlanningError("approval omits evidence required by the current project policy")
+
+
+def _read_current_policy(target: PolicyTarget) -> _CurrentPolicy:
+    if not target.checkout.is_dir():
+        raise PlanningError(f"policy checkout is unavailable: {target.checkout}")
+    if not target.remote or target.remote.startswith("-"):
+        raise PlanningError("policy remote must be nonempty and must not begin with '-'")
+    if not target.canonical_ref.startswith("refs/heads/"):
+        raise PlanningError("policy canonical ref must be a full branch ref")
+    path = PurePosixPath(target.path)
+    if path.is_absolute() or ".." in path.parts or target.path != path.as_posix():
+        raise PlanningError("policy path must be a normalized repository-relative path")
+    listing = _git_output(
+        target.checkout,
+        ("ls-remote", target.remote, target.canonical_ref),
+        "read current project-policy ref",
+    )
+    rows = [line.split() for line in listing.splitlines() if line.strip()]
+    matches = [row for row in rows if len(row) == 2 and row[1] == target.canonical_ref]
+    if len(matches) != 1 or not SHA_PATTERN.fullmatch(matches[0][0]):
+        raise PlanningError("current project-policy ref is missing or ambiguous")
+    commit = matches[0][0]
+    fetched = run_git(
+        target.checkout,
+        ("fetch", "--no-tags", target.remote, commit),
+    )
+    _require_git(fetched, "fetch current project-policy commit")
+    content = _git_output(
+        target.checkout,
+        ("show", f"{commit}:{target.path}"),
+        "read current project policy",
+    )
+    with tempfile.TemporaryDirectory(prefix="atelier-policy-validate-") as temporary:
+        policy_path = Path(temporary) / "policy.yaml"
+        policy_path.write_text(content, encoding="utf-8")
+        value = validate_project_policy(policy_path)
+    repository = value["repository"]["identity"]
+    if value["repository"]["canonical_ref"] != target.canonical_ref:
+        raise PlanningError("policy target ref contradicts repository.canonical_ref")
+    return _CurrentPolicy(
+        value=value,
+        repository=repository,
+        commit=commit,
+        path=target.path,
+    )
+
+
+def _validated_observation(
+    path: Path,
+    *,
+    not_before: datetime,
+    now: datetime | None,
+) -> dict[str, Any]:
+    try:
+        return validate_observation(path, not_before=not_before, now=now)
+    except HostBoundaryError as error:
+        raise PlanningError(f"GitHub observation is not current and complete: {error}") from error
+
+
+def _require_same_observation(
+    expected: Mapping[str, Any],
+    current: Mapping[str, Any],
+) -> None:
+    if _digest_json(expected) != _digest_json(current):
+        raise MailboxTransitionRejected("GitHub observation changed during the transition")
+
+
+def _ticket_material_digest(
+    issue: Mapping[str, Any],
+    policy: Mapping[str, Any],
+) -> str:
+    relationships = {
+        "parent": issue["parent"]["id"] if issue["parent"] else None,
+        "sub_issues": sorted(item["id"] for item in issue["sub_issues"]),
+        "blocked_by": sorted(item["id"] for item in issue["blocked_by"]),
+        "blocking": sorted(item["id"] for item in issue["blocking"]),
+    }
+    available = {
+        "body": issue["body"],
+        "state": issue["state"],
+        "relationships": relationships,
+    }
+    selected = {
+        name: available[name]
+        for name in policy["ticket"]["material_fields"]
+    }
+    return _digest_json(selected)
+
+
+def _read_project(checkout: Path, project_id: str) -> dict[str, Any]:
+    _require_identifier(project_id, "prj")
+    path = checkout / f"projects/{project_id}/project.md"
+    value, _ = _read_document(path)
+    if value["id"] != project_id:
+        raise PlanningError(f"{project_id}: project document identity mismatch")
+    return value
+
+
+def _read_document(path: Path) -> tuple[dict[str, Any], str]:
+    try:
+        return _read_yaml(path, frontmatter=True)
+    except MailboxValidationError as error:
+        raise PlanningError(str(error)) from error
+
+
+def _render_work(assignment: AssignmentDraft, revision: int) -> str:
+    value = {
+        "schema": "atelier.work/v1",
+        "id": assignment.id,
+        "title": assignment.title,
+        "project_id": assignment.project_id,
+        "initiative_id": assignment.initiative_id,
+        "status": "draft",
+        "revision": revision,
+        "dependencies": list(assignment.dependencies),
+        "replaces": list(assignment.replaces),
+        "native_ticket": {
+            "provider": "github",
+            "id": str(assignment.ticket_number),
+            "url": assignment.ticket_url,
+        },
+        "approval": None,
+        "claim": None,
+        "blocking_message_id": None,
+        "attempt_receipt_id": None,
+        "delivery_receipt_id": None,
+        "acceptance": None,
+    }
+    sections = [(name, getattr(assignment, name)) for name in SECTION_NAMES]
+    return _render_document(value, _render_sections(sections))
+
+
+def _render_initiative(initiative: InitiativeDraft) -> str:
+    value = {
+        "schema": "atelier.initiative/v1",
+        "id": initiative.id,
+        "title": initiative.title,
+    }
+    sections = [(name, getattr(initiative, name)) for name in INITIATIVE_SECTION_NAMES]
+    return _render_document(value, _render_sections(sections))
+
+
+def _render_document(frontmatter: Mapping[str, Any], body: str) -> str:
+    encoded = yaml.safe_dump(
+        dict(frontmatter),
+        allow_unicode=True,
+        default_flow_style=False,
+        sort_keys=False,
+        width=100,
+    )
+    return f"---\n{encoded}---\n{body.rstrip()}\n"
+
+
+def _render_sections(sections: Sequence[tuple[str, str]]) -> str:
+    return "\n\n".join(
+        f"## {name.replace('_', ' ').title()}\n\n{value.strip()}"
+        for name, value in sections
+    )
+
+
+def _validate_assignment_input(assignment: AssignmentDraft) -> None:
+    _require_identifier(assignment.id, "wrk")
+    _require_identifier(assignment.project_id, "prj")
+    if assignment.initiative_id is not None:
+        _require_identifier(assignment.initiative_id, "ini")
+    for identifier in (*assignment.dependencies, *assignment.replaces):
+        _require_identifier(identifier, "wrk")
+    if assignment.id in assignment.dependencies or assignment.id in assignment.replaces:
+        raise PlanningError("assignment cannot depend on or replace itself")
+    if len(set(assignment.dependencies)) != len(assignment.dependencies):
+        raise PlanningError("assignment dependencies must be unique")
+    if len(set(assignment.replaces)) != len(assignment.replaces):
+        raise PlanningError("assignment replacement targets must be unique")
+    if assignment.ticket_number < 1:
+        raise PlanningError("GitHub ticket number must be positive")
+    _require_text("assignment.title", assignment.title)
+    for name in SECTION_NAMES:
+        _require_text(f"assignment.{name}", getattr(assignment, name))
+
+
+def _validate_initiative_input(
+    initiative: InitiativeDraft | None,
+    assignment_initiative_id: str | None,
+) -> None:
+    if initiative is None:
+        return
+    _require_identifier(initiative.id, "ini")
+    if initiative.id != assignment_initiative_id:
+        raise PlanningError("initiative identity does not match assignment.initiative_id")
+    _require_text("initiative.title", initiative.title)
+    for name in INITIATIVE_SECTION_NAMES:
+        _require_text(f"initiative.{name}", getattr(initiative, name))
+
+
+def _validate_envelope(envelope: ApprovalEnvelope) -> None:
+    if len(set(envelope.authority_ceiling)) != len(envelope.authority_ceiling):
+        raise PlanningError("approval authority actions must be unique")
+    if len(set(envelope.required_evidence)) != len(envelope.required_evidence):
+        raise PlanningError("approval evidence names must be unique")
+    unknown_actions = set(envelope.authority_ceiling) - AUTHORITY_ACTIONS
+    if unknown_actions:
+        raise PlanningError(
+            f"unsupported approval authority: {', '.join(sorted(unknown_actions))}"
+        )
+    unknown_evidence = set(envelope.required_evidence) - EVIDENCE_NAMES
+    if unknown_evidence:
+        raise PlanningError(
+            f"unsupported approval evidence: {', '.join(sorted(unknown_evidence))}"
+        )
+    if not envelope.required_evidence:
+        raise PlanningError("approval must require at least one evidence predicate")
+
+
+def _require_identifier(value: str, prefix: str) -> None:
+    match = ID_PATTERN.fullmatch(value)
+    if match is None or match.group("prefix") != prefix:
+        raise PlanningError(f"{value!r} is not a valid {prefix} identifier")
+
+
+def _require_text(label: str, value: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise PlanningError(f"{label} must not be empty")
+
+
+def _work_path(work_id: str) -> str:
+    return f"work/{work_id}/work.md"
+
+
+def _initiative_path(initiative_id: str) -> str:
+    return f"initiatives/{initiative_id}/initiative.md"
+
+
+def _timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _digest_json(value: Any) -> str:
+    encoded = json.dumps(
+        value,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    return _digest_bytes(encoded)
+
+
+def _digest_bytes(value: bytes) -> str:
+    return f"sha256:{hashlib.sha256(value).hexdigest()}"
+
+
+def _require_git(result: Any, operation: str) -> None:
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "Git command failed"
+        raise PlanningError(f"{operation}: {detail}")
+
+
+def _git_output(cwd: Path, arguments: Sequence[str], operation: str) -> str:
+    result = run_git(cwd, arguments)
+    _require_git(result, operation)
+    return result.stdout.strip()
+
+
+def _planning_result(
+    result: WriteResult,
+    work_id: str,
+    revision: int,
+    status: str,
+) -> PlanningResult:
+    return PlanningResult(
+        operation=result.operation,
+        work_id=work_id,
+        revision=revision,
+        status=status,
+        commit=result.commit,
+        base_revision=result.base_revision,
+        branch=result.branch,
+        attempts=result.attempts,
+        recovered=result.recovered,
+    )
+
+
+def _parse_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise PlanningError(f"invalid timestamp {value!r}") from error
+    if parsed.utcoffset() is None:
+        raise PlanningError("timestamp must include a UTC offset")
+    return parsed
+
+
+def _read_request(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise PlanningError(f"request is unreadable: {error}") from error
+    if not isinstance(value, dict):
+        raise PlanningError("request must be a JSON object")
+    return value
+
+
+def _assignment(value: Mapping[str, Any]) -> AssignmentDraft:
+    return AssignmentDraft(
+        id=value["id"],
+        title=value["title"],
+        project_id=value["project_id"],
+        initiative_id=value.get("initiative_id"),
+        dependencies=tuple(value.get("dependencies", [])),
+        replaces=tuple(value.get("replaces", [])),
+        ticket_number=value["ticket_number"],
+        ticket_url=value["ticket_url"],
+        **{name: value[name] for name in SECTION_NAMES},
+    )
+
+
+def _initiative(value: Mapping[str, Any] | None) -> InitiativeDraft | None:
+    if value is None:
+        return None
+    return InitiativeDraft(
+        id=value["id"],
+        title=value["title"],
+        **{name: value[name] for name in INITIATIVE_SECTION_NAMES},
+    )
+
+
+def _envelope(value: Mapping[str, Any]) -> ApprovalEnvelope:
+    return ApprovalEnvelope(
+        authority_ceiling=tuple(value["authority_ceiling"]),
+        required_evidence=tuple(value["required_evidence"]),
+    )
+
+
+def _policy_target(value: Mapping[str, Any]) -> PolicyTarget:
+    return PolicyTarget(
+        checkout=Path(value["checkout"]),
+        remote=value["remote"],
+        canonical_ref=value["canonical_ref"],
+        path=value["path"],
+    )
+
+
+def _preview(value: Mapping[str, Any]) -> PlanPreview:
+    return PlanPreview(
+        schema=value["schema"],
+        work_id=value["work_id"],
+        revision=value["revision"],
+        work_digest=value["work_digest"],
+        ticket_observation_digest=value["ticket_observation_digest"],
+        policy_repository=value["policy_repository"],
+        policy_commit=value["policy_commit"],
+        policy_path=value["policy_path"],
+        authority_ceiling=tuple(value["authority_ceiling"]),
+        required_evidence=tuple(value["required_evidence"]),
+        preview_digest=value["preview_digest"],
+        mailbox_commit=value["mailbox_commit"],
+    )
+
+
+def _common_request(value: Mapping[str, Any]) -> tuple[Planner, Path, datetime]:
+    planner = Planner(
+        value["mailbox"]["remote"],
+        value["mailbox"]["canonical_branch"],
+        max_attempts=value["mailbox"].get("max_attempts", 3),
+    )
+    return (
+        planner,
+        Path(value["observation"]["path"]),
+        _parse_timestamp(value["observation"]["not_before"]),
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    identifier = subparsers.add_parser("new-id")
+    identifier.add_argument("prefix", choices=("ini", "wrk"))
+    for name in ("create", "revise", "preview", "approve"):
+        command = subparsers.add_parser(name)
+        command.add_argument("request", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.command == "new-id":
+        print(new_identifier(args.prefix))
+        return 0
+    try:
+        request = _read_request(args.request)
+        planner, observation_path, not_before = _common_request(request)
+        if args.command == "create":
+            result: Any = planner.create_draft(
+                _assignment(request["assignment"]),
+                initiative=_initiative(request.get("initiative")),
+                observation_path=observation_path,
+                observation_not_before=not_before,
+            )
+        elif args.command == "revise":
+            result = planner.revise_draft(
+                _assignment(request["assignment"]),
+                expected_revision=request["expected_revision"],
+                initiative=_initiative(request.get("initiative")),
+                observation_path=observation_path,
+                observation_not_before=not_before,
+            )
+        elif args.command == "preview":
+            result = planner.preview_approval(
+                request["work_id"],
+                expected_revision=request["expected_revision"],
+                envelope=_envelope(request["envelope"]),
+                policy_target=_policy_target(request["policy"]),
+                observation_path=observation_path,
+                observation_not_before=not_before,
+            )
+        else:
+            result = planner.approve(
+                _preview(request["preview"]),
+                approved_by=request["approved_by"],
+                approved_at=_parse_timestamp(request["approved_at"]),
+                policy_target=_policy_target(request["policy"]),
+                observation_path=observation_path,
+                observation_not_before=not_before,
+            )
+        print(json.dumps(asdict(result), indent=2, sort_keys=True, default=str))
+        return 0
+    except (
+        KeyError,
+        TypeError,
+        PlanningError,
+        MailboxWriteError,
+        MailboxTransitionRejected,
+        MailboxValidationError,
+        ValueError,
+    ) as error:
+        print(f"planning failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## TL;DR

Adds fail-closed Atelier plan mode for drafting, revising, explicitly approving, and promoting one GitHub-backed assignment without claiming or executing it.

## Summary

- Creates and revises one non-executable initiative and assignment with complete worker-readable intent.
- Produces a strict, human-readable approval preview bound to exact assignment, initiative, ticket, policy, authority, evidence, and revision identities.
- Requires explicit operator confirmation and fresh live reads before promotion.
- Rejects stale or ineligible tickets, policy or realm drift, contradictory preview payloads, boolean revisions, and stale shared-initiative writes.
- Keeps claiming, worker selection, implementation, PR mutation, acceptance, merge, deployment, and later graph nodes out of scope.

## Validation

- `just lint`
- `python3 -m ruff check skills/atelier/scripts/planning.py contract_tests/test_planning.py`
- 15 focused planning contract tests
- `just test` — 122 unit tests and 16 mailbox protocol scenarios
- Exact-head repository review: clean at `e44e8421a9381d1da0272840e3787e4c9e91ad59`

## Acceptance

- Draft creation, revision, and non-executable state: passed
- Complete fresh-worker contract and canonical ticket identity: passed
- Exact rendered operator preview and explicit approval: passed
- Current policy, mailbox realm, authority, and evidence binding: passed
- Stale, contradictory, blocked, duplicate-PR, and contention fail-closed paths: passed
- Worker claiming and later graph behavior: intentionally absent

## Tickets

Refs #777
