### PR TITLE
feat(work): add claim and checkpoint coordination

### DIFF
--- a/contract_tests/test_claiming.py
+++ b/contract_tests/test_claiming.py
@@ -20,15 +20,24 @@ from contract_tests.test_planning import (
     write_json,
 )
 from skills.atelier.scripts.claiming import (
+    AttemptEvidence,
     CheckpointRequest,
     ClaimCoordinator,
     ClaimFence,
     ClaimingError,
     HostTarget,
+    _attempt_receipt,
     _candidate_remote_reachable,
+    _render_document,
     new_identifier,
 )
-from skills.atelier.scripts.git_mailbox import MailboxTransitionRejected
+from skills.atelier.scripts.git_mailbox import (
+    FileChange,
+    GitMailboxWriter,
+    MailboxTransitionRejected,
+    TransitionPlan,
+    run_git,
+)
 from skills.atelier.scripts.mailbox import _read_yaml, reconstruct_mailbox
 from skills.atelier.scripts.planning import (
     ApprovalEnvelope,
@@ -258,8 +267,10 @@ class ClaimingContract(unittest.TestCase):
         candidate_head: str | None = None,
         phase: str = "pre_external_mutation",
         candidate: dict[str, Any] | None = None,
+        coordinator: ClaimCoordinator | None = None,
+        host_target: HostTarget | None = None,
     ):
-        return self.coordinator.authorize(
+        return (coordinator or self.coordinator).authorize(
             self.work_id,
             CheckpointRequest(
                 fence=self.fence(result),
@@ -276,6 +287,7 @@ class ClaimingContract(unittest.TestCase):
             ),
             approved_commit=self.approved_commit,
             policy_target=self.policy_target(),
+            host_target=host_target or self.host_target(),
             observation_path=self.observation_path,
             observation_not_before=self.live_at,
             now=OBSERVED_AT + timedelta(minutes=2),
@@ -294,7 +306,7 @@ class ClaimingContract(unittest.TestCase):
             "published_at": "2026-07-28T04:02:00Z",
         }
 
-    def publish_candidate_with_descendant(self):
+    def publish_candidate_with_descendant(self, *, with_pull_request: bool = False):
         candidate_head = git(self.project_checkout, "rev-parse", "HEAD").stdout.strip()
         candidate_ref = "refs/heads/scott/example-work"
         git(self.project_checkout, "push", "origin", f"{candidate_head}:{candidate_ref}")
@@ -323,6 +335,29 @@ class ClaimingContract(unittest.TestCase):
             phase="candidate_published",
             candidate=candidate,
         )
+        if with_pull_request:
+            pull_request = self.checkpoint(
+                published,
+                action="pull_request.create",
+                token="token-3",
+                candidate_head=candidate_head,
+            )
+            republish = self.checkpoint(
+                pull_request,
+                action="repository.candidate.push",
+                token="token-4",
+                candidate_head=candidate_head,
+            )
+            candidate = dict(candidate)
+            candidate["pull_request"] = "https://github.com/example/project-1/pull/778"
+            published = self.checkpoint(
+                republish,
+                action="repository.candidate.push",
+                token="token-5",
+                candidate_head=candidate_head,
+                phase="candidate_published",
+                candidate=candidate,
+            )
         candidate_marker = self.project_checkout / "candidate.txt"
         candidate_marker.write_text("descendant\n", encoding="utf-8")
         git(self.project_checkout, "add", str(candidate_marker))
@@ -338,6 +373,71 @@ class ClaimingContract(unittest.TestCase):
         )
         git(self.project_checkout, "push", "origin", f"HEAD:{candidate_ref}")
         return published, candidate_head
+
+    def deliver_candidate(self, published, candidate_head: str) -> str:
+        receipt_id = new_identifier("rcp")
+        planned: dict[str, Any] = {}
+
+        def revalidate(context) -> None:
+            work, body = _read_yaml(
+                context.checkout / f"work/{self.work_id}/work.md",
+                frontmatter=True,
+                label="work",
+            )
+            self.assertEqual(work["claim"]["id"], published.claim_id)
+            receipt = _attempt_receipt(
+                work,
+                work["claim"],
+                receipt_id=receipt_id,
+                outcome="delivered",
+                mutation_ownership="retained",
+                ended_at=OBSERVED_AT + timedelta(minutes=4),
+                evidence=AttemptEvidence(
+                    validation=(
+                        {
+                            "command": "just test",
+                            "outcome": "passed",
+                            "candidate_revision": candidate_head,
+                            "observed_at": fixtures.TIMESTAMP,
+                        },
+                    ),
+                    reviews=(
+                        {
+                            "mechanism": "review-code-change",
+                            "verdict": "clean",
+                            "candidate_revision": candidate_head,
+                            "comparison_base_revision": work["claim"]["candidate"][
+                                "base_revision"
+                            ],
+                            "observed_at": fixtures.TIMESTAMP,
+                        },
+                    ),
+                ),
+            )
+            planned.clear()
+            planned.update(work=work, body=body, receipt=receipt)
+
+        def plan(context) -> TransitionPlan:
+            work = dict(planned["work"])
+            work["status"] = "delivered"
+            work["attempt_receipt_id"] = receipt_id
+            work["delivery_receipt_id"] = receipt_id
+            return TransitionPlan(
+                commit_message=f"deliver {self.work_id} for takeover contract",
+                changes=(
+                    FileChange(
+                        f"work/{self.work_id}/receipts/{receipt_id}.md",
+                        _render_document(planned["receipt"], "Delivered candidate."),
+                    ),
+                    FileChange(
+                        f"work/{self.work_id}/work.md",
+                        _render_document(work, planned["body"]),
+                    ),
+                ),
+            )
+
+        self.coordinator.writer.publish("deliver", revalidate=revalidate, plan=plan)
+        return receipt_id
 
     def mailbox_clone(self, name: str) -> Path:
         checkout = self.root / name
@@ -529,6 +629,46 @@ class ClaimingContract(unittest.TestCase):
                 ended_at=OBSERVED_AT + timedelta(minutes=5),
             )
 
+    def test_delivered_takeover_returns_active_with_historical_delivery(self) -> None:
+        published, candidate_head = self.publish_candidate_with_descendant(
+            with_pull_request=True
+        )
+        receipt_id = self.deliver_candidate(published, candidate_head)
+        takeover = self.coordinator.takeover(
+            self.work_id,
+            self.fence(published),
+            claim_id=new_identifier("clm"),
+            worker_run_id=new_identifier("run"),
+            continuation_token="delivered-takeover-token-0",
+            takeover_message_id=new_identifier("msg"),
+            reason="Continue from the delivered candidate under a replacement claim.",
+            taken_over_at=OBSERVED_AT + timedelta(minutes=5),
+            approved_commit=self.approved_commit,
+            policy_target=self.policy_target(),
+            host_target=self.host_target(),
+            observation_path=self.observation_path,
+            observation_not_before=self.live_at,
+            now=OBSERVED_AT + timedelta(minutes=5),
+        )
+        checkout = self.mailbox_clone("delivered-takeover-read")
+        work, _ = _read_yaml(
+            checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+            label="work",
+        )
+        receipt, _ = _read_yaml(
+            checkout / f"work/{self.work_id}/receipts/{receipt_id}.md",
+            frontmatter=True,
+            label="delivery receipt",
+        )
+        snapshot = reconstruct_mailbox(checkout)
+        self.assertEqual(takeover.status, "active")
+        self.assertEqual(work["status"], "active")
+        self.assertEqual(work["attempt_receipt_id"], receipt_id)
+        self.assertIsNone(work["delivery_receipt_id"])
+        self.assertEqual(receipt["candidate"]["head_revision"], candidate_head)
+        self.assertEqual(snapshot["views"]["active"], [self.work_id])
+
     def test_release_and_reclaim_accept_reachable_candidate_ancestor(self) -> None:
         published, candidate_head = self.publish_candidate_with_descendant()
         released = self.coordinator.release(
@@ -548,6 +688,93 @@ class ClaimingContract(unittest.TestCase):
         )
         self.assertEqual(reclaimed.status, "active")
         self.assertEqual(work["claim"]["candidate"]["head_revision"], candidate_head)
+
+    def test_checkpoint_capability_absence_and_retry_drift_fail_before_allowance(self) -> None:
+        claimed = self.claim()
+        unavailable = ClaimCoordinator(
+            str(self.mailbox_remote),
+            "main",
+            capability_verifier=lambda target: False,
+        )
+        with self.assertRaisesRegex(ClaimingError, "capability is unavailable"):
+            self.checkpoint(
+                claimed,
+                action="repository.candidate.push",
+                token="missing-capability-token",
+                candidate_head=HEAD,
+                coordinator=unavailable,
+            )
+
+        message_id = new_identifier("msg")
+        message = {
+            "schema": "atelier.message/v1",
+            "id": message_id,
+            "work_id": self.work_id,
+            "kind": "instruction",
+            "author_role": "planner",
+            "worker_run_id": None,
+            "audience": "worker",
+            "in_reply_to": None,
+            "resolves": None,
+            "blocks": None,
+            "created_at": fixtures.TIMESTAMP,
+            "subject": "Concurrent instruction",
+        }
+        concurrent_writer = GitMailboxWriter(str(self.mailbox_remote), "main")
+
+        def advance() -> None:
+            concurrent_writer.publish(
+                "concurrent instruction",
+                revalidate=lambda context: None,
+                plan=lambda context: TransitionPlan(
+                    commit_message="append concurrent instruction",
+                    changes=(
+                        FileChange(
+                            f"work/{self.work_id}/messages/{message_id}.md",
+                            _render_document(message, "Revalidate before continuing."),
+                        ),
+                    ),
+                ),
+            )
+
+        advance_pending = True
+
+        def runner(cwd, arguments):
+            nonlocal advance_pending
+            if arguments and arguments[0] == "push" and advance_pending:
+                advance_pending = False
+                advance()
+            return run_git(cwd, arguments)
+
+        capability_checks = 0
+
+        def capability_verifier(target) -> bool:
+            nonlocal capability_checks
+            capability_checks += 1
+            return capability_checks == 1
+
+        retrying = ClaimCoordinator(
+            str(self.mailbox_remote),
+            "main",
+            writer=GitMailboxWriter(str(self.mailbox_remote), "main", runner=runner),
+            capability_verifier=capability_verifier,
+        )
+        with self.assertRaisesRegex(ClaimingError, "capability is unavailable"):
+            self.checkpoint(
+                claimed,
+                action="repository.candidate.push",
+                token="drifted-capability-token",
+                candidate_head=HEAD,
+                coordinator=retrying,
+            )
+        checkout = self.mailbox_clone("capability-drift-read")
+        work, _ = _read_yaml(
+            checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+            label="work",
+        )
+        self.assertEqual(capability_checks, 2)
+        self.assertEqual(work["claim"]["checkpoint"]["sequence"], 0)
 
     def test_missing_capability_and_wrong_approval_commit_fail_before_mailbox_write(self) -> None:
         before = git(

--- a/contract_tests/test_claiming.py
+++ b/contract_tests/test_claiming.py
@@ -1,0 +1,566 @@
+"""Executable contract for project-serial claims and hash-bound checkpoints."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import threading
+import unittest
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+from contract_tests import test_mailbox as fixtures
+from contract_tests.test_planning import (
+    AUTHORITY,
+    EVIDENCE,
+    OBSERVED_AT,
+    git,
+    observation,
+    write_json,
+)
+from skills.atelier.scripts.claiming import (
+    CheckpointRequest,
+    ClaimCoordinator,
+    ClaimFence,
+    ClaimingError,
+    HostTarget,
+    new_identifier,
+)
+from skills.atelier.scripts.git_mailbox import MailboxTransitionRejected
+from skills.atelier.scripts.mailbox import _read_yaml, reconstruct_mailbox
+from skills.atelier.scripts.planning import (
+    ApprovalEnvelope,
+    AssignmentDraft,
+    InitiativeDraft,
+    Planner,
+    PolicyTarget,
+)
+
+DIGEST = "sha256:" + "d" * 64
+HEAD = "b" * 40
+CLAIMING_SCRIPT = Path(__file__).parents[1] / "skills/atelier/scripts/claiming.py"
+
+
+class ClaimingContract(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="atelier-claiming-test-")
+        self.root = Path(self.temporary.name)
+        self.mailbox_remote = self.root / "mailbox.git"
+        git(None, "init", "--bare", "--initial-branch=main", str(self.mailbox_remote))
+        mailbox_seed = self.root / "mailbox-seed"
+        git(None, "clone", str(self.mailbox_remote), str(mailbox_seed))
+        mailbox = fixtures.MailboxFixture(mailbox_seed)
+        self.project_id, self.repository = mailbox.add_project(1)
+        git(mailbox_seed, "add", "-A")
+        git(
+            mailbox_seed,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "-m",
+            "seed mailbox",
+        )
+        git(mailbox_seed, "push", "origin", "HEAD:main")
+
+        self.project_remote = self.root / "project.git"
+        git(None, "init", "--bare", "--initial-branch=main", str(self.project_remote))
+        self.project_checkout = self.root / "project"
+        git(None, "clone", str(self.project_remote), str(self.project_checkout))
+        self.policy_path = self.project_checkout / ".atelier/policy.yaml"
+        self.policy_path.parent.mkdir(parents=True)
+        self.write_policy()
+        git(self.project_checkout, "add", "-A")
+        git(
+            self.project_checkout,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "-m",
+            "add project policy",
+        )
+        git(self.project_checkout, "push", "origin", "HEAD:main")
+
+        self.observation_path = self.root / "observation.json"
+        write_json(self.observation_path, observation())
+        self.work_id = fixtures.identifier("wrk", 778)
+        self.initiative_id = fixtures.identifier("ini", 778)
+        planner = Planner(str(self.mailbox_remote), "main")
+        planner.create_draft(
+            self.assignment(),
+            initiative=self.initiative(),
+            observation_path=self.observation_path,
+            observation_not_before=OBSERVED_AT,
+            now=OBSERVED_AT + timedelta(seconds=30),
+        )
+        preview = planner.preview_approval(
+            self.work_id,
+            expected_revision=1,
+            envelope=ApprovalEnvelope(AUTHORITY, EVIDENCE),
+            policy_target=self.policy_target(),
+            observation_path=self.observation_path,
+            observation_not_before=OBSERVED_AT,
+            now=OBSERVED_AT + timedelta(seconds=30),
+        )
+        self.live_at = OBSERVED_AT + timedelta(minutes=1)
+        write_json(self.observation_path, self.fresh_observation())
+        approved = planner.approve(
+            preview,
+            approved_by="operator",
+            approved_at=self.live_at,
+            policy_target=self.policy_target(),
+            observation_path=self.observation_path,
+            observation_not_before=self.live_at,
+            now=self.live_at + timedelta(seconds=30),
+        )
+        self.approved_commit = approved.commit
+        self.coordinator = ClaimCoordinator(
+            str(self.mailbox_remote),
+            "main",
+            candidate_verifier=lambda candidate: candidate["head_revision"] == HEAD,
+            capability_verifier=lambda target: True,
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_policy(self, *, authority: tuple[str, ...] = AUTHORITY) -> None:
+        fixtures.write_yaml(
+            self.policy_path,
+            {
+                "schema": "atelier.project-policy/v1",
+                "mailbox": {
+                    "remote": str(self.mailbox_remote),
+                    "realm_id": "personal",
+                    "canonical_branch": "main",
+                    "project_id": self.project_id,
+                },
+                "repository": {
+                    "identity": self.repository,
+                    "canonical_ref": "refs/heads/main",
+                },
+                "ticket": {
+                    "provider": "github",
+                    "allowed_states": ["open"],
+                    "require_no_blockers": True,
+                    "material_fields": ["body", "state", "relationships"],
+                },
+                "execution": {
+                    "capability": "agent-scripts.implement-ticket/delegated-execution/v1",
+                    "delivery_outcome": "ready_pr",
+                    "parallel_assignments": False,
+                },
+                "authority": {"allow": list(authority)},
+                "validation": {"required_commands": ["just test", "just lint"]},
+                "acceptance": {"actor": "operator", "evidence": list(EVIDENCE)},
+            },
+        )
+
+    def policy_target(self, checkout: Path | None = None) -> PolicyTarget:
+        return PolicyTarget(
+            checkout=checkout or self.project_checkout,
+            remote="origin",
+            canonical_ref="refs/heads/main",
+            path=".atelier/policy.yaml",
+        )
+
+    def host_target(self) -> HostTarget:
+        return HostTarget(
+            descriptor_path=self.root / "host-capability.json",
+            skill_name="agent-scripts:implement-ticket",
+            skill_root=self.root / "agent-scripts",
+            connector="github@openai-curated",
+            operations=("read_issue",),
+        )
+
+    def fresh_observation(self) -> dict[str, Any]:
+        value = observation()
+        value["observed_at"] = self.live_at.isoformat().replace("+00:00", "Z")
+        return value
+
+    def assignment(self) -> AssignmentDraft:
+        return AssignmentDraft(
+            id=self.work_id,
+            title="Claim one approved assignment",
+            project_id=self.project_id,
+            initiative_id=self.initiative_id,
+            dependencies=(),
+            replaces=(),
+            ticket_number=777,
+            ticket_url="https://github.com/example/project-1/issues/777",
+            intent="Fence one current worker to one approved assignment.",
+            rationale="Durable ownership must survive the worker transcript.",
+            scope="Derive readiness, claim once, checkpoint mutations, and preserve handoffs.",
+            non_goals="Do not implement or audit the linked ticket.",
+            constraints="Use verified fast-forward Git mailbox writes.",
+            edge_cases="Reject stale tokens, policy drift, ticket drift, and foreign claimants.",
+            related_context="Delegation remains owned by the next graph ticket.",
+            done_definition="One current claim and its exact checkpoint ledger reconstruct.",
+            verification_expectations="Run focused and complete repository contract tests.",
+            review_shape_guidance="Keep claim coordination independent from delegation.",
+        )
+
+    def initiative(self) -> InitiativeDraft:
+        return InitiativeDraft(
+            id=self.initiative_id,
+            title="Accountable claim coordination",
+            intent="Keep worker mutation ownership durable.",
+            rationale="Host-local state cannot fence a fresh worker.",
+            non_goals="Do not add a scheduler or lease service.",
+            constraints="Keep the Git mailbox as the only shared state.",
+            edge_cases="A worker may disappear with or without a candidate.",
+            related_context="The assignment is project-specific.",
+            outcome="One recoverable project-serial claim.",
+        )
+
+    def claim(
+        self,
+        *,
+        coordinator: ClaimCoordinator | None = None,
+        policy_target: PolicyTarget | None = None,
+        claim_id: str | None = None,
+        worker_run_id: str | None = None,
+        token: str = "token-0",
+    ):
+        return (coordinator or self.coordinator).claim(
+            self.work_id,
+            claim_id=claim_id or new_identifier("clm"),
+            worker_run_id=worker_run_id or new_identifier("run"),
+            continuation_token=token,
+            approved_commit=self.approved_commit,
+            claimed_at=OBSERVED_AT + timedelta(minutes=1),
+            policy_target=policy_target or self.policy_target(),
+            host_target=self.host_target(),
+            observation_path=self.observation_path,
+            observation_not_before=self.live_at,
+            now=OBSERVED_AT + timedelta(minutes=1),
+        )
+
+    def fence(self, result) -> ClaimFence:
+        return ClaimFence(
+            claim_id=result.claim_id,
+            worker_run_id=result.worker_run_id,
+            sequence=result.sequence,
+            continuation_token=result.continuation_token,
+        )
+
+    def checkpoint(
+        self,
+        result,
+        *,
+        action: str,
+        token: str,
+        candidate_head: str | None = None,
+        phase: str = "pre_external_mutation",
+        candidate: dict[str, Any] | None = None,
+    ):
+        return self.coordinator.authorize(
+            self.work_id,
+            CheckpointRequest(
+                fence=self.fence(result),
+                phase=phase,
+                action=action,
+                proposed_effect_digest=DIGEST,
+                candidate_head=candidate_head,
+                acknowledged_candidate_head=(
+                    candidate_head if phase == "candidate_published" else None
+                ),
+                next_continuation_token=token,
+                recorded_at=OBSERVED_AT + timedelta(minutes=2),
+                candidate=candidate,
+            ),
+            approved_commit=self.approved_commit,
+            policy_target=self.policy_target(),
+            observation_path=self.observation_path,
+            observation_not_before=self.live_at,
+            now=OBSERVED_AT + timedelta(minutes=2),
+        )
+
+    def candidate(self) -> dict[str, Any]:
+        return {
+            "repository": self.repository,
+            "remote": "origin",
+            "remote_url": "git@github.com:example/project-1.git",
+            "remote_ref": "refs/heads/scott/example-work",
+            "base_revision": "a" * 40,
+            "head_revision": HEAD,
+            "pull_request": None,
+            "workspace_id": None,
+            "published_at": "2026-07-28T04:02:00Z",
+        }
+
+    def mailbox_clone(self, name: str) -> Path:
+        checkout = self.root / name
+        git(None, "clone", str(self.mailbox_remote), str(checkout))
+        return checkout
+
+    def test_concurrent_workers_produce_exactly_one_current_claim(self) -> None:
+        policy_a = self.root / "policy-a"
+        policy_b = self.root / "policy-b"
+        git(None, "clone", str(self.project_remote), str(policy_a))
+        git(None, "clone", str(self.project_remote), str(policy_b))
+        results: list[object] = []
+        errors: list[Exception] = []
+        lock = threading.Lock()
+
+        def attempt(number: int, checkout: Path) -> None:
+            coordinator = ClaimCoordinator(
+                str(self.mailbox_remote),
+                "main",
+                candidate_verifier=lambda candidate: True,
+                capability_verifier=lambda target: True,
+            )
+            try:
+                result = self.claim(
+                    coordinator=coordinator,
+                    policy_target=self.policy_target(checkout),
+                    claim_id=fixtures.identifier("clm", 100 + number),
+                    worker_run_id=fixtures.identifier("run", 100 + number),
+                )
+            except Exception as error:
+                with lock:
+                    errors.append(error)
+            else:
+                with lock:
+                    results.append(result)
+
+        threads = [
+            threading.Thread(target=attempt, args=(1, policy_a)),
+            threading.Thread(target=attempt, args=(2, policy_b)),
+        ]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], MailboxTransitionRejected)
+        snapshot = reconstruct_mailbox(self.mailbox_clone("claim-read"))
+        self.assertEqual(snapshot["views"]["active"], [self.work_id])
+
+    def test_checkpoint_rotates_token_and_rejects_replay_and_ticket_drift(self) -> None:
+        claimed = self.claim()
+        allowed = self.checkpoint(
+            claimed,
+            action="repository.candidate.create",
+            token="token-1",
+        )
+        self.assertEqual(allowed.sequence, 1)
+        self.assertEqual(allowed.continuation_token, "token-1")
+
+        with self.assertRaisesRegex(MailboxTransitionRejected, "stale or foreign"):
+            self.checkpoint(
+                claimed,
+                action="repository.candidate.create",
+                token="replayed-token",
+            )
+
+        changed = self.fresh_observation()
+        changed["issue"]["body"] = "Materially changed after claim."
+        write_json(self.observation_path, changed)
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected, "material ticket observation changed"
+        ):
+            self.checkpoint(
+                allowed,
+                action="repository.candidate.create",
+                token="token-2",
+            )
+
+    def test_candidate_publication_requires_paired_push_and_exact_remote_reachability(self) -> None:
+        claimed = self.claim()
+        push = self.checkpoint(
+            claimed,
+            action="repository.candidate.push",
+            token="token-1",
+            candidate_head=HEAD,
+        )
+        published = self.checkpoint(
+            push,
+            action="repository.candidate.push",
+            token="token-2",
+            candidate_head=HEAD,
+            phase="candidate_published",
+            candidate=self.candidate(),
+        )
+        self.assertEqual(published.sequence, 2)
+
+        checkout = self.mailbox_clone("candidate-read")
+        work, _ = _read_yaml(
+            checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+            label="work",
+        )
+        self.assertEqual(work["claim"]["candidate"]["head_revision"], HEAD)
+        self.assertEqual(
+            [entry["phase"] for entry in work["claim"]["checkpoint"]["authorizations"]],
+            ["pre_external_mutation", "candidate_published"],
+        )
+
+    def test_policy_tightening_denies_removed_action_without_widening_claim_authority(self) -> None:
+        claimed = self.claim()
+        self.write_policy(
+            authority=tuple(action for action in AUTHORITY if action != "review.resolve")
+        )
+        git(self.project_checkout, "add", "-A")
+        git(
+            self.project_checkout,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "-m",
+            "tighten project policy",
+        )
+        git(self.project_checkout, "push", "origin", "HEAD:main")
+
+        with self.assertRaisesRegex(MailboxTransitionRejected, "exceeds effective authority"):
+            self.checkpoint(
+                claimed,
+                action="review.resolve",
+                token="token-1",
+                candidate_head=HEAD,
+            )
+
+    def test_block_takeover_and_release_preserve_recoverable_candidate(self) -> None:
+        claimed = self.claim()
+        push = self.checkpoint(
+            claimed,
+            action="repository.candidate.push",
+            token="token-1",
+            candidate_head=HEAD,
+        )
+        published = self.checkpoint(
+            push,
+            action="repository.candidate.push",
+            token="token-2",
+            candidate_head=HEAD,
+            phase="candidate_published",
+            candidate=self.candidate(),
+        )
+        blocked = self.coordinator.block(
+            self.work_id,
+            self.fence(published),
+            message_id=new_identifier("msg"),
+            receipt_id=new_identifier("rcp"),
+            subject="A planner decision is required",
+            detail="The exact candidate is preserved while the worker waits.",
+            created_at=OBSERVED_AT + timedelta(minutes=3),
+        )
+        self.assertEqual(blocked.status, "blocked")
+
+        takeover = self.coordinator.takeover(
+            self.work_id,
+            self.fence(blocked),
+            claim_id=new_identifier("clm"),
+            worker_run_id=new_identifier("run"),
+            continuation_token="takeover-token-0",
+            takeover_message_id=new_identifier("msg"),
+            reason="The prior worker cannot continue; preserve its exact candidate.",
+            taken_over_at=OBSERVED_AT + timedelta(minutes=4),
+            approved_commit=self.approved_commit,
+            policy_target=self.policy_target(),
+            host_target=self.host_target(),
+            observation_path=self.observation_path,
+            observation_not_before=self.live_at,
+            now=OBSERVED_AT + timedelta(minutes=4),
+        )
+        self.assertEqual(takeover.status, "active")
+        with self.assertRaisesRegex(MailboxTransitionRejected, "stale or foreign"):
+            self.coordinator.release(
+                self.work_id,
+                self.fence(blocked),
+                receipt_id=new_identifier("rcp"),
+                reason="A stale worker must not release the replacement claim.",
+                ended_at=OBSERVED_AT + timedelta(minutes=5),
+            )
+
+        released = self.coordinator.release(
+            self.work_id,
+            self.fence(takeover),
+            receipt_id=new_identifier("rcp"),
+            reason="Return the exact transferable candidate to ready work.",
+            ended_at=OBSERVED_AT + timedelta(minutes=5),
+        )
+        self.assertEqual(released.status, "approved")
+        reclaimed = self.claim(token="reclaim-token-0")
+        checkout = self.mailbox_clone("handoff-read")
+        work, _ = _read_yaml(
+            checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+            label="work",
+        )
+        self.assertEqual(reclaimed.status, "active")
+        self.assertEqual(work["claim"]["candidate"]["head_revision"], HEAD)
+
+    def test_missing_capability_and_wrong_approval_commit_fail_before_mailbox_write(self) -> None:
+        before = git(
+            None, "--git-dir", str(self.mailbox_remote), "rev-parse", "main"
+        ).stdout.strip()
+        wrong_approval = git(
+            None,
+            "--git-dir",
+            str(self.mailbox_remote),
+            "rev-parse",
+            f"{self.approved_commit}^",
+        ).stdout.strip()
+        unavailable = ClaimCoordinator(
+            str(self.mailbox_remote),
+            "main",
+            capability_verifier=lambda target: False,
+        )
+        with self.assertRaisesRegex(ClaimingError, "capability is unavailable"):
+            unavailable.claim(
+                self.work_id,
+                claim_id=new_identifier("clm"),
+                worker_run_id=new_identifier("run"),
+                continuation_token="token-0",
+                approved_commit=self.approved_commit,
+                claimed_at=OBSERVED_AT + timedelta(minutes=1),
+                policy_target=self.policy_target(),
+                host_target=self.host_target(),
+                observation_path=self.observation_path,
+                observation_not_before=self.live_at,
+                now=OBSERVED_AT + timedelta(minutes=1),
+            )
+        with self.assertRaisesRegex(MailboxTransitionRejected, "approved commit"):
+            self.coordinator.claim(
+                self.work_id,
+                claim_id=new_identifier("clm"),
+                worker_run_id=new_identifier("run"),
+                continuation_token="token-0",
+                approved_commit=wrong_approval,
+                claimed_at=OBSERVED_AT + timedelta(minutes=1),
+                policy_target=self.policy_target(),
+                host_target=self.host_target(),
+                observation_path=self.observation_path,
+                observation_not_before=self.live_at,
+                now=OBSERVED_AT + timedelta(minutes=1),
+            )
+        after = git(None, "--git-dir", str(self.mailbox_remote), "rev-parse", "main").stdout.strip()
+        self.assertEqual(after, before)
+
+    def test_cli_generates_a_strict_durable_identifier(self) -> None:
+        completed = subprocess.run(
+            ["python3", str(CLAIMING_SCRIPT), "new-id", "clm"],
+            cwd=Path(__file__).parents[1],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        self.assertRegex(
+            completed.stdout.strip(),
+            r"^clm_[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-"
+            r"[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/contract_tests/test_claiming.py
+++ b/contract_tests/test_claiming.py
@@ -28,6 +28,7 @@ from skills.atelier.scripts.claiming import (
     HostTarget,
     _attempt_receipt,
     _candidate_remote_reachable,
+    _policy_remote_matches_repository,
     _render_document,
     new_identifier,
 )
@@ -133,6 +134,7 @@ class ClaimingContract(unittest.TestCase):
             "main",
             candidate_verifier=lambda candidate: candidate["head_revision"] == HEAD,
             capability_verifier=lambda target: True,
+            policy_remote_verifier=self.policy_remote_matches,
         )
 
     def tearDown(self) -> None:
@@ -177,6 +179,13 @@ class ClaimingContract(unittest.TestCase):
             canonical_ref="refs/heads/main",
             path=".atelier/policy.yaml",
         )
+
+
+    def policy_remote_matches(self, target: PolicyTarget, repository: str) -> bool:
+        configured = run_git(target.checkout, ("remote", "get-url", target.remote))
+        if configured.returncode != 0 or repository != self.repository:
+            return False
+        return Path(configured.stdout.strip()).resolve() == self.project_remote.resolve()
 
     def host_target(self) -> HostTarget:
         return HostTarget(
@@ -319,6 +328,7 @@ class ClaimingContract(unittest.TestCase):
                 {**value, "remote_url": str(self.project_remote)}
             ),
             capability_verifier=lambda target: True,
+            policy_remote_verifier=self.policy_remote_matches,
         )
         claimed = self.claim()
         push = self.checkpoint(
@@ -459,6 +469,7 @@ class ClaimingContract(unittest.TestCase):
                 "main",
                 candidate_verifier=lambda candidate: True,
                 capability_verifier=lambda target: True,
+                policy_remote_verifier=self.policy_remote_matches,
             )
             try:
                 result = self.claim(
@@ -548,6 +559,52 @@ class ClaimingContract(unittest.TestCase):
             ["pre_external_mutation", "candidate_published"],
         )
 
+
+    def test_default_policy_remote_verifier_binds_github_repository_identity(self) -> None:
+        git(
+            self.project_checkout,
+            "remote",
+            "set-url",
+            "origin",
+            "git@github.com:example/project-1.git",
+        )
+        target = self.policy_target()
+        self.assertTrue(_policy_remote_matches_repository(target, self.repository))
+        self.assertFalse(
+            _policy_remote_matches_repository(target, "github:example/a-foreign-project")
+        )
+        git(self.project_checkout, "remote", "set-url", "origin", str(self.project_remote))
+
+    def test_foreign_policy_mirror_cannot_hide_canonical_tightening(self) -> None:
+        stale_remote = self.root / "stale-project.git"
+        stale_checkout = self.root / "stale-project"
+        git(None, "clone", "--bare", str(self.project_remote), str(stale_remote))
+        git(None, "clone", str(stale_remote), str(stale_checkout))
+
+        self.write_policy(
+            authority=tuple(
+                action for action in AUTHORITY if action != "repository.candidate.create"
+            )
+        )
+        git(self.project_checkout, "add", "-A")
+        git(
+            self.project_checkout,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "-m",
+            "tighten canonical project policy",
+        )
+        git(self.project_checkout, "push", "origin", "HEAD:main")
+
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "policy remote is foreign or unverifiable",
+        ):
+            self.claim(policy_target=self.policy_target(stale_checkout))
+
     def test_policy_tightening_denies_removed_action_without_widening_claim_authority(self) -> None:
         claimed = self.claim()
         self.write_policy(
@@ -629,6 +686,30 @@ class ClaimingContract(unittest.TestCase):
                 ended_at=OBSERVED_AT + timedelta(minutes=5),
             )
 
+        released = self.coordinator.release(
+            self.work_id,
+            self.fence(takeover),
+            receipt_id=new_identifier("rcp"),
+            reason="Relinquish the replacement claim while retaining the inherited decision.",
+            ended_at=OBSERVED_AT + timedelta(minutes=5),
+        )
+        self.assertEqual(released.status, "approved")
+        released_checkout = self.mailbox_clone("takeover-release-read")
+        released_work, _ = _read_yaml(
+            released_checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+            label="released takeover",
+        )
+        historical_blocker, _ = _read_yaml(
+            released_checkout / f"work/{self.work_id}/messages/{blocker_id}.md",
+            frontmatter=True,
+            label="inherited historical blocker",
+        )
+        reconstruct_mailbox(released_checkout)
+        self.assertEqual(released_work["status"], "approved")
+        self.assertIsNone(released_work["blocking_message_id"])
+        self.assertIsNone(historical_blocker["resolves"])
+
     def test_blocked_release_keeps_decision_historical_without_resolving_it(self) -> None:
         claimed = self.claim()
         blocker_id = new_identifier("msg")
@@ -647,7 +728,7 @@ class ClaimingContract(unittest.TestCase):
             self.fence(blocked),
             receipt_id=release_receipt_id,
             reason="Relinquish the blocked attempt without inventing a resolution.",
-            ended_at=OBSERVED_AT + timedelta(minutes=4),
+            ended_at=OBSERVED_AT + timedelta(minutes=30),
         )
         self.assertEqual(released.status, "approved")
         reclaimed = self.claim(token="post-blocked-release-token")
@@ -676,6 +757,27 @@ class ClaimingContract(unittest.TestCase):
         self.assertIsNone(blocker["resolves"])
         self.assertEqual(release_receipt["outcome"], "released")
         self.assertEqual(snapshot["views"]["active"], [self.work_id])
+
+        current_blocker_id = new_identifier("msg")
+        reblocked = self.coordinator.block(
+            self.work_id,
+            self.fence(reclaimed),
+            message_id=current_blocker_id,
+            receipt_id=new_identifier("rcp"),
+            subject="The replacement worker now needs a different decision",
+            detail="A later attempt remains current regardless of attribution timestamps.",
+            created_at=OBSERVED_AT + timedelta(minutes=5),
+        )
+        self.assertEqual(reblocked.status, "blocked")
+        reblocked_checkout = self.mailbox_clone("reblocked-after-release-read")
+        reblocked_work, _ = _read_yaml(
+            reblocked_checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+            label="reblocked work",
+        )
+        reblocked_snapshot = reconstruct_mailbox(reblocked_checkout)
+        self.assertEqual(reblocked_work["blocking_message_id"], current_blocker_id)
+        self.assertEqual(reblocked_snapshot["views"]["blocked"], [self.work_id])
 
     def test_delivered_takeover_returns_active_with_historical_delivery(self) -> None:
         published, candidate_head = self.publish_candidate_with_descendant(
@@ -743,6 +845,7 @@ class ClaimingContract(unittest.TestCase):
             str(self.mailbox_remote),
             "main",
             capability_verifier=lambda target: False,
+            policy_remote_verifier=self.policy_remote_matches,
         )
         with self.assertRaisesRegex(ClaimingError, "capability is unavailable"):
             self.checkpoint(
@@ -806,6 +909,7 @@ class ClaimingContract(unittest.TestCase):
             "main",
             writer=GitMailboxWriter(str(self.mailbox_remote), "main", runner=runner),
             capability_verifier=capability_verifier,
+            policy_remote_verifier=self.policy_remote_matches,
         )
         with self.assertRaisesRegex(ClaimingError, "capability is unavailable"):
             self.checkpoint(
@@ -839,6 +943,7 @@ class ClaimingContract(unittest.TestCase):
             str(self.mailbox_remote),
             "main",
             capability_verifier=lambda target: False,
+            policy_remote_verifier=self.policy_remote_matches,
         )
         with self.assertRaisesRegex(ClaimingError, "capability is unavailable"):
             unavailable.claim(

--- a/contract_tests/test_claiming.py
+++ b/contract_tests/test_claiming.py
@@ -631,6 +631,82 @@ class ClaimingContract(unittest.TestCase):
                 candidate_head=HEAD,
             )
 
+
+    def test_active_takeover_preserves_published_candidate_with_handoff_receipt(self) -> None:
+        published, candidate_head = self.publish_candidate_with_descendant()
+        prior_fence = self.fence(published)
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "active takeover requires a stable receipt identity",
+        ):
+            self.coordinator.takeover(
+                self.work_id,
+                prior_fence,
+                claim_id=new_identifier("clm"),
+                worker_run_id=new_identifier("run"),
+                continuation_token="missing-active-takeover-receipt",
+                takeover_message_id=new_identifier("msg"),
+                reason="Candidate provenance cannot be implicit.",
+                taken_over_at=OBSERVED_AT + timedelta(minutes=4),
+                approved_commit=self.approved_commit,
+                policy_target=self.policy_target(),
+                host_target=self.host_target(),
+                observation_path=self.observation_path,
+                observation_not_before=self.live_at,
+                now=OBSERVED_AT + timedelta(minutes=4),
+            )
+
+        takeover_receipt_id = new_identifier("rcp")
+        takeover = self.coordinator.takeover(
+            self.work_id,
+            prior_fence,
+            claim_id=new_identifier("clm"),
+            worker_run_id=new_identifier("run"),
+            continuation_token="active-takeover-token-0",
+            takeover_message_id=new_identifier("msg"),
+            takeover_receipt_id=takeover_receipt_id,
+            reason="The active worker disappeared after publishing its candidate.",
+            taken_over_at=OBSERVED_AT + timedelta(minutes=4),
+            approved_commit=self.approved_commit,
+            policy_target=self.policy_target(),
+            host_target=self.host_target(),
+            observation_path=self.observation_path,
+            observation_not_before=self.live_at,
+            now=OBSERVED_AT + timedelta(minutes=4),
+        )
+        checkout = self.mailbox_clone("active-takeover-read")
+        work, _ = _read_yaml(
+            checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+            label="active takeover work",
+        )
+        receipt, _ = _read_yaml(
+            checkout / f"work/{self.work_id}/receipts/{takeover_receipt_id}.md",
+            frontmatter=True,
+            label="active takeover handoff",
+        )
+        snapshot = reconstruct_mailbox(checkout)
+        self.assertEqual(takeover.status, "active")
+        self.assertEqual(work["attempt_receipt_id"], takeover_receipt_id)
+        self.assertEqual(work["claim"]["checkpoint"]["sequence"], 0)
+        self.assertEqual(work["claim"]["checkpoint"]["authorizations"], [])
+        self.assertEqual(work["claim"]["candidate"]["head_revision"], candidate_head)
+        self.assertEqual(receipt["claim_id"], prior_fence.claim_id)
+        self.assertEqual(receipt["worker_run_id"], prior_fence.worker_run_id)
+        self.assertEqual(receipt["candidate"]["head_revision"], candidate_head)
+        self.assertEqual(receipt["outcome"], "released")
+        self.assertEqual(receipt["mutation_ownership"], "relinquished")
+        self.assertEqual(snapshot["views"]["active"], [self.work_id])
+
+        with self.assertRaisesRegex(MailboxTransitionRejected, "stale or foreign"):
+            self.coordinator.release(
+                self.work_id,
+                prior_fence,
+                receipt_id=new_identifier("rcp"),
+                reason="The fenced worker cannot release the replacement claim.",
+                ended_at=OBSERVED_AT + timedelta(minutes=5),
+            )
+
     def test_blocked_takeover_preserves_unresolved_blocker_and_candidate(self) -> None:
         published, _candidate_head = self.publish_candidate_with_descendant()
         blocker_id = new_identifier("msg")

--- a/contract_tests/test_claiming.py
+++ b/contract_tests/test_claiming.py
@@ -25,6 +25,7 @@ from skills.atelier.scripts.claiming import (
     ClaimFence,
     ClaimingError,
     HostTarget,
+    _candidate_remote_reachable,
     new_identifier,
 )
 from skills.atelier.scripts.git_mailbox import MailboxTransitionRejected
@@ -293,6 +294,51 @@ class ClaimingContract(unittest.TestCase):
             "published_at": "2026-07-28T04:02:00Z",
         }
 
+    def publish_candidate_with_descendant(self):
+        candidate_head = git(self.project_checkout, "rev-parse", "HEAD").stdout.strip()
+        candidate_ref = "refs/heads/scott/example-work"
+        git(self.project_checkout, "push", "origin", f"{candidate_head}:{candidate_ref}")
+        candidate = self.candidate()
+        candidate.update(remote_ref=candidate_ref, head_revision=candidate_head)
+        self.coordinator = ClaimCoordinator(
+            str(self.mailbox_remote),
+            "main",
+            candidate_verifier=lambda value: _candidate_remote_reachable(
+                {**value, "remote_url": str(self.project_remote)}
+            ),
+            capability_verifier=lambda target: True,
+        )
+        claimed = self.claim()
+        push = self.checkpoint(
+            claimed,
+            action="repository.candidate.push",
+            token="token-1",
+            candidate_head=candidate_head,
+        )
+        published = self.checkpoint(
+            push,
+            action="repository.candidate.push",
+            token="token-2",
+            candidate_head=candidate_head,
+            phase="candidate_published",
+            candidate=candidate,
+        )
+        candidate_marker = self.project_checkout / "candidate.txt"
+        candidate_marker.write_text("descendant\n", encoding="utf-8")
+        git(self.project_checkout, "add", str(candidate_marker))
+        git(
+            self.project_checkout,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "-m",
+            "advance candidate",
+        )
+        git(self.project_checkout, "push", "origin", f"HEAD:{candidate_ref}")
+        return published, candidate_head
+
     def mailbox_clone(self, name: str) -> Path:
         checkout = self.root / name
         git(None, "clone", str(self.mailbox_remote), str(checkout))
@@ -428,26 +474,13 @@ class ClaimingContract(unittest.TestCase):
                 candidate_head=HEAD,
             )
 
-    def test_block_takeover_and_release_preserve_recoverable_candidate(self) -> None:
-        claimed = self.claim()
-        push = self.checkpoint(
-            claimed,
-            action="repository.candidate.push",
-            token="token-1",
-            candidate_head=HEAD,
-        )
-        published = self.checkpoint(
-            push,
-            action="repository.candidate.push",
-            token="token-2",
-            candidate_head=HEAD,
-            phase="candidate_published",
-            candidate=self.candidate(),
-        )
+    def test_blocked_takeover_preserves_unresolved_blocker_and_candidate(self) -> None:
+        published, _candidate_head = self.publish_candidate_with_descendant()
+        blocker_id = new_identifier("msg")
         blocked = self.coordinator.block(
             self.work_id,
             self.fence(published),
-            message_id=new_identifier("msg"),
+            message_id=blocker_id,
             receipt_id=new_identifier("rcp"),
             subject="A planner decision is required",
             detail="The exact candidate is preserved while the worker waits.",
@@ -455,13 +488,14 @@ class ClaimingContract(unittest.TestCase):
         )
         self.assertEqual(blocked.status, "blocked")
 
+        takeover_message_id = new_identifier("msg")
         takeover = self.coordinator.takeover(
             self.work_id,
             self.fence(blocked),
             claim_id=new_identifier("clm"),
             worker_run_id=new_identifier("run"),
             continuation_token="takeover-token-0",
-            takeover_message_id=new_identifier("msg"),
+            takeover_message_id=takeover_message_id,
             reason="The prior worker cannot continue; preserve its exact candidate.",
             taken_over_at=OBSERVED_AT + timedelta(minutes=4),
             approved_commit=self.approved_commit,
@@ -471,7 +505,21 @@ class ClaimingContract(unittest.TestCase):
             observation_not_before=self.live_at,
             now=OBSERVED_AT + timedelta(minutes=4),
         )
-        self.assertEqual(takeover.status, "active")
+        self.assertEqual(takeover.status, "blocked")
+        takeover_checkout = self.mailbox_clone("takeover-read")
+        takeover_work, _ = _read_yaml(
+            takeover_checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+            label="work",
+        )
+        takeover_message, _ = _read_yaml(
+            takeover_checkout / f"work/{self.work_id}/messages/{takeover_message_id}.md",
+            frontmatter=True,
+            label="takeover message",
+        )
+        self.assertEqual(takeover_work["blocking_message_id"], blocker_id)
+        self.assertEqual(takeover_message["in_reply_to"], blocker_id)
+        self.assertIsNone(takeover_message["resolves"])
         with self.assertRaisesRegex(MailboxTransitionRejected, "stale or foreign"):
             self.coordinator.release(
                 self.work_id,
@@ -481,9 +529,11 @@ class ClaimingContract(unittest.TestCase):
                 ended_at=OBSERVED_AT + timedelta(minutes=5),
             )
 
+    def test_release_and_reclaim_accept_reachable_candidate_ancestor(self) -> None:
+        published, candidate_head = self.publish_candidate_with_descendant()
         released = self.coordinator.release(
             self.work_id,
-            self.fence(takeover),
+            self.fence(published),
             receipt_id=new_identifier("rcp"),
             reason="Return the exact transferable candidate to ready work.",
             ended_at=OBSERVED_AT + timedelta(minutes=5),
@@ -497,7 +547,7 @@ class ClaimingContract(unittest.TestCase):
             label="work",
         )
         self.assertEqual(reclaimed.status, "active")
-        self.assertEqual(work["claim"]["candidate"]["head_revision"], HEAD)
+        self.assertEqual(work["claim"]["candidate"]["head_revision"], candidate_head)
 
     def test_missing_capability_and_wrong_approval_commit_fail_before_mailbox_write(self) -> None:
         before = git(

--- a/contract_tests/test_claiming.py
+++ b/contract_tests/test_claiming.py
@@ -629,6 +629,54 @@ class ClaimingContract(unittest.TestCase):
                 ended_at=OBSERVED_AT + timedelta(minutes=5),
             )
 
+    def test_blocked_release_keeps_decision_historical_without_resolving_it(self) -> None:
+        claimed = self.claim()
+        blocker_id = new_identifier("msg")
+        blocked = self.coordinator.block(
+            self.work_id,
+            self.fence(claimed),
+            message_id=blocker_id,
+            receipt_id=new_identifier("rcp"),
+            subject="A planner decision is required",
+            detail="Release must retain this unanswered decision as history.",
+            created_at=OBSERVED_AT + timedelta(minutes=3),
+        )
+        release_receipt_id = new_identifier("rcp")
+        released = self.coordinator.release(
+            self.work_id,
+            self.fence(blocked),
+            receipt_id=release_receipt_id,
+            reason="Relinquish the blocked attempt without inventing a resolution.",
+            ended_at=OBSERVED_AT + timedelta(minutes=4),
+        )
+        self.assertEqual(released.status, "approved")
+        reclaimed = self.claim(token="post-blocked-release-token")
+        checkout = self.mailbox_clone("blocked-release-read")
+        work, _ = _read_yaml(
+            checkout / f"work/{self.work_id}/work.md",
+            frontmatter=True,
+            label="work",
+        )
+        blocker, _ = _read_yaml(
+            checkout / f"work/{self.work_id}/messages/{blocker_id}.md",
+            frontmatter=True,
+            label="historical blocker",
+        )
+        release_receipt, _ = _read_yaml(
+            checkout / f"work/{self.work_id}/receipts/{release_receipt_id}.md",
+            frontmatter=True,
+            label="release receipt",
+        )
+        snapshot = reconstruct_mailbox(checkout)
+        self.assertEqual(reclaimed.status, "active")
+        self.assertEqual(work["status"], "active")
+        self.assertIsNone(work["blocking_message_id"])
+        self.assertEqual(work["attempt_receipt_id"], release_receipt_id)
+        self.assertEqual(blocker["blocks"], "worker")
+        self.assertIsNone(blocker["resolves"])
+        self.assertEqual(release_receipt["outcome"], "released")
+        self.assertEqual(snapshot["views"]["active"], [self.work_id])
+
     def test_delivered_takeover_returns_active_with_historical_delivery(self) -> None:
         published, candidate_head = self.publish_candidate_with_descendant(
             with_pull_request=True

--- a/scripts/validate_repository.py
+++ b/scripts/validate_repository.py
@@ -82,8 +82,8 @@ def validate_skill(errors: list[str]) -> None:
         errors.append("Atelier skill frontmatter must include a description")
     if "[TODO:" in text:
         errors.append("Atelier skill contains a TODO placeholder")
-    if "The `work` and `audit` modes are not implemented yet" not in text:
-        errors.append("skill must state that work and audit modes are unavailable")
+    if "Delegated implementation and audit are not implemented yet" not in text:
+        errors.append("skill must state that delegated work and audit are unavailable")
 
 
 def validate_reset_boundary(errors: list[str]) -> None:

--- a/skills/atelier/SKILL.md
+++ b/skills/atelier/SKILL.md
@@ -46,16 +46,24 @@ Before planning, read `references/planning.md` and follow its draft, revision,
 preview, explicit operator approval, and promotion boundary. Use
 `scripts/planning.py`; do not emulate a second persistence or approval path.
 
-The `work` and `audit` modes are not implemented yet. Do not emulate missing
-Atelier behavior with ad hoc orchestration, hidden local state, copied Agent
-Scripts workflows, or tracker mutations.
+Production work coordination through claim, checkpoint, block, release, and
+takeover is implemented. Before claiming, read `references/claiming.md`, repeat
+the fail-closed host preflight, and use `scripts/claiming.py`. Never mint a
+replacement fence for a stale worker or acknowledge a candidate that is not
+reachable at its exact declared remote ref and head.
 
-When either unavailable mode is requested:
+Delegated implementation and audit are not implemented yet. Work mode stops
+after durable claim/checkpoint coordination; it cannot launch Agent Scripts,
+validate a terminal result, or deliver the assignment. Do not emulate missing
+behavior with ad hoc orchestration, hidden local state, copied Agent Scripts
+workflows, or tracker mutations.
 
-1. Identify the requested mode: `work` or `audit`.
+When either unavailable behavior is requested:
+
+1. Identify the requested behavior: delegated work or audit.
 1. Report that the mode is unavailable in the reset scaffold.
 1. Link the owning issue:
-   - `work`: shaug/atelier#778 and shaug/atelier#779
+   - delegated work: shaug/atelier#779
    - `audit`: shaug/atelier#780
 1. Make no mailbox, repository, ticket, pull-request, or acceptance mutation.
 
@@ -66,8 +74,8 @@ production mode available.
 ## Mailbox boundary
 
 The strict v1 mailbox schema and fresh-clone reconstruction helper are
-implemented. Verified fast-forward canonical writes and the bounded plan-mode
-transitions are also implemented. Before interpreting mailbox documents, read
+implemented. Verified fast-forward canonical writes plus bounded plan and claim
+coordination transitions are also implemented. Before interpreting mailbox documents, read
 `references/mailbox-validation.md` and use its read-only helper.
 Before persisting a transition, read `references/git-mailbox-writes.md` and use
 its isolated compare-and-swap writer.

--- a/skills/atelier/references/claiming.md
+++ b/skills/atelier/references/claiming.md
@@ -1,0 +1,139 @@
+# Claim and checkpoint boundary
+
+Use `../scripts/claiming.py` for the production portion of work mode owned by
+shaug/atelier#778. It is the only supported path for claim acquisition,
+delegated-execution checkpoint authorization, candidate acknowledgement, block,
+release, and takeover.
+
+This boundary does not launch `implement-ticket`, validate a terminal delegated
+result, deliver work, audit a pull request, or record operator acceptance. Those
+remain unavailable until #779 and #780 implement them.
+
+## Preconditions
+
+Before `claim`, `checkpoint`, or `takeover`:
+
+1. Complete the fail-closed host preflight in `host-boundary.md`.
+2. Supply one complete GitHub observation captured at or after the operation's
+   `not_before` boundary.
+3. Supply the managed project's current policy checkout, remote, full canonical
+   ref, and `.atelier/policy.yaml` path.
+4. Supply the exact canonical mailbox commit that first contains the approved
+   work revision.
+5. Supply the exact installed Agent Scripts skill root, stable name, connector
+   identity, and complete read-only operation set required by the host descriptor.
+
+The script rereads approved and current policy, the canonical mailbox, the
+approved work transition, and the material ticket observation during every
+write attempt. It combines policy using the Project Policy Contract and fails
+closed on incompatible identity, eligibility, authority, or evidence drift.
+
+## Commands
+
+Generate durable identifiers before the first attempt so retries reuse them:
+
+```text
+python3 skills/atelier/scripts/claiming.py new-id clm
+python3 skills/atelier/scripts/claiming.py new-id run
+python3 skills/atelier/scripts/claiming.py new-id msg
+python3 skills/atelier/scripts/claiming.py new-id rcp
+```
+
+Run one transition with a JSON request:
+
+```text
+python3 skills/atelier/scripts/claiming.py claim request.json
+python3 skills/atelier/scripts/claiming.py checkpoint request.json
+python3 skills/atelier/scripts/claiming.py block request.json
+python3 skills/atelier/scripts/claiming.py release request.json
+python3 skills/atelier/scripts/claiming.py takeover request.json
+```
+
+Every request contains:
+
+```json
+{
+  "mailbox": {
+    "remote": "git@github.com:example/atelier-mailbox.git",
+    "canonical_branch": "main",
+    "max_attempts": 3
+  },
+  "work_id": "wrk_019f9a9e-0000-7000-8000-000000000001"
+}
+```
+
+Execution-state operations additionally contain:
+
+```json
+{
+  "approved_commit": "0123456789abcdef0123456789abcdef01234567",
+  "host": {
+    "descriptor_path": "/absolute/path/to/atelier/references/host-capability.json",
+    "skill_name": "agent-scripts:implement-ticket",
+    "skill_root": "/absolute/path/to/installed/implement-ticket",
+    "connector": "github@openai-curated",
+    "operations": ["read_issue", "read_issue_relationships"]
+  },
+  "observation": {
+    "path": "/absolute/path/to/github-observation.json",
+    "not_before": "2026-07-28T12:00:00Z"
+  },
+  "policy": {
+    "checkout": "/absolute/path/to/managed-project",
+    "remote": "origin",
+    "canonical_ref": "refs/heads/main",
+    "path": ".atelier/policy.yaml"
+  },
+  "now": "2026-07-28T12:00:30Z"
+}
+```
+
+`now` is optional and exists for deterministic hosts and contract tests.
+
+## Claim
+
+Add `claim_id`, `worker_run_id`, `continuation_token`, and `claimed_at`. A claim
+is allowed only for approved work whose dependencies, project-serial gate,
+policy, native ticket, and capability gate pass. A released transferable
+candidate is adopted only after its exact remote ref and head are verified.
+
+Two claimers may plan concurrently, but only the verified canonical
+fast-forward winner owns the assignment. A losing claimant stops.
+
+## Checkpoint
+
+Add a `checkpoint` object containing:
+
+- the current `fence` (`claim_id`, `worker_run_id`, `sequence`, and
+  `continuation_token`);
+- `phase`, `action`, and `proposed_effect_digest`;
+- `candidate_head` and `acknowledged_candidate_head`, including explicit nulls;
+- a new `next_continuation_token`;
+- `recorded_at`; and
+- `candidate`, explicitly null except for `candidate_published`.
+
+Each allowed transition increments the sequence by one, rotates the token, and
+appends one authorization. Denial does not advance the ledger. A
+`candidate_published` checkpoint must immediately follow the exact candidate
+push authorization and verifies the declared remote ref and head before
+recording the candidate.
+
+## Block, release, and takeover
+
+`block` and `release` require the complete current `fence`.
+
+- `block` adds stable `message_id` and `receipt_id` values, a subject, detail,
+  timestamp, and optional validation/review evidence. It retains the claim and
+  mutation ownership.
+- `release` adds a stable `receipt_id`, reason, timestamp, and optional evidence.
+  It relinquishes mutation ownership, clears the claim, and preserves an exact
+  transferable candidate when one exists.
+- `takeover` requires the exact `replaced_fence`, fresh claim and run
+  identifiers, a fresh continuation token, a stable `takeover_message_id`, a
+  reason, and timestamp. It records the rationale, resolves the current blocker
+  when present, starts an empty checkpoint ledger, and copies the prior
+  candidate exactly.
+
+Never invent a token after losing it, reuse a released claim or run identity,
+discard a candidate during takeover, combine release and reacquisition into one
+transition, or treat a local-only candidate as transferable.

--- a/skills/atelier/references/claiming.md
+++ b/skills/atelier/references/claiming.md
@@ -23,10 +23,11 @@ Before `claim`, `checkpoint`, or `takeover`:
 5. Supply the exact installed Agent Scripts skill root, stable name, connector
    identity, and complete read-only operation set required by the host descriptor.
 
-The script rereads approved and current policy, the canonical mailbox, the
-approved work transition, and the material ticket observation during every
-write attempt. It combines policy using the Project Policy Contract and fails
-closed on incompatible identity, eligibility, authority, or evidence drift.
+The script rechecks the pinned host capability and rereads approved and current
+policy, the canonical mailbox, the approved work transition, and the material
+ticket observation during every write attempt. It combines policy using the
+Project Policy Contract and fails closed on incompatible identity, eligibility,
+authority, capability, or evidence drift.
 
 ## Commands
 
@@ -130,9 +131,11 @@ recording the candidate.
   transferable candidate when one exists.
 - `takeover` requires the exact `replaced_fence`, fresh claim and run
   identifiers, a fresh continuation token, a stable `takeover_message_id`, a
-  reason, and timestamp. It records the rationale, resolves the current blocker
-  when present, starts an empty checkpoint ledger, and copies the prior
-  candidate exactly.
+  reason, and timestamp. It records the rationale, starts an empty checkpoint
+  ledger, and copies the prior candidate exactly. Blocked takeover preserves the
+  unresolved blocker and remains blocked. Delivered takeover clears only the
+  delivery pointer, retains the delivery as the current historical attempt, and
+  returns the transferred candidate to active work.
 
 Never invent a token after losing it, reuse a released claim or run identity,
 discard a candidate during takeover, combine release and reacquisition into one

--- a/skills/atelier/references/claiming.md
+++ b/skills/atelier/references/claiming.md
@@ -128,7 +128,9 @@ recording the candidate.
   mutation ownership.
 - `release` adds a stable `receipt_id`, reason, timestamp, and optional evidence.
   It relinquishes mutation ownership, clears the claim, and preserves an exact
-  transferable candidate when one exists.
+  transferable candidate when one exists. A blocked release retains the unanswered
+  decision message as historical audit evidence without treating it as a current
+  blocker or falsely resolving it.
 - `takeover` requires the exact `replaced_fence`, fresh claim and run
   identifiers, a fresh continuation token, a stable `takeover_message_id`, a
   reason, and timestamp. It records the rationale, starts an empty checkpoint

--- a/skills/atelier/references/claiming.md
+++ b/skills/atelier/references/claiming.md
@@ -23,10 +23,11 @@ Before `claim`, `checkpoint`, or `takeover`:
 5. Supply the exact installed Agent Scripts skill root, stable name, connector
    identity, and complete read-only operation set required by the host descriptor.
 
-The script rechecks the pinned host capability and rereads approved and current
-policy, the canonical mailbox, the approved work transition, and the material
-ticket observation during every write attempt. It combines policy using the
-Project Policy Contract and fails closed on incompatible identity, eligibility,
+The script binds the policy remote's canonical GitHub URL to the managed project
+repository identity, rechecks the pinned host capability, and rereads approved and
+current policy, the canonical mailbox, the approved work transition, and the
+material ticket observation during every write attempt. It combines policy using
+the Project Policy Contract and fails closed on incompatible identity, eligibility,
 authority, capability, or evidence drift.
 
 ## Commands
@@ -130,7 +131,8 @@ recording the candidate.
   It relinquishes mutation ownership, clears the claim, and preserves an exact
   transferable candidate when one exists. A blocked release retains the unanswered
   decision message as historical audit evidence without treating it as a current
-  blocker or falsely resolving it.
+  blocker or falsely resolving it. Historical blockers are derived from released
+  execution identities and explicit takeover handoffs, never global wall-clock order.
 - `takeover` requires the exact `replaced_fence`, fresh claim and run
   identifiers, a fresh continuation token, a stable `takeover_message_id`, a
   reason, and timestamp. It records the rationale, starts an empty checkpoint

--- a/skills/atelier/references/claiming.md
+++ b/skills/atelier/references/claiming.md
@@ -135,11 +135,13 @@ recording the candidate.
   execution identities and explicit takeover handoffs, never global wall-clock order.
 - `takeover` requires the exact `replaced_fence`, fresh claim and run
   identifiers, a fresh continuation token, a stable `takeover_message_id`, a
-  reason, and timestamp. It records the rationale, starts an empty checkpoint
-  ledger, and copies the prior candidate exactly. Blocked takeover preserves the
-  unresolved blocker and remains blocked. Delivered takeover clears only the
-  delivery pointer, retains the delivery as the current historical attempt, and
-  returns the transferred candidate to active work.
+  reason, and timestamp. Active takeover additionally requires a stable
+  `takeover_receipt_id`; it records the replaced active attempt as released and
+  relinquished so an inherited candidate has durable provenance while the new
+  checkpoint ledger starts empty. Blocked takeover preserves the unresolved
+  blocker and remains blocked. Delivered takeover clears only the delivery
+  pointer, retains the delivery as the current historical attempt, and returns
+  the transferred candidate to active work.
 
 Never invent a token after losing it, reuse a released claim or run identity,
 discard a candidate during takeover, combine release and reacquisition into one

--- a/skills/atelier/scripts/claiming.py
+++ b/skills/atelier/scripts/claiming.py
@@ -536,6 +536,7 @@ class ClaimCoordinator:
                 },
                 "candidate": copy.deepcopy(prior_claim["candidate"]),
             }
+            current_status = state.work["status"]
             current_blocker = state.work["blocking_message_id"]
             takeover_message = {
                 "schema": "atelier.message/v1",
@@ -546,7 +547,7 @@ class ClaimCoordinator:
                 "worker_run_id": None,
                 "audience": "worker",
                 "in_reply_to": current_blocker,
-                "resolves": current_blocker,
+                "resolves": None,
                 "blocks": None,
                 "created_at": _timestamp(taken_over_at),
                 "subject": "Claim taken over",
@@ -556,14 +557,15 @@ class ClaimCoordinator:
                 state=state,
                 claim=new_claim,
                 takeover_message=takeover_message,
+                status=current_status,
             )
 
         def plan(context: TransitionContext) -> TransitionPlan:
             state: _ExecutionState = planned["state"]
             work = copy.deepcopy(state.work)
-            work["status"] = "active"
+            work["status"] = planned["status"]
             work["claim"] = copy.deepcopy(planned["claim"])
-            work["blocking_message_id"] = None
+            work["blocking_message_id"] = state.work["blocking_message_id"]
             work["delivery_receipt_id"] = None
             work["acceptance"] = None
             changes = [
@@ -579,7 +581,7 @@ class ClaimCoordinator:
             )
 
         result = self.writer.publish("takeover", revalidate=revalidate, plan=plan)
-        return _claim_result(result, work_id, "active", planned["claim"])
+        return _claim_result(result, work_id, planned["status"], planned["claim"])
 
     def _execution_state(
         self,
@@ -902,11 +904,30 @@ def _candidate_remote_reachable(candidate: Mapping[str, Any]) -> bool:
         or SHA_PATTERN.fullmatch(head) is None
     ):
         return False
-    result = run_git(None, ("ls-remote", "--exit-code", remote_url, remote_ref))
-    if result.returncode != 0:
-        return False
-    rows = [line.split() for line in result.stdout.splitlines() if line.strip()]
-    return rows == [[head, remote_ref]]
+    with tempfile.TemporaryDirectory(prefix="atelier-candidate-reachability-") as temporary:
+        repository = Path(temporary) / "candidate.git"
+        initialized = run_git(None, ("init", "--bare", str(repository)))
+        if initialized.returncode != 0:
+            return False
+        fetched = run_git(
+            repository,
+            (
+                "fetch",
+                "--no-tags",
+                remote_url,
+                f"{remote_ref}:refs/atelier/candidate",
+            ),
+        )
+        if fetched.returncode != 0:
+            return False
+        exists = run_git(repository, ("cat-file", "-e", f"{head}^{{commit}}"))
+        if exists.returncode != 0:
+            return False
+        reachable = run_git(
+            repository,
+            ("merge-base", "--is-ancestor", head, "refs/atelier/candidate"),
+        )
+        return reachable.returncode == 0
 
 
 def _capability_compatible(target: HostTarget) -> bool:

--- a/skills/atelier/scripts/claiming.py
+++ b/skills/atelier/scripts/claiming.py
@@ -200,11 +200,10 @@ class ClaimCoordinator:
         _require_sha(approved_commit, "approved_commit")
         _require_token(continuation_token, "continuation_token")
         _require_timestamp(claimed_at, "claimed_at")
-        if not self.capability_verifier(host_target):
-            raise ClaimingError("required delegated implement-ticket capability is unavailable")
         planned: dict[str, Any] = {}
 
         def revalidate(context: TransitionContext) -> None:
+            self._verify_capability(host_target)
             state = self._execution_state(
                 context,
                 work_id,
@@ -283,6 +282,7 @@ class ClaimCoordinator:
         *,
         approved_commit: str,
         policy_target: PolicyTarget,
+        host_target: HostTarget,
         observation_path: Path,
         observation_not_before: datetime,
         now: datetime | None = None,
@@ -293,6 +293,7 @@ class ClaimCoordinator:
         planned: dict[str, Any] = {}
 
         def revalidate(context: TransitionContext) -> None:
+            self._verify_capability(host_target)
             state = self._execution_state(
                 context,
                 work_id,
@@ -498,11 +499,10 @@ class ClaimCoordinator:
         _require_token(continuation_token, "continuation_token")
         _require_text(reason, "reason")
         _require_timestamp(taken_over_at, "taken_over_at")
-        if not self.capability_verifier(host_target):
-            raise ClaimingError("required delegated implement-ticket capability is unavailable")
         planned: dict[str, Any] = {}
 
         def revalidate(context: TransitionContext) -> None:
+            self._verify_capability(host_target)
             state = self._execution_state(
                 context,
                 work_id,
@@ -537,6 +537,7 @@ class ClaimCoordinator:
                 "candidate": copy.deepcopy(prior_claim["candidate"]),
             }
             current_status = state.work["status"]
+            takeover_status = "active" if current_status == "delivered" else current_status
             current_blocker = state.work["blocking_message_id"]
             takeover_message = {
                 "schema": "atelier.message/v1",
@@ -557,7 +558,7 @@ class ClaimCoordinator:
                 state=state,
                 claim=new_claim,
                 takeover_message=takeover_message,
-                status=current_status,
+                status=takeover_status,
             )
 
         def plan(context: TransitionContext) -> TransitionPlan:
@@ -784,6 +785,12 @@ class ClaimCoordinator:
         )
         claim["checkpoint"]["sequence"] = next_sequence
         claim["checkpoint"]["continuation_token"] = request.next_continuation_token
+
+    def _verify_capability(self, target: HostTarget) -> None:
+        if not self.capability_verifier(target):
+            raise ClaimingError(
+                "required delegated implement-ticket capability is unavailable"
+            )
 
     def _verify_candidate(self, candidate: Mapping[str, Any] | None) -> None:
         if candidate is not None and not self.candidate_verifier(candidate):
@@ -1279,6 +1286,7 @@ def main() -> int:
                 ),
                 approved_commit=request["approved_commit"],
                 policy_target=policy,
+                host_target=_host_target(request["host"]),
                 observation_path=observation,
                 observation_not_before=not_before,
                 now=now,

--- a/skills/atelier/scripts/claiming.py
+++ b/skills/atelier/scripts/claiming.py
@@ -489,6 +489,7 @@ class ClaimCoordinator:
         worker_run_id: str,
         continuation_token: str,
         takeover_message_id: str,
+        takeover_receipt_id: str | None = None,
         reason: str,
         taken_over_at: datetime,
         approved_commit: str,
@@ -503,6 +504,8 @@ class ClaimCoordinator:
         _require_identifier(claim_id, "clm")
         _require_identifier(worker_run_id, "run")
         _require_identifier(takeover_message_id, "msg")
+        if takeover_receipt_id is not None:
+            _require_identifier(takeover_receipt_id, "rcp")
         _require_token(continuation_token, "continuation_token")
         _require_text(reason, "reason")
         _require_timestamp(taken_over_at, "taken_over_at")
@@ -545,6 +548,21 @@ class ClaimCoordinator:
             }
             current_status = state.work["status"]
             takeover_status = "active" if current_status == "delivered" else current_status
+            takeover_receipt = None
+            if current_status == "active":
+                if takeover_receipt_id is None:
+                    raise MailboxTransitionRejected(
+                        f"{work_id}: active takeover requires a stable receipt identity"
+                    )
+                takeover_receipt = _attempt_receipt(
+                    state.work,
+                    prior_claim,
+                    receipt_id=takeover_receipt_id,
+                    outcome="released",
+                    mutation_ownership="relinquished",
+                    ended_at=taken_over_at,
+                    evidence=AttemptEvidence(),
+                )
             current_blocker = state.work["blocking_message_id"]
             takeover_message = {
                 "schema": "atelier.message/v1",
@@ -565,6 +583,7 @@ class ClaimCoordinator:
                 state=state,
                 claim=new_claim,
                 takeover_message=takeover_message,
+                takeover_receipt=takeover_receipt,
                 status=takeover_status,
             )
 
@@ -583,6 +602,19 @@ class ClaimCoordinator:
                 ),
                 FileChange(_work_path(work_id), _render_document(work, state.body)),
             ]
+            if planned["takeover_receipt"] is not None:
+                work["attempt_receipt_id"] = takeover_receipt_id
+                changes = [
+                    FileChange(
+                        _receipt_path(work_id, takeover_receipt_id),
+                        _render_document(planned["takeover_receipt"], reason),
+                    ),
+                    FileChange(
+                        _message_path(work_id, takeover_message_id),
+                        _render_document(planned["takeover_message"], reason),
+                    ),
+                    FileChange(_work_path(work_id), _render_document(work, state.body)),
+                ]
             return TransitionPlan(
                 commit_message=f"take over {work_id}",
                 changes=tuple(changes),
@@ -1345,6 +1377,7 @@ def main() -> int:
                 worker_run_id=request["worker_run_id"],
                 continuation_token=request["continuation_token"],
                 takeover_message_id=request["takeover_message_id"],
+                takeover_receipt_id=request.get("takeover_receipt_id"),
                 reason=request["reason"],
                 taken_over_at=_parse_timestamp(request["taken_over_at"]),
                 approved_commit=request["approved_commit"],

--- a/skills/atelier/scripts/claiming.py
+++ b/skills/atelier/scripts/claiming.py
@@ -30,7 +30,11 @@ from skills.atelier.scripts.git_mailbox import (
 )
 from skills.atelier.scripts.host_boundary import HostBoundaryError, check_host
 from skills.atelier.scripts.identifiers import new_identifier
-from skills.atelier.scripts.mailbox import MailboxValidationError, validate_project_policy
+from skills.atelier.scripts.mailbox import (
+    MailboxValidationError,
+    _github_remote_url,
+    validate_project_policy,
+)
 from skills.atelier.scripts.planning import (
     PolicyTarget,
     _CurrentPolicy,
@@ -155,6 +159,7 @@ class _ExecutionState:
 
 CandidateVerifier = Callable[[Mapping[str, Any]], bool]
 CapabilityVerifier = Callable[[HostTarget], bool]
+PolicyRemoteVerifier = Callable[[PolicyTarget, str], bool]
 
 
 class ClaimCoordinator:
@@ -169,6 +174,7 @@ class ClaimCoordinator:
         writer: GitMailboxWriter | None = None,
         candidate_verifier: CandidateVerifier | None = None,
         capability_verifier: CapabilityVerifier | None = None,
+        policy_remote_verifier: PolicyRemoteVerifier | None = None,
     ):
         if not remote or remote.startswith("-"):
             raise ClaimingError("mailbox remote must be nonempty and must not begin with '-'")
@@ -177,6 +183,7 @@ class ClaimCoordinator:
         self.writer = writer or GitMailboxWriter(remote, branch, max_attempts=max_attempts)
         self.candidate_verifier = candidate_verifier or _candidate_remote_reachable
         self.capability_verifier = capability_verifier or _capability_compatible
+        self.policy_remote_verifier = policy_remote_verifier or _policy_remote_matches_repository
 
     def claim(
         self,
@@ -601,6 +608,10 @@ class ClaimCoordinator:
             raise MailboxTransitionRejected(f"{work_id}: work has no current approval")
         self._require_approved_commit(context, work_id, work, body, approved_commit)
         project = _read_project(context.checkout, work["project_id"])
+        if not self.policy_remote_verifier(policy_target, project["repository"]):
+            raise MailboxTransitionRejected(
+                "policy remote is foreign or unverifiable for the managed project"
+            )
         observation = _validated_observation(
             observation_path,
             not_before=observation_not_before,
@@ -896,6 +907,20 @@ def _read_policy_at_commit(target: PolicyTarget, commit: str) -> dict[str, Any]:
         policy_path.write_text(content, encoding="utf-8")
         return validate_project_policy(policy_path)
 
+
+def _policy_remote_matches_repository(target: PolicyTarget, repository: str) -> bool:
+    configured = run_git(
+        target.checkout,
+        ("remote", "get-url", "--all", target.remote),
+    )
+    if configured.returncode == 0:
+        urls = [line.strip() for line in configured.stdout.splitlines() if line.strip()]
+        if len(urls) != 1:
+            return False
+        remote_url = urls[0]
+    else:
+        remote_url = target.remote
+    return _github_remote_url(remote_url, repository=repository)
 
 def _candidate_remote_reachable(candidate: Mapping[str, Any]) -> bool:
     remote_url = candidate.get("remote_url")

--- a/skills/atelier/scripts/claiming.py
+++ b/skills/atelier/scripts/claiming.py
@@ -1,0 +1,1332 @@
+#!/usr/bin/env python3
+"""Claim Atelier work and persist claim-fenced checkpoint and handoff transitions."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import re
+import sys
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+if __package__ in {None, ""}:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from skills.atelier.scripts.git_mailbox import (
+    FileChange,
+    GitMailboxWriter,
+    MailboxTransitionRejected,
+    MailboxWriteError,
+    TransitionContext,
+    TransitionPlan,
+    WriteResult,
+    run_git,
+)
+from skills.atelier.scripts.host_boundary import HostBoundaryError, check_host
+from skills.atelier.scripts.identifiers import new_identifier
+from skills.atelier.scripts.mailbox import MailboxValidationError, validate_project_policy
+from skills.atelier.scripts.planning import (
+    PolicyTarget,
+    _CurrentPolicy,
+    _git_output,
+    _read_current_policy,
+    _read_document,
+    _read_project,
+    _render_document,
+    _require_git,
+    _require_work_ticket,
+    _ticket_material_digest,
+    _validated_observation,
+)
+
+AUTHORITY_ACTIONS = frozenset(
+    {
+        "repository.candidate.create",
+        "repository.candidate.push",
+        "pull_request.create",
+        "pull_request.update",
+        "review.reply",
+        "review.resolve",
+    }
+)
+CANDIDATE_REQUIRED_ACTIONS = frozenset(
+    {
+        "repository.candidate.push",
+        "pull_request.create",
+        "pull_request.update",
+        "review.reply",
+        "review.resolve",
+    }
+)
+ID_PATTERN = re.compile(
+    r"^(?P<prefix>clm|msg|rcp|run|wrk)_[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-"
+    r"[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+)
+SHA_PATTERN = re.compile(r"^[0-9a-f]{40}$")
+DIGEST_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+ACTIVE_STATES = frozenset({"active", "blocked", "delivered"})
+
+
+class ClaimingError(RuntimeError):
+    """A claim or checkpoint transition cannot be trusted or safely applied."""
+
+
+@dataclass(frozen=True)
+class ClaimFence:
+    """The exact current claim-ledger tail required by a worker transition."""
+
+    claim_id: str
+    worker_run_id: str
+    sequence: int
+    continuation_token: str
+
+
+@dataclass(frozen=True)
+class HostTarget:
+    """The exact installed capability and read-only connector boundary to prove."""
+
+    descriptor_path: Path
+    skill_name: str
+    skill_root: Path
+    connector: str
+    operations: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CheckpointRequest:
+    """One proposed delegated-execution checkpoint transition."""
+
+    fence: ClaimFence
+    phase: str
+    action: str
+    proposed_effect_digest: str
+    candidate_head: str | None
+    acknowledged_candidate_head: str | None
+    next_continuation_token: str
+    recorded_at: datetime
+    candidate: Mapping[str, Any] | None = None
+
+
+@dataclass(frozen=True)
+class AttemptEvidence:
+    """Evidence copied into one blocked, released, or takeover receipt."""
+
+    validation: tuple[Mapping[str, Any], ...] = ()
+    reviews: tuple[Mapping[str, Any], ...] = ()
+    unresolved_obligations: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ClaimResult:
+    """One verified canonical claim-coordination transition."""
+
+    operation: str
+    work_id: str
+    status: str
+    claim_id: str | None
+    worker_run_id: str | None
+    sequence: int | None
+    continuation_token: str | None
+    commit: str
+    base_revision: str
+    branch: str
+    attempts: int
+    recovered: bool
+
+
+@dataclass(frozen=True)
+class _ExecutionState:
+    work: dict[str, Any]
+    body: str
+    project: dict[str, Any]
+    approved_commit: str
+    approved_policy: dict[str, Any]
+    current_policy: _CurrentPolicy
+    effective_policy: dict[str, Any]
+    observation: dict[str, Any]
+    ticket_digest: str
+
+
+CandidateVerifier = Callable[[Mapping[str, Any]], bool]
+CapabilityVerifier = Callable[[HostTarget], bool]
+
+
+class ClaimCoordinator:
+    """Production claim and checkpoint transitions over one canonical Git mailbox."""
+
+    def __init__(
+        self,
+        remote: str,
+        branch: str,
+        *,
+        max_attempts: int = 3,
+        writer: GitMailboxWriter | None = None,
+        candidate_verifier: CandidateVerifier | None = None,
+        capability_verifier: CapabilityVerifier | None = None,
+    ):
+        if not remote or remote.startswith("-"):
+            raise ClaimingError("mailbox remote must be nonempty and must not begin with '-'")
+        self.remote = remote
+        self.branch = branch
+        self.writer = writer or GitMailboxWriter(remote, branch, max_attempts=max_attempts)
+        self.candidate_verifier = candidate_verifier or _candidate_remote_reachable
+        self.capability_verifier = capability_verifier or _capability_compatible
+
+    def claim(
+        self,
+        work_id: str,
+        *,
+        claim_id: str,
+        worker_run_id: str,
+        continuation_token: str,
+        approved_commit: str,
+        claimed_at: datetime,
+        policy_target: PolicyTarget,
+        host_target: HostTarget,
+        observation_path: Path,
+        observation_not_before: datetime,
+        now: datetime | None = None,
+    ) -> ClaimResult:
+        """Atomically claim one currently ready project-serial assignment."""
+        _require_identifier(work_id, "wrk")
+        _require_identifier(claim_id, "clm")
+        _require_identifier(worker_run_id, "run")
+        _require_sha(approved_commit, "approved_commit")
+        _require_token(continuation_token, "continuation_token")
+        _require_timestamp(claimed_at, "claimed_at")
+        if not self.capability_verifier(host_target):
+            raise ClaimingError("required delegated implement-ticket capability is unavailable")
+        planned: dict[str, Any] = {}
+
+        def revalidate(context: TransitionContext) -> None:
+            state = self._execution_state(
+                context,
+                work_id,
+                approved_commit=approved_commit,
+                policy_target=policy_target,
+                observation_path=observation_path,
+                observation_not_before=observation_not_before,
+                now=now,
+            )
+            work = state.work
+            if work["status"] != "approved" or work["claim"] is not None:
+                raise MailboxTransitionRejected(f"{work_id}: work is not unclaimed and approved")
+            status_by_work = {item["id"]: item["status"] for item in context.snapshot["work"]}
+            unresolved = [
+                dependency
+                for dependency in work["dependencies"]
+                if status_by_work.get(dependency) != "accepted"
+            ]
+            if unresolved:
+                raise MailboxTransitionRejected(
+                    f"{work_id}: dependencies are not accepted: {', '.join(unresolved)}"
+                )
+            active = [
+                item["id"]
+                for item in context.snapshot["work"]
+                if item["id"] != work_id
+                and item["project_id"] == work["project_id"]
+                and item["status"] in ACTIVE_STATES
+            ]
+            if active:
+                raise MailboxTransitionRejected(
+                    f"{work_id}: project already has active work: {', '.join(active)}"
+                )
+            candidate = self._released_candidate(context, work)
+            planned.clear()
+            planned.update(
+                state=state,
+                claim={
+                    "id": claim_id,
+                    "worker_run_id": worker_run_id,
+                    "work_revision": work["revision"],
+                    "approved_commit": approved_commit,
+                    "policy_commit": state.current_policy.commit,
+                    "ticket_observation_digest": state.ticket_digest,
+                    "claimed_at": _timestamp(claimed_at),
+                    "host": "codex",
+                    "checkpoint": {
+                        "sequence": 0,
+                        "continuation_token": continuation_token,
+                        "authorizations": [],
+                    },
+                    "candidate": candidate,
+                },
+            )
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            state: _ExecutionState = planned["state"]
+            work = copy.deepcopy(state.work)
+            work["status"] = "active"
+            work["claim"] = copy.deepcopy(planned["claim"])
+            work["blocking_message_id"] = None
+            work["delivery_receipt_id"] = None
+            work["acceptance"] = None
+            return TransitionPlan(
+                commit_message=f"claim {work_id}",
+                changes=(FileChange(_work_path(work_id), _render_document(work, state.body)),),
+            )
+
+        result = self.writer.publish("claim", revalidate=revalidate, plan=plan)
+        return _claim_result(result, work_id, "active", planned["claim"])
+
+    def authorize(
+        self,
+        work_id: str,
+        request: CheckpointRequest,
+        *,
+        approved_commit: str,
+        policy_target: PolicyTarget,
+        observation_path: Path,
+        observation_not_before: datetime,
+        now: datetime | None = None,
+    ) -> ClaimResult:
+        """Allow one exact external action or acknowledge one exact published candidate."""
+        _require_identifier(work_id, "wrk")
+        _validate_checkpoint_request(request)
+        planned: dict[str, Any] = {}
+
+        def revalidate(context: TransitionContext) -> None:
+            state = self._execution_state(
+                context,
+                work_id,
+                approved_commit=approved_commit,
+                policy_target=policy_target,
+                observation_path=observation_path,
+                observation_not_before=observation_not_before,
+                now=now,
+            )
+            if state.work["status"] != "active":
+                raise MailboxTransitionRejected(f"{work_id}: checkpoints require active work")
+            claim = _require_fence(state.work, request.fence)
+            if claim["approved_commit"] != approved_commit:
+                raise MailboxTransitionRejected(f"{work_id}: claim approved commit changed")
+            if claim["ticket_observation_digest"] != state.ticket_digest:
+                raise MailboxTransitionRejected(
+                    f"{work_id}: material ticket observation changed during the invocation"
+                )
+            effective_authority = set(state.effective_policy["authority"]["allow"])
+            approved_authority = set(state.work["approval"]["authority_ceiling"])
+            if request.action not in effective_authority & approved_authority:
+                raise MailboxTransitionRejected(
+                    f"{work_id}: action {request.action!r} exceeds effective authority"
+                )
+            updated_claim = copy.deepcopy(claim)
+            self._apply_checkpoint(updated_claim, request)
+            planned.clear()
+            planned.update(state=state, claim=updated_claim)
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            state: _ExecutionState = planned["state"]
+            work = copy.deepcopy(state.work)
+            work["claim"] = copy.deepcopy(planned["claim"])
+            return TransitionPlan(
+                commit_message=(
+                    f"record {request.phase} checkpoint {request.fence.sequence + 1} "
+                    f"for {work_id}"
+                ),
+                changes=(FileChange(_work_path(work_id), _render_document(work, state.body)),),
+            )
+
+        result = self.writer.publish("checkpoint", revalidate=revalidate, plan=plan)
+        return _claim_result(result, work_id, "active", planned["claim"])
+
+    def block(
+        self,
+        work_id: str,
+        fence: ClaimFence,
+        *,
+        message_id: str,
+        receipt_id: str,
+        subject: str,
+        detail: str,
+        created_at: datetime,
+        evidence: AttemptEvidence | None = None,
+    ) -> ClaimResult:
+        """Persist one exact worker blocker and retained attempt receipt."""
+        _require_identifier(work_id, "wrk")
+        _require_identifier(message_id, "msg")
+        _require_identifier(receipt_id, "rcp")
+        _require_text(subject, "subject")
+        _require_text(detail, "detail")
+        _require_timestamp(created_at, "created_at")
+        evidence = evidence or AttemptEvidence()
+        planned: dict[str, Any] = {}
+
+        def revalidate(context: TransitionContext) -> None:
+            work, body = _read_work(context.checkout, work_id)
+            if work["status"] != "active":
+                raise MailboxTransitionRejected(f"{work_id}: only active work can be blocked")
+            claim = _require_fence(work, fence)
+            self._verify_candidate(claim["candidate"])
+            receipt = _attempt_receipt(
+                work,
+                claim,
+                receipt_id=receipt_id,
+                outcome="blocked",
+                mutation_ownership="retained",
+                ended_at=created_at,
+                evidence=evidence,
+            )
+            message = {
+                "schema": "atelier.message/v1",
+                "id": message_id,
+                "work_id": work_id,
+                "kind": "needs-decision",
+                "author_role": "worker",
+                "worker_run_id": claim["worker_run_id"],
+                "audience": "planner",
+                "in_reply_to": None,
+                "resolves": None,
+                "blocks": "worker",
+                "created_at": _timestamp(created_at),
+                "subject": subject,
+            }
+            planned.clear()
+            planned.update(work=work, body=body, claim=claim, receipt=receipt, message=message)
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            work = copy.deepcopy(planned["work"])
+            work["status"] = "blocked"
+            work["blocking_message_id"] = message_id
+            work["attempt_receipt_id"] = receipt_id
+            return TransitionPlan(
+                commit_message=f"block {work_id}",
+                changes=(
+                    FileChange(
+                        _message_path(work_id, message_id),
+                        _render_document(planned["message"], detail),
+                    ),
+                    FileChange(
+                        _receipt_path(work_id, receipt_id),
+                        _render_document(planned["receipt"], detail),
+                    ),
+                    FileChange(_work_path(work_id), _render_document(work, planned["body"])),
+                ),
+            )
+
+        result = self.writer.publish("block", revalidate=revalidate, plan=plan)
+        return _claim_result(result, work_id, "blocked", planned["claim"])
+
+    def release(
+        self,
+        work_id: str,
+        fence: ClaimFence,
+        *,
+        receipt_id: str,
+        reason: str,
+        ended_at: datetime,
+        evidence: AttemptEvidence | None = None,
+    ) -> ClaimResult:
+        """Release one exact claim while preserving its authoritative handoff receipt."""
+        _require_identifier(work_id, "wrk")
+        _require_identifier(receipt_id, "rcp")
+        _require_text(reason, "reason")
+        _require_timestamp(ended_at, "ended_at")
+        evidence = evidence or AttemptEvidence()
+        planned: dict[str, Any] = {}
+
+        def revalidate(context: TransitionContext) -> None:
+            work, body = _read_work(context.checkout, work_id)
+            if work["status"] not in ACTIVE_STATES:
+                raise MailboxTransitionRejected(f"{work_id}: work has no releasable claim")
+            claim = _require_fence(work, fence)
+            self._verify_candidate(claim["candidate"])
+            receipt = _attempt_receipt(
+                work,
+                claim,
+                receipt_id=receipt_id,
+                outcome="released",
+                mutation_ownership="relinquished",
+                ended_at=ended_at,
+                evidence=evidence,
+            )
+            planned.clear()
+            planned.update(work=work, body=body, receipt=receipt)
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            work = copy.deepcopy(planned["work"])
+            work["status"] = "approved"
+            work["claim"] = None
+            work["blocking_message_id"] = None
+            work["attempt_receipt_id"] = receipt_id
+            work["delivery_receipt_id"] = None
+            work["acceptance"] = None
+            return TransitionPlan(
+                commit_message=f"release {work_id}",
+                changes=(
+                    FileChange(
+                        _receipt_path(work_id, receipt_id),
+                        _render_document(planned["receipt"], reason),
+                    ),
+                    FileChange(_work_path(work_id), _render_document(work, planned["body"])),
+                ),
+            )
+
+        result = self.writer.publish("release", revalidate=revalidate, plan=plan)
+        return _claim_result(result, work_id, "approved", None)
+
+    def takeover(
+        self,
+        work_id: str,
+        replaced_fence: ClaimFence,
+        *,
+        claim_id: str,
+        worker_run_id: str,
+        continuation_token: str,
+        takeover_message_id: str,
+        reason: str,
+        taken_over_at: datetime,
+        approved_commit: str,
+        policy_target: PolicyTarget,
+        host_target: HostTarget,
+        observation_path: Path,
+        observation_not_before: datetime,
+        now: datetime | None = None,
+    ) -> ClaimResult:
+        """Replace one exact current claim without discarding its candidate or history."""
+        _require_identifier(work_id, "wrk")
+        _require_identifier(claim_id, "clm")
+        _require_identifier(worker_run_id, "run")
+        _require_identifier(takeover_message_id, "msg")
+        _require_token(continuation_token, "continuation_token")
+        _require_text(reason, "reason")
+        _require_timestamp(taken_over_at, "taken_over_at")
+        if not self.capability_verifier(host_target):
+            raise ClaimingError("required delegated implement-ticket capability is unavailable")
+        planned: dict[str, Any] = {}
+
+        def revalidate(context: TransitionContext) -> None:
+            state = self._execution_state(
+                context,
+                work_id,
+                approved_commit=approved_commit,
+                policy_target=policy_target,
+                observation_path=observation_path,
+                observation_not_before=observation_not_before,
+                now=now,
+            )
+            if state.work["status"] not in ACTIVE_STATES:
+                raise MailboxTransitionRejected(f"{work_id}: work has no replaceable claim")
+            prior_claim = _require_fence(state.work, replaced_fence)
+            if prior_claim["id"] == claim_id or prior_claim["worker_run_id"] == worker_run_id:
+                raise MailboxTransitionRejected(
+                    f"{work_id}: takeover requires fresh claim identities"
+                )
+            self._verify_candidate(prior_claim["candidate"])
+            new_claim = {
+                "id": claim_id,
+                "worker_run_id": worker_run_id,
+                "work_revision": state.work["revision"],
+                "approved_commit": approved_commit,
+                "policy_commit": state.current_policy.commit,
+                "ticket_observation_digest": state.ticket_digest,
+                "claimed_at": _timestamp(taken_over_at),
+                "host": "codex",
+                "checkpoint": {
+                    "sequence": 0,
+                    "continuation_token": continuation_token,
+                    "authorizations": [],
+                },
+                "candidate": copy.deepcopy(prior_claim["candidate"]),
+            }
+            current_blocker = state.work["blocking_message_id"]
+            takeover_message = {
+                "schema": "atelier.message/v1",
+                "id": takeover_message_id,
+                "work_id": work_id,
+                "kind": "notification",
+                "author_role": "planner",
+                "worker_run_id": None,
+                "audience": "worker",
+                "in_reply_to": current_blocker,
+                "resolves": current_blocker,
+                "blocks": None,
+                "created_at": _timestamp(taken_over_at),
+                "subject": "Claim taken over",
+            }
+            planned.clear()
+            planned.update(
+                state=state,
+                claim=new_claim,
+                takeover_message=takeover_message,
+            )
+
+        def plan(context: TransitionContext) -> TransitionPlan:
+            state: _ExecutionState = planned["state"]
+            work = copy.deepcopy(state.work)
+            work["status"] = "active"
+            work["claim"] = copy.deepcopy(planned["claim"])
+            work["blocking_message_id"] = None
+            work["delivery_receipt_id"] = None
+            work["acceptance"] = None
+            changes = [
+                FileChange(
+                    _message_path(work_id, takeover_message_id),
+                    _render_document(planned["takeover_message"], reason),
+                ),
+                FileChange(_work_path(work_id), _render_document(work, state.body)),
+            ]
+            return TransitionPlan(
+                commit_message=f"take over {work_id}",
+                changes=tuple(changes),
+            )
+
+        result = self.writer.publish("takeover", revalidate=revalidate, plan=plan)
+        return _claim_result(result, work_id, "active", planned["claim"])
+
+    def _execution_state(
+        self,
+        context: TransitionContext,
+        work_id: str,
+        *,
+        approved_commit: str,
+        policy_target: PolicyTarget,
+        observation_path: Path,
+        observation_not_before: datetime,
+        now: datetime | None,
+    ) -> _ExecutionState:
+        work, body = _read_work(context.checkout, work_id)
+        approval = work["approval"]
+        if approval is None or approval["revision"] != work["revision"]:
+            raise MailboxTransitionRejected(f"{work_id}: work has no current approval")
+        self._require_approved_commit(context, work_id, work, body, approved_commit)
+        project = _read_project(context.checkout, work["project_id"])
+        observation = _validated_observation(
+            observation_path,
+            not_before=observation_not_before,
+            now=now,
+        )
+        _require_work_ticket(work, project, observation)
+        approved_policy = _read_policy_at_commit(policy_target, approval["policy"]["commit"])
+        current_policy = _read_current_policy(policy_target)
+        effective_policy = _effective_policy(approved_policy, current_policy.value)
+        _require_policy_identity(
+            effective_policy,
+            current_policy,
+            project=project,
+            work=work,
+            mailbox_remote=self.remote,
+            mailbox_branch=self.branch,
+            mailbox_realm=context.snapshot["realm_id"],
+            approval=approval,
+        )
+        issue = observation["issue"]
+        if issue["state"].lower() not in effective_policy["ticket"]["allowed_states"]:
+            raise MailboxTransitionRejected(f"ticket #{issue['number']} is not in an allowed state")
+        if effective_policy["ticket"]["require_no_blockers"]:
+            blockers = [item for item in issue["blocked_by"] if item["state"] != "CLOSED"]
+            if blockers:
+                numbers = ", ".join(f"#{item['number']}" for item in blockers)
+                raise MailboxTransitionRejected(
+                    f"ticket #{issue['number']} has unresolved blockers: {numbers}"
+                )
+        ticket_digest = _ticket_material_digest(issue, effective_policy)
+        return _ExecutionState(
+            work=work,
+            body=body,
+            project=project,
+            approved_commit=approved_commit,
+            approved_policy=approved_policy,
+            current_policy=current_policy,
+            effective_policy=effective_policy,
+            observation=observation,
+            ticket_digest=ticket_digest,
+        )
+
+    def _require_approved_commit(
+        self,
+        context: TransitionContext,
+        work_id: str,
+        work: Mapping[str, Any],
+        body: str,
+        approved_commit: str,
+    ) -> None:
+        _require_sha(approved_commit, "approved_commit")
+        with tempfile.TemporaryDirectory(prefix="atelier-approval-history-") as temporary:
+            history = Path(temporary) / "mailbox"
+            cloned = run_git(
+                None,
+                (
+                    "clone",
+                    "--no-checkout",
+                    "--branch",
+                    self.branch,
+                    self.remote,
+                    str(history),
+                ),
+            )
+            _require_git(cloned, "read canonical mailbox approval history")
+            ancestor = run_git(
+                history,
+                ("merge-base", "--is-ancestor", approved_commit, context.base_revision),
+            )
+            if ancestor.returncode != 0:
+                raise MailboxTransitionRejected(
+                    f"{work_id}: approved commit is not in canonical mailbox history"
+                )
+            approved_work, approved_body = _read_work_at(
+                history, approved_commit, _work_path(work_id)
+            )
+            if _approved_contract(approved_work, approved_body) != _approved_contract(work, body):
+                raise MailboxTransitionRejected(
+                    f"{work_id}: approved commit does not contain the current approved contract"
+                )
+            parent = run_git(history, ("rev-parse", f"{approved_commit}^"))
+            if parent.returncode == 0:
+                try:
+                    parent_work, parent_body = _read_work_at(
+                        history, parent.stdout.strip(), _work_path(work_id)
+                    )
+                except ClaimingError:
+                    pass
+                else:
+                    if _approved_contract(parent_work, parent_body) == _approved_contract(
+                        approved_work, approved_body
+                    ):
+                        raise MailboxTransitionRejected(
+                            f"{work_id}: supplied approved commit is not the approval transition"
+                        )
+
+    def _released_candidate(
+        self,
+        context: TransitionContext,
+        work: Mapping[str, Any],
+    ) -> dict[str, Any] | None:
+        receipt_id = work["attempt_receipt_id"]
+        if receipt_id is None:
+            return None
+        receipt, _ = _read_document(context.checkout / _receipt_path(work["id"], receipt_id))
+        if receipt["outcome"] != "released":
+            raise MailboxTransitionRejected(
+                f"{work['id']}: approved work attempt is not a released receipt"
+            )
+        candidate = receipt["candidate"] if receipt["handoff"] == "transferable" else None
+        self._verify_candidate(candidate)
+        return copy.deepcopy(candidate)
+
+    def _apply_checkpoint(
+        self,
+        claim: dict[str, Any],
+        request: CheckpointRequest,
+    ) -> None:
+        ledger = claim["checkpoint"]["authorizations"]
+        candidate = copy.deepcopy(request.candidate) if request.candidate is not None else None
+        if request.phase == "candidate_published":
+            if (
+                request.action != "repository.candidate.push"
+                or request.candidate_head is None
+                or request.acknowledged_candidate_head != request.candidate_head
+                or candidate is None
+                or candidate.get("head_revision") != request.candidate_head
+            ):
+                raise MailboxTransitionRejected(
+                    "candidate publication must acknowledge one exact repository candidate push"
+                )
+            if not ledger:
+                raise MailboxTransitionRejected(
+                    "candidate publication has no preceding push authorization"
+                )
+            prior = ledger[-1]
+            if (
+                prior["phase"] != "pre_external_mutation"
+                or prior["action"] != "repository.candidate.push"
+                or prior["candidate_head"] != request.candidate_head
+                or prior["proposed_effect_digest"] != request.proposed_effect_digest
+            ):
+                raise MailboxTransitionRejected(
+                    "candidate publication does not match the preceding push authorization"
+                )
+            self._verify_candidate(candidate)
+            claim["candidate"] = candidate
+        else:
+            if request.acknowledged_candidate_head is not None:
+                raise MailboxTransitionRejected(
+                    "pre-mutation checkpoint cannot acknowledge a candidate"
+                )
+            if request.action in CANDIDATE_REQUIRED_ACTIONS and request.candidate_head is None:
+                raise MailboxTransitionRejected(
+                    f"action {request.action!r} requires an exact candidate head"
+                )
+            current_head = (
+                claim["candidate"]["head_revision"] if claim["candidate"] is not None else None
+            )
+            if (
+                request.action in CANDIDATE_REQUIRED_ACTIONS
+                and request.action != "repository.candidate.push"
+                and request.candidate_head != current_head
+            ):
+                raise MailboxTransitionRejected(
+                    f"action {request.action!r} does not name the acknowledged candidate"
+                )
+            if current_head is not None:
+                self._verify_candidate(claim["candidate"])
+        next_sequence = request.fence.sequence + 1
+        ledger.append(
+            {
+                "sequence": next_sequence,
+                "invocation_id": request.fence.worker_run_id,
+                "phase": request.phase,
+                "action": request.action,
+                "proposed_effect_digest": request.proposed_effect_digest,
+                "candidate_head": request.candidate_head,
+                "acknowledged_candidate_head": request.acknowledged_candidate_head,
+                "recorded_at": _timestamp(request.recorded_at),
+            }
+        )
+        claim["checkpoint"]["sequence"] = next_sequence
+        claim["checkpoint"]["continuation_token"] = request.next_continuation_token
+
+    def _verify_candidate(self, candidate: Mapping[str, Any] | None) -> None:
+        if candidate is not None and not self.candidate_verifier(candidate):
+            raise MailboxTransitionRejected(
+                "candidate is not reachable at its exact declared remote ref and head"
+            )
+
+
+def _effective_policy(
+    approved: Mapping[str, Any],
+    current: Mapping[str, Any],
+) -> dict[str, Any]:
+    invariant_paths = (
+        ("schema",),
+        ("mailbox", "remote"),
+        ("mailbox", "realm_id"),
+        ("mailbox", "canonical_branch"),
+        ("mailbox", "project_id"),
+        ("repository", "identity"),
+        ("repository", "canonical_ref"),
+        ("ticket", "provider"),
+        ("execution", "capability"),
+        ("execution", "delivery_outcome"),
+        ("execution", "parallel_assignments"),
+        ("acceptance", "actor"),
+    )
+    for path in invariant_paths:
+        if _at(approved, path) != _at(current, path):
+            raise MailboxTransitionRejected(
+                f"approved and current policies are incompatible at {'.'.join(path)}"
+            )
+    effective = copy.deepcopy(current)
+    effective["authority"]["allow"] = _ordered_intersection(
+        approved["authority"]["allow"], current["authority"]["allow"]
+    )
+    effective["validation"]["required_commands"] = _ordered_union(
+        approved["validation"]["required_commands"], current["validation"]["required_commands"]
+    )
+    effective["acceptance"]["evidence"] = _ordered_union(
+        approved["acceptance"]["evidence"], current["acceptance"]["evidence"]
+    )
+    effective["ticket"]["allowed_states"] = _ordered_intersection(
+        approved["ticket"]["allowed_states"], current["ticket"]["allowed_states"]
+    )
+    effective["ticket"]["material_fields"] = _ordered_union(
+        approved["ticket"]["material_fields"], current["ticket"]["material_fields"]
+    )
+    effective["ticket"]["require_no_blockers"] = (
+        approved["ticket"]["require_no_blockers"]
+        or current["ticket"]["require_no_blockers"]
+    )
+    return effective
+
+
+def _require_policy_identity(
+    policy: Mapping[str, Any],
+    current: _CurrentPolicy,
+    *,
+    project: Mapping[str, Any],
+    work: Mapping[str, Any],
+    mailbox_remote: str,
+    mailbox_branch: str,
+    mailbox_realm: str,
+    approval: Mapping[str, Any],
+) -> None:
+    expected_repository = project["repository"]
+    if current.repository != expected_repository:
+        raise MailboxTransitionRejected("current policy repository does not match the project")
+    if project["policy"] != {"repository": current.repository, "path": current.path}:
+        raise MailboxTransitionRejected("project policy locator contradicts the current target")
+    if approval["policy"]["repository"] != current.repository:
+        raise MailboxTransitionRejected("approval policy repository does not match the project")
+    if approval["policy"]["path"] != current.path:
+        raise MailboxTransitionRejected("approval policy path does not match the current target")
+    if policy["mailbox"] != {
+        "remote": mailbox_remote,
+        "realm_id": mailbox_realm,
+        "canonical_branch": mailbox_branch,
+        "project_id": work["project_id"],
+    }:
+        raise MailboxTransitionRejected("project policy mailbox identity is incompatible")
+    if policy["repository"]["identity"] != expected_repository:
+        raise MailboxTransitionRejected("project policy repository identity is incompatible")
+    if policy["execution"] != {
+        "capability": "agent-scripts.implement-ticket/delegated-execution/v1",
+        "delivery_outcome": "ready_pr",
+        "parallel_assignments": False,
+    }:
+        raise MailboxTransitionRejected("project policy execution boundary is unsupported")
+
+
+def _read_policy_at_commit(target: PolicyTarget, commit: str) -> dict[str, Any]:
+    _require_sha(commit, "approved policy commit")
+    fetched = run_git(target.checkout, ("fetch", "--no-tags", target.remote, commit))
+    _require_git(fetched, "fetch approved project-policy commit")
+    content = _git_output(
+        target.checkout,
+        ("show", f"{commit}:{target.path}"),
+        "read approved project policy",
+    )
+    with tempfile.TemporaryDirectory(prefix="atelier-approved-policy-") as temporary:
+        policy_path = Path(temporary) / "policy.yaml"
+        policy_path.write_text(content, encoding="utf-8")
+        return validate_project_policy(policy_path)
+
+
+def _candidate_remote_reachable(candidate: Mapping[str, Any]) -> bool:
+    remote_url = candidate.get("remote_url")
+    remote_ref = candidate.get("remote_ref")
+    head = candidate.get("head_revision")
+    if (
+        not isinstance(remote_url, str)
+        or not remote_url
+        or remote_url.startswith("-")
+        or not isinstance(remote_ref, str)
+        or not remote_ref.startswith("refs/heads/")
+        or not isinstance(head, str)
+        or SHA_PATTERN.fullmatch(head) is None
+    ):
+        return False
+    result = run_git(None, ("ls-remote", "--exit-code", remote_url, remote_ref))
+    if result.returncode != 0:
+        return False
+    rows = [line.split() for line in result.stdout.splitlines() if line.strip()]
+    return rows == [[head, remote_ref]]
+
+
+def _capability_compatible(target: HostTarget) -> bool:
+    try:
+        result = check_host(
+            descriptor_path=target.descriptor_path,
+            skill_name=target.skill_name,
+            skill_root=target.skill_root,
+            connector=target.connector,
+            operations=list(target.operations),
+        )
+    except HostBoundaryError:
+        return False
+    return (
+        result["status"] == "compatible"
+        and result["delegated_capability"]
+        == "agent-scripts.implement-ticket/delegated-execution/v1"
+    )
+
+
+def _require_fence(work: Mapping[str, Any], fence: ClaimFence) -> dict[str, Any]:
+    _require_identifier(fence.claim_id, "clm")
+    _require_identifier(fence.worker_run_id, "run")
+    if type(fence.sequence) is not int or fence.sequence < 0:
+        raise ClaimingError("claim fence sequence must be a nonnegative integer")
+    _require_token(fence.continuation_token, "claim fence continuation_token")
+    claim = work["claim"]
+    if claim is None:
+        raise MailboxTransitionRejected(f"{work['id']}: no current claim")
+    checkpoint = claim["checkpoint"]
+    expected = (
+        claim["id"],
+        claim["worker_run_id"],
+        checkpoint["sequence"],
+        checkpoint["continuation_token"],
+    )
+    supplied = (
+        fence.claim_id,
+        fence.worker_run_id,
+        fence.sequence,
+        fence.continuation_token,
+    )
+    if supplied != expected:
+        raise MailboxTransitionRejected(f"{work['id']}: stale or foreign claim fence")
+    return copy.deepcopy(claim)
+
+
+def _validate_checkpoint_request(request: CheckpointRequest) -> None:
+    if request.phase not in {"pre_external_mutation", "candidate_published"}:
+        raise ClaimingError(f"unsupported checkpoint phase {request.phase!r}")
+    if request.action not in AUTHORITY_ACTIONS:
+        raise ClaimingError(f"unsupported checkpoint action {request.action!r}")
+    if (
+        not isinstance(request.proposed_effect_digest, str)
+        or DIGEST_PATTERN.fullmatch(request.proposed_effect_digest) is None
+    ):
+        raise ClaimingError("proposed_effect_digest must be a lowercase SHA-256 digest")
+    for label, value in (
+        ("candidate_head", request.candidate_head),
+        ("acknowledged_candidate_head", request.acknowledged_candidate_head),
+    ):
+        if value is not None:
+            _require_sha(value, label)
+    _require_token(request.next_continuation_token, "next_continuation_token")
+    if request.next_continuation_token == request.fence.continuation_token:
+        raise ClaimingError("next continuation token must rotate")
+    _require_timestamp(request.recorded_at, "recorded_at")
+
+
+def _attempt_receipt(
+    work: Mapping[str, Any],
+    claim: Mapping[str, Any],
+    *,
+    receipt_id: str,
+    outcome: str,
+    mutation_ownership: str,
+    ended_at: datetime,
+    evidence: AttemptEvidence,
+) -> dict[str, Any]:
+    candidate = copy.deepcopy(claim["candidate"])
+    return {
+        "schema": "atelier.receipt/v1",
+        "id": receipt_id,
+        "work_id": work["id"],
+        "outcome": outcome,
+        "approved_revision": work["revision"],
+        "approved_commit": claim["approved_commit"],
+        "policy_commit": claim["policy_commit"],
+        "claim_id": claim["id"],
+        "worker_run_id": claim["worker_run_id"],
+        "candidate": candidate,
+        "handoff": "transferable" if candidate is not None else "none",
+        "native_ticket": {
+            "provider": work["native_ticket"]["provider"],
+            "id": work["native_ticket"]["id"],
+        },
+        "validation": [copy.deepcopy(dict(item)) for item in evidence.validation],
+        "reviews": [copy.deepcopy(dict(item)) for item in evidence.reviews],
+        "unresolved_obligations": list(evidence.unresolved_obligations),
+        "mutation_ownership": mutation_ownership,
+        "ended_at": _timestamp(ended_at),
+    }
+
+
+def _approved_contract(work: Mapping[str, Any], body: str) -> tuple[Any, ...]:
+    return (
+        work["schema"],
+        work["id"],
+        work["title"],
+        work["project_id"],
+        work["initiative_id"],
+        work["revision"],
+        tuple(work["dependencies"]),
+        tuple(work["replaces"]),
+        copy.deepcopy(work["native_ticket"]),
+        copy.deepcopy(work["approval"]),
+        body,
+    )
+
+
+def _read_work(root: Path, work_id: str) -> tuple[dict[str, Any], str]:
+    path = root / _work_path(work_id)
+    work, body = _read_document(path)
+    if work["id"] != work_id:
+        raise ClaimingError(f"{work_id}: work document identity mismatch")
+    return work, body
+
+
+def _read_work_at(root: Path, revision: str, path: str) -> tuple[dict[str, Any], str]:
+    result = run_git(root, ("show", f"{revision}:{path}"))
+    if result.returncode != 0:
+        raise ClaimingError(f"{path}@{revision}: approved work is unreadable")
+    with tempfile.TemporaryDirectory(prefix="atelier-approved-work-") as temporary:
+        document_path = Path(temporary) / "work.md"
+        document_path.write_text(result.stdout, encoding="utf-8")
+        return _read_document(document_path)
+
+
+def _claim_result(
+    result: WriteResult,
+    work_id: str,
+    status: str,
+    claim: Mapping[str, Any] | None,
+) -> ClaimResult:
+    checkpoint = claim["checkpoint"] if claim is not None else None
+    return ClaimResult(
+        operation=result.operation,
+        work_id=work_id,
+        status=status,
+        claim_id=claim["id"] if claim is not None else None,
+        worker_run_id=claim["worker_run_id"] if claim is not None else None,
+        sequence=checkpoint["sequence"] if checkpoint is not None else None,
+        continuation_token=checkpoint["continuation_token"] if checkpoint is not None else None,
+        commit=result.commit,
+        base_revision=result.base_revision,
+        branch=result.branch,
+        attempts=result.attempts,
+        recovered=result.recovered,
+    )
+
+
+def _at(value: Mapping[str, Any], path: Sequence[str]) -> Any:
+    current: Any = value
+    for part in path:
+        current = current[part]
+    return current
+
+
+def _ordered_union(first: Sequence[str], second: Sequence[str]) -> list[str]:
+    return list(dict.fromkeys((*first, *second)))
+
+
+def _ordered_intersection(first: Sequence[str], second: Sequence[str]) -> list[str]:
+    allowed = set(second)
+    return [item for item in first if item in allowed]
+
+
+def _require_identifier(value: str, prefix: str) -> None:
+    if not isinstance(value, str):
+        raise ClaimingError(f"{prefix} identifier must be a string")
+    match = ID_PATTERN.fullmatch(value)
+    if match is None or match.group("prefix") != prefix:
+        raise ClaimingError(f"invalid {prefix} identifier: {value!r}")
+
+
+def _require_sha(value: str, label: str) -> None:
+    if not isinstance(value, str) or SHA_PATTERN.fullmatch(value) is None:
+        raise ClaimingError(f"{label} must be a lowercase 40-character Git SHA")
+
+
+def _require_token(value: str, label: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ClaimingError(f"{label} must be nonempty")
+
+
+def _require_text(value: str, label: str) -> None:
+    if not isinstance(value, str) or not value.strip():
+        raise ClaimingError(f"{label} must be nonempty")
+
+
+def _require_timestamp(value: datetime, label: str) -> None:
+    if not isinstance(value, datetime) or value.utcoffset() is None:
+        raise ClaimingError(f"{label} must be a timezone-aware datetime")
+
+
+def _timestamp(value: datetime) -> str:
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _work_path(work_id: str) -> str:
+    return f"work/{work_id}/work.md"
+
+
+def _message_path(work_id: str, message_id: str) -> str:
+    return f"work/{work_id}/messages/{message_id}.md"
+
+
+def _receipt_path(work_id: str, receipt_id: str) -> str:
+    return f"work/{work_id}/receipts/{receipt_id}.md"
+
+
+def _read_request(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ClaimingError(f"request is unreadable: {error}") from error
+    if not isinstance(value, dict):
+        raise ClaimingError("request must be a JSON object")
+    return value
+
+
+def _coordinator(value: Mapping[str, Any]) -> ClaimCoordinator:
+    mailbox = value["mailbox"]
+    return ClaimCoordinator(
+        mailbox["remote"],
+        mailbox["canonical_branch"],
+        max_attempts=mailbox.get("max_attempts", 3),
+    )
+
+
+def _policy_target(value: Mapping[str, Any]) -> PolicyTarget:
+    return PolicyTarget(
+        checkout=Path(value["checkout"]),
+        remote=value["remote"],
+        canonical_ref=value["canonical_ref"],
+        path=value["path"],
+    )
+
+
+def _host_target(value: Mapping[str, Any]) -> HostTarget:
+    return HostTarget(
+        descriptor_path=Path(value["descriptor_path"]),
+        skill_name=value["skill_name"],
+        skill_root=Path(value["skill_root"]),
+        connector=value["connector"],
+        operations=tuple(value["operations"]),
+    )
+
+
+def _fence(value: Mapping[str, Any]) -> ClaimFence:
+    return ClaimFence(
+        claim_id=value["claim_id"],
+        worker_run_id=value["worker_run_id"],
+        sequence=value["sequence"],
+        continuation_token=value["continuation_token"],
+    )
+
+
+def _evidence(value: Mapping[str, Any] | None) -> AttemptEvidence:
+    supplied = value or {}
+    return AttemptEvidence(
+        validation=tuple(supplied.get("validation", ())),
+        reviews=tuple(supplied.get("reviews", ())),
+        unresolved_obligations=tuple(supplied.get("unresolved_obligations", ())),
+    )
+
+
+def _parse_timestamp(value: str) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (AttributeError, ValueError) as error:
+        raise ClaimingError("timestamp must be an ISO 8601 date-time") from error
+    _require_timestamp(parsed, "timestamp")
+    return parsed
+
+
+def _execution_arguments(
+    request: Mapping[str, Any],
+) -> tuple[PolicyTarget, Path, datetime, datetime | None]:
+    observation = request["observation"]
+    now = _parse_timestamp(request["now"]) if request.get("now") is not None else None
+    return (
+        _policy_target(request["policy"]),
+        Path(observation["path"]),
+        _parse_timestamp(observation["not_before"]),
+        now,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    identifier = commands.add_parser("new-id", help="generate a strict Atelier identifier")
+    identifier.add_argument("prefix", choices=("clm", "msg", "rcp", "run"))
+    for name in ("claim", "checkpoint", "block", "release", "takeover"):
+        command = commands.add_parser(name)
+        command.add_argument("request", type=Path)
+    return parser
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    if args.command == "new-id":
+        print(new_identifier(args.prefix))
+        return 0
+    try:
+        request = _read_request(args.request)
+        coordinator = _coordinator(request)
+        if args.command == "claim":
+            policy, observation, not_before, now = _execution_arguments(request)
+            result = coordinator.claim(
+                request["work_id"],
+                claim_id=request["claim_id"],
+                worker_run_id=request["worker_run_id"],
+                continuation_token=request["continuation_token"],
+                approved_commit=request["approved_commit"],
+                claimed_at=_parse_timestamp(request["claimed_at"]),
+                policy_target=policy,
+                host_target=_host_target(request["host"]),
+                observation_path=observation,
+                observation_not_before=not_before,
+                now=now,
+            )
+        elif args.command == "checkpoint":
+            policy, observation, not_before, now = _execution_arguments(request)
+            checkpoint = request["checkpoint"]
+            result = coordinator.authorize(
+                request["work_id"],
+                CheckpointRequest(
+                    fence=_fence(checkpoint["fence"]),
+                    phase=checkpoint["phase"],
+                    action=checkpoint["action"],
+                    proposed_effect_digest=checkpoint["proposed_effect_digest"],
+                    candidate_head=checkpoint["candidate_head"],
+                    acknowledged_candidate_head=checkpoint["acknowledged_candidate_head"],
+                    next_continuation_token=checkpoint["next_continuation_token"],
+                    recorded_at=_parse_timestamp(checkpoint["recorded_at"]),
+                    candidate=checkpoint["candidate"],
+                ),
+                approved_commit=request["approved_commit"],
+                policy_target=policy,
+                observation_path=observation,
+                observation_not_before=not_before,
+                now=now,
+            )
+        elif args.command == "block":
+            result = coordinator.block(
+                request["work_id"],
+                _fence(request["fence"]),
+                message_id=request["message_id"],
+                receipt_id=request["receipt_id"],
+                subject=request["subject"],
+                detail=request["detail"],
+                created_at=_parse_timestamp(request["created_at"]),
+                evidence=_evidence(request.get("evidence")),
+            )
+        elif args.command == "release":
+            result = coordinator.release(
+                request["work_id"],
+                _fence(request["fence"]),
+                receipt_id=request["receipt_id"],
+                reason=request["reason"],
+                ended_at=_parse_timestamp(request["ended_at"]),
+                evidence=_evidence(request.get("evidence")),
+            )
+        else:
+            policy, observation, not_before, now = _execution_arguments(request)
+            result = coordinator.takeover(
+                request["work_id"],
+                _fence(request["replaced_fence"]),
+                claim_id=request["claim_id"],
+                worker_run_id=request["worker_run_id"],
+                continuation_token=request["continuation_token"],
+                takeover_message_id=request["takeover_message_id"],
+                reason=request["reason"],
+                taken_over_at=_parse_timestamp(request["taken_over_at"]),
+                approved_commit=request["approved_commit"],
+                policy_target=policy,
+                host_target=_host_target(request["host"]),
+                observation_path=observation,
+                observation_not_before=not_before,
+                now=now,
+            )
+        print(json.dumps(asdict(result), indent=2, sort_keys=True))
+        return 0
+    except (
+        KeyError,
+        TypeError,
+        ValueError,
+        ClaimingError,
+        MailboxTransitionRejected,
+        MailboxWriteError,
+        MailboxValidationError,
+    ) as error:
+        print(f"claiming failed: {error}", file=sys.stderr)
+        return 1
+
+
+__all__ = [
+    "AttemptEvidence",
+    "CheckpointRequest",
+    "ClaimCoordinator",
+    "ClaimFence",
+    "ClaimResult",
+    "ClaimingError",
+    "HostTarget",
+    "PolicyTarget",
+    "new_identifier",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/atelier/scripts/git_mailbox.py
+++ b/skills/atelier/scripts/git_mailbox.py
@@ -538,6 +538,27 @@ class GitMailboxWriter:
                     )
                 self._verify_new_claim(checkout, path, current_claim)
                 work_id = PurePosixPath(path).parts[1]
+                takeover_times: set[str] = set()
+                for change in changes:
+                    message_path = PurePosixPath(change.path)
+                    if (
+                        change.content is None
+                        or len(message_path.parts) != 4
+                        or message_path.parts[:3] != ("work", work_id, "messages")
+                    ):
+                        continue
+                    message, _ = _read_yaml(
+                        checkout / change.path,
+                        frontmatter=True,
+                        label=change.path,
+                    )
+                    if (
+                        message["kind"] == "notification"
+                        and message["author_role"] == "planner"
+                        and message["worker_run_id"] is None
+                        and message["subject"] == "Claim taken over"
+                    ):
+                        takeover_times.add(message["created_at"])
                 for change in changes:
                     receipt_path = PurePosixPath(change.path)
                     if (
@@ -554,6 +575,13 @@ class GitMailboxWriter:
                     if (
                         receipt["outcome"] == "released"
                         and receipt["claim_id"] == prior_claim["id"]
+                        and not (
+                            document["attempt_receipt_id"] == receipt["id"]
+                            and receipt["worker_run_id"] == prior_claim["worker_run_id"]
+                            and receipt["candidate"] == prior_claim["candidate"]
+                            and receipt["mutation_ownership"] == "relinquished"
+                            and receipt["ended_at"] in takeover_times
+                        )
                     ):
                         raise MailboxTransitionRejected(
                             f"{path}: release and new claim require distinct transitions"

--- a/skills/atelier/scripts/identifiers.py
+++ b/skills/atelier/scripts/identifiers.py
@@ -1,0 +1,32 @@
+"""Generate strict UUIDv7 identifiers for Atelier mailbox documents."""
+
+from __future__ import annotations
+
+import secrets
+import time
+
+SUPPORTED_PREFIXES = frozenset({"clm", "ini", "msg", "prj", "rcp", "run", "wrk"})
+
+
+def new_identifier(prefix: str) -> str:
+    """Return one lowercase UUIDv7 identifier with an Atelier prefix."""
+    if prefix not in SUPPORTED_PREFIXES:
+        supported = ", ".join(sorted(SUPPORTED_PREFIXES))
+        raise ValueError(
+            f"unsupported Atelier identifier prefix {prefix!r}; expected one of {supported}"
+        )
+    milliseconds = int(time.time() * 1000)
+    if milliseconds >= 1 << 48:
+        raise ValueError("current time exceeds the UUIDv7 timestamp range")
+    random_bits = secrets.randbits(74)
+    value = milliseconds << 80
+    value |= 0x7 << 76
+    value |= ((random_bits >> 62) & 0xFFF) << 64
+    value |= 0b10 << 62
+    value |= random_bits & ((1 << 62) - 1)
+    hexadecimal = f"{value:032x}"
+    uuid = (
+        f"{hexadecimal[:8]}-{hexadecimal[8:12]}-{hexadecimal[12:16]}-"
+        f"{hexadecimal[16:20]}-{hexadecimal[20:]}"
+    )
+    return f"{prefix}_{uuid}"

--- a/skills/atelier/scripts/mailbox.py
+++ b/skills/atelier/scripts/mailbox.py
@@ -1244,21 +1244,32 @@ def _validate_lifecycle(
                         "decision resolutions require a planner or operator",
                     )
                 )
-    released_cutoffs = [
-        datetime.fromisoformat(receipt["ended_at"].replace("Z", "+00:00"))
+    released_worker_runs = {
+        receipt["worker_run_id"]
         for receipt in work_receipts.values()
         if receipt["outcome"] == "released"
-    ]
-    latest_release = max(released_cutoffs, default=None)
+    }
+    handed_off_blockers = {
+        message["in_reply_to"]
+        for message in work_messages.values()
+        if message["kind"] == "notification"
+        and message["author_role"] == "planner"
+        and message["in_reply_to"] is not None
+        and message["resolves"] is None
+    }
+    current_worker_run = claim["worker_run_id"] if claim is not None else None
     unresolved_worker_blockers = sorted(
         message_id
         for message_id, message in work_messages.items()
         if message["blocks"] == "worker"
         and message_id not in resolutions
         and (
-            latest_release is None
-            or datetime.fromisoformat(message["created_at"].replace("Z", "+00:00"))
-            > latest_release
+            message_id == blocker
+            or message["worker_run_id"] == current_worker_run
+            or (
+                message["worker_run_id"] not in released_worker_runs
+                and not (released_worker_runs and message_id in handed_off_blockers)
+            )
         )
     )
     expected_worker_blockers = [blocker] if blocker is not None else []

--- a/skills/atelier/scripts/mailbox.py
+++ b/skills/atelier/scripts/mailbox.py
@@ -1072,6 +1072,27 @@ def _validate_lifecycle(
     delivery = work["delivery_receipt_id"]
     acceptance = work["acceptance"]
     status = work["status"]
+    blocker_message = work_messages.get(blocker) if blocker is not None else None
+    blocked_handoff = (
+        status == "blocked"
+        and claim is not None
+        and blocker_message is not None
+        and attempt_receipt is not None
+        and attempt_receipt["outcome"] == "blocked"
+        and attempt_receipt["mutation_ownership"] == "retained"
+        and attempt_receipt["claim_id"] != claim["id"]
+        and attempt_receipt["worker_run_id"] != claim["worker_run_id"]
+        and attempt_receipt["candidate"] == claim["candidate"]
+        and blocker_message["author_role"] == "worker"
+        and blocker_message["worker_run_id"] == attempt_receipt["worker_run_id"]
+        and any(
+            message["kind"] == "notification"
+            and message["author_role"] == "planner"
+            and message["in_reply_to"] == blocker
+            and message["resolves"] is None
+            for message in work_messages.values()
+        )
+    )
     diagnostics: list[Diagnostic] = []
 
     valid = {
@@ -1249,16 +1270,20 @@ def _validate_lifecycle(
             diagnostics.append(
                 Diagnostic(path, "blocking-message", "current blocker is missing or resolved")
             )
-        if message is not None and (
-            claim is None
-            or message["author_role"] != "worker"
-            or message["worker_run_id"] != claim["worker_run_id"]
+        if message is not None and not (
+            claim is not None
+            and message["author_role"] == "worker"
+            and (
+                message["worker_run_id"] == claim["worker_run_id"]
+                or blocked_handoff
+            )
         ):
             diagnostics.append(
                 Diagnostic(
                     path,
                     "blocker-actor",
-                    "current blocker must be authored by the claiming worker",
+                    "current blocker must belong to the current claim or "
+                    "a preserved takeover handoff",
                 )
             )
 
@@ -1302,12 +1327,19 @@ def _validate_lifecycle(
                     "blocked work requires a blocked attempt receipt with retained ownership",
                 )
             )
-        if claim is not None and status in {"blocked", "delivered"} and (
-            attempt_receipt is None
-            or attempt_receipt["claim_id"] != claim["id"]
-            or attempt_receipt["worker_run_id"] != claim["worker_run_id"]
-            or attempt_receipt["approved_commit"] != claim["approved_commit"]
-            or attempt_receipt["policy_commit"] != claim["policy_commit"]
+        attempt_matches_claim = (
+            claim is not None
+            and attempt_receipt is not None
+            and attempt_receipt["claim_id"] == claim["id"]
+            and attempt_receipt["worker_run_id"] == claim["worker_run_id"]
+            and attempt_receipt["approved_commit"] == claim["approved_commit"]
+            and attempt_receipt["policy_commit"] == claim["policy_commit"]
+        )
+        if (
+            claim is not None
+            and status in {"blocked", "delivered"}
+            and not attempt_matches_claim
+            and not blocked_handoff
         ):
             diagnostics.append(
                 Diagnostic(path, "attempt-identity", "attempt receipt contradicts the claim")

--- a/skills/atelier/scripts/mailbox.py
+++ b/skills/atelier/scripts/mailbox.py
@@ -1244,10 +1244,22 @@ def _validate_lifecycle(
                         "decision resolutions require a planner or operator",
                     )
                 )
+    released_cutoffs = [
+        datetime.fromisoformat(receipt["ended_at"].replace("Z", "+00:00"))
+        for receipt in work_receipts.values()
+        if receipt["outcome"] == "released"
+    ]
+    latest_release = max(released_cutoffs, default=None)
     unresolved_worker_blockers = sorted(
         message_id
         for message_id, message in work_messages.items()
-        if message["blocks"] == "worker" and message_id not in resolutions
+        if message["blocks"] == "worker"
+        and message_id not in resolutions
+        and (
+            latest_release is None
+            or datetime.fromisoformat(message["created_at"].replace("Z", "+00:00"))
+            > latest_release
+        )
     )
     expected_worker_blockers = [blocker] if blocker is not None else []
     if unresolved_worker_blockers != expected_worker_blockers:

--- a/skills/atelier/scripts/planning.py
+++ b/skills/atelier/scripts/planning.py
@@ -7,10 +7,8 @@ import argparse
 import hashlib
 import json
 import re
-import secrets
 import sys
 import tempfile
-import time
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, fields, replace
 from datetime import UTC, datetime
@@ -33,6 +31,7 @@ from skills.atelier.scripts.git_mailbox import (
     run_git,
 )
 from skills.atelier.scripts.host_boundary import HostBoundaryError, validate_observation
+from skills.atelier.scripts.identifiers import new_identifier as _new_identifier
 from skills.atelier.scripts.mailbox import (
     MailboxValidationError,
     _read_yaml,
@@ -206,21 +205,10 @@ def new_identifier(prefix: str) -> str:
 
     if prefix not in {"ini", "wrk"}:
         raise PlanningError("planning identifiers support only ini and wrk prefixes")
-    milliseconds = int(time.time() * 1000)
-    if milliseconds >= 1 << 48:
-        raise PlanningError("current time exceeds the UUIDv7 timestamp range")
-    random_bits = secrets.randbits(74)
-    value = milliseconds << 80
-    value |= 0x7 << 76
-    value |= ((random_bits >> 62) & 0xFFF) << 64
-    value |= 0b10 << 62
-    value |= random_bits & ((1 << 62) - 1)
-    hexadecimal = f"{value:032x}"
-    uuid = (
-        f"{hexadecimal[:8]}-{hexadecimal[8:12]}-{hexadecimal[12:16]}-"
-        f"{hexadecimal[16:20]}-{hexadecimal[20:]}"
-    )
-    return f"{prefix}_{uuid}"
+    try:
+        return _new_identifier(prefix)
+    except ValueError as error:
+        raise PlanningError(str(error)) from error
 
 
 class Planner:


### PR DESCRIPTION
## TL;DR

Implements durable, Git-backed assignment claiming with exact fencing, checkpoint ledgers, and recoverable handoffs for Atelier work.

## Summary

- Derives eligible project-serial work from current mailbox documents and verified native observations, then acquires claims through fast-forward compare-and-swap writes.
- Binds every claim and consequential transition to the exact approved revision, policy commit, ticket observation, worker identity, candidate, sequence, and authority allowance.
- Adds hash-bound checkpoint histories that reject stale sequences, replay, foreign invocations, repository mismatch, capability loss, and policy or ticket drift before mutation.
- Supports block, release, active or historical takeover, and replacement while retaining candidate provenance and audit history for fresh-clone reconstruction.
- Tightens mailbox lifecycle and transition validation so ordinary release/reclaim remains distinct while an explicitly receipted atomic takeover is recognized narrowly.

This is intentionally published as one oversized changeset at the operator's direction because the coordinator, mailbox invariants, lifecycle validation, and executable contract form one protocol boundary.

## Tickets

Fixes #778
