### PR TITLE
docs(repository): describe production audit boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,10 @@ The [Atelier as a Skill], [Git Mailbox Contract], [Project Policy Contract], and
 ## Current state
 
 The repository is a reset scaffold. The `/atelier` skill implements one
-GitHub-backed planning assignment and one claimed, delegated `ready_pr` work
-path. Production `audit` is not implemented. The open native issue graph
-beginning at #772 defines implementation order.
+GitHub-backed planning assignment, one claimed, delegated `ready_pr` work path,
+and production audit plus explicit operator acceptance for one delivered or
+accepted assignment. The open native issue graph beginning at #772 defines
+implementation order.
 
 Do not claim unavailable behavior or emulate it with ad hoc orchestration.
 


### PR DESCRIPTION
## TL;DR

Updates Atelier’s authoritative current-state instructions to reflect its implemented, bounded production audit and explicit operator-acceptance capability.

## Summary

- Replaces the stale claim that production audit is unavailable with the implemented boundary for one delivered or accepted assignment.
- Preserves the reset scaffold, planning and delegation scope, and every existing architecture, authority, storage, and non-goal boundary.
- Leaves runtime behavior, providers, policy, mailbox schemas, tests, the #781 runbook, and post-v0 work unchanged.

## Validation

- `just lint`
- `just test`
- Repository-owned exact-head review: clean

## Tickets

Fixes #796