### PR TITLE
fix(delegation): finalize stale blocked recovery

### DIFF
--- a/contract_tests/test_claiming.py
+++ b/contract_tests/test_claiming.py
@@ -2687,6 +2687,35 @@ print(json.dumps(value, sort_keys=True))
             "candidate pull request metadata lacks exact pre-mutation authority",
             denial["reason"],
         )
+        git(
+            self.project_checkout,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit",
+            "--allow-empty",
+            "-m",
+            "Advance canonical base after denied acknowledgement",
+        )
+        git(self.project_checkout, "push", "origin", "HEAD:main")
+        current_base = git(self.project_checkout, "rev-parse", "HEAD").stdout.strip()
+        self.assertNotEqual(current_base, advanced_invocation["repository"]["base_sha"])
+        stale_checkpoint = self.delegated_request(
+            advanced_invocation,
+            advanced_push,
+            action="repository.candidate.push",
+            candidate=recoverable_candidate,
+        )
+        stale_denial = self.assert_checkpoint_denied_without_mutation(
+            advanced_delegation,
+            advanced_invocation,
+            stale_checkpoint,
+        )
+        self.assertIn(
+            "delegated invocation base is stale against the current repository",
+            stale_denial["reason"],
+        )
         advanced_blocked_result = self.blocked_result(
             advanced_invocation,
             advanced_push,
@@ -2701,6 +2730,25 @@ print(json.dumps(value, sort_keys=True))
             "Release and reclaim the exact pushed candidate.",
             "Obtain fresh pull_request.update authority before restoring the existing PR.",
         ]
+        ordinary_blocked = json.loads(json.dumps(advanced_blocked_result))
+        ordinary_blocked["unresolved_obligations"] = []
+        with self.assertRaisesRegex(
+            MailboxTransitionRejected,
+            "delegated invocation base is stale against the current repository",
+        ):
+            advanced_delegation.finalize(
+                self.work_id,
+                advanced_invocation,
+                ordinary_blocked,
+                self.fence(advanced_push),
+                approved_commit=self.approved_commit,
+                policy_target=self.policy_target(),
+                host_target=self.delegation_host_target(),
+                observation_path=self.observation_path,
+                observation_not_before=self.live_at,
+                ended_at=self.live_at + timedelta(minutes=3),
+                now=self.live_at + timedelta(minutes=3),
+            )
         advanced_delegation.finalize(
             self.work_id,
             advanced_invocation,
@@ -2753,7 +2801,12 @@ print(json.dumps(value, sort_keys=True))
         self.assertIsNone(blocked_receipt["candidate"]["pull_request"])
         self.assertEqual(
             blocked_receipt["unresolved_obligations"],
-            advanced_blocked_result["unresolved_obligations"],
+            [
+                *advanced_blocked_result["unresolved_obligations"],
+                "Delegated invocation base "
+                f"{advanced_invocation['repository']['base_sha']} is stale against "
+                f"current canonical base {current_base}.",
+            ],
         )
         self.assertEqual(prior_receipt["candidate"]["pull_request"], pull_request_url)
 
@@ -2769,18 +2822,90 @@ print(json.dumps(value, sort_keys=True))
         final_claim = self.claim(token="ready-pr-token-0")
         final_delegation = self.delegation()
         final_invocation = self.delegated_invocation(final_claim)
+        self.assertEqual(final_invocation["repository"]["base_sha"], current_base)
         replacement_pull_request_url = pull_request_url
+        current_head = git(
+            self.project_checkout,
+            "-c",
+            "user.name=Atelier Test",
+            "-c",
+            "user.email=atelier-test@invalid",
+            "commit-tree",
+            candidate_tree,
+            "-p",
+            current_base,
+            "-m",
+            "Rebase denied acknowledgement candidate onto current main",
+        ).stdout.strip()
+        current_candidate = {
+            **advanced_candidate,
+            "base_sha": current_base,
+            "head_sha": current_head,
+        }
         replacement_terminal_candidate = json.loads(json.dumps(advanced_terminal_candidate))
+        replacement_terminal_candidate.update(current_candidate)
         replacement_pull_request = replacement_terminal_candidate["publication"]["pull_requests"][0]
         replacement_pull_request["id"] = "794"
         replacement_pull_request["url"] = replacement_pull_request_url
-        replacement_authorized = self.delegated_checkpoint(
+        replacement_pull_request["base_sha"] = current_base
+        replacement_pull_request["head_sha"] = current_head
+        current_push = self.delegated_checkpoint(
             final_delegation,
             final_invocation,
             final_claim,
-            action="pull_request.update",
+            action="repository.candidate.push",
             token="ready-pr-token-1",
-            candidate=advanced_candidate,
+            candidate=current_candidate,
+        )
+        git(
+            self.project_checkout,
+            "push",
+            "--force",
+            "origin",
+            f"{current_head}:{candidate_ref}",
+        )
+        current_acknowledged = self.delegated_checkpoint(
+            final_delegation,
+            final_invocation,
+            current_push,
+            action="repository.candidate.push",
+            phase="candidate_published",
+            token="ready-pr-token-2",
+            candidate={
+                **current_candidate,
+                "publication": {"kind": "ordinary", "pull_requests": []},
+            },
+        )
+        replacement_authorized = self.delegated_checkpoint(
+            final_delegation,
+            final_invocation,
+            current_acknowledged,
+            action="pull_request.update",
+            token="ready-pr-token-3",
+            candidate=current_candidate,
+        )
+        current_repush = self.delegated_checkpoint(
+            final_delegation,
+            final_invocation,
+            replacement_authorized,
+            action="repository.candidate.push",
+            token="ready-pr-token-4",
+            candidate=current_candidate,
+        )
+        git(
+            self.project_checkout,
+            "push",
+            "origin",
+            f"{current_head}:{candidate_ref}",
+        )
+        pr_acknowledged = self.delegated_checkpoint(
+            final_delegation,
+            final_invocation,
+            current_repush,
+            action="repository.candidate.push",
+            phase="candidate_published",
+            token="ready-pr-token-5",
+            candidate=replacement_terminal_candidate,
         )
 
         live = observation(with_pull_request=True)
@@ -2789,10 +2914,10 @@ print(json.dumps(value, sort_keys=True))
         )
         live["pull_request"]["url"] = replacement_pull_request_url
         live["pull_request"]["base"].update(
-            ref=final_invocation["repository"]["base_ref"], sha=advanced_candidate["base_sha"]
+            ref=final_invocation["repository"]["base_ref"], sha=current_base
         )
         live["pull_request"]["head"].update(
-            ref=advanced_candidate["remote_ref"], sha=advanced_head
+            ref=current_candidate["remote_ref"], sha=current_head
         )
         write_json(self.observation_path, live)
         ready_result = {
@@ -2817,14 +2942,14 @@ print(json.dumps(value, sort_keys=True))
             "candidate": replacement_terminal_candidate,
             "handoff": {"transferable": True, "reason": None},
             "checkpoint": {
-                "last_sequence": replacement_authorized.sequence,
-                "continuation_token": replacement_authorized.continuation_token,
+                "last_sequence": pr_acknowledged.sequence,
+                "continuation_token": pr_acknowledged.continuation_token,
             },
             "validation": [
                 {
                     "name": command,
                     "outcome": "passed",
-                    "candidate_sha": advanced_head,
+                    "candidate_sha": current_head,
                     "observed_at": fixtures.TIMESTAMP,
                 }
                 for command in final_invocation["validation"]
@@ -2833,17 +2958,17 @@ print(json.dumps(value, sort_keys=True))
                 {
                     "name": "review-code-change",
                     "outcome": "passed",
-                    "candidate_sha": advanced_head,
+                    "candidate_sha": current_head,
                     "observed_at": fixtures.TIMESTAMP,
                 }
             ],
             "feedback": {
                 "unresolved_material_count": 0,
-                "candidate_sha": advanced_head,
+                "candidate_sha": current_head,
                 "observed_at": fixtures.TIMESTAMP,
             },
-            "authority_used": ["pull_request.update"],
-            "acceptance_evidence": self.acceptance_records(final_invocation, advanced_head),
+            "authority_used": ["repository.candidate.push", "pull_request.update"],
+            "acceptance_evidence": self.acceptance_records(final_invocation, current_head),
             "unresolved_obligations": [],
             "blocking_reason": None,
             "next_action": "Atelier validates the inherited ready pull request.",
@@ -2852,7 +2977,7 @@ print(json.dumps(value, sort_keys=True))
             self.work_id,
             final_invocation,
             ready_result,
-            self.fence(replacement_authorized),
+            self.fence(pr_acknowledged),
             approved_commit=self.approved_commit,
             policy_target=self.policy_target(),
             host_target=self.delegation_host_target(),
@@ -2870,7 +2995,7 @@ print(json.dumps(value, sort_keys=True))
         )
         reconstruct_mailbox(delivered_checkout)
         self.assertEqual(delivered_work["status"], "delivered")
-        self.assertEqual(delivered_work["claim"]["candidate"]["head_revision"], advanced_head)
+        self.assertEqual(delivered_work["claim"]["candidate"]["head_revision"], current_head)
         self.assertEqual(
             delivered_work["claim"]["candidate"]["pull_request"],
             replacement_pull_request_url,
@@ -2880,7 +3005,13 @@ print(json.dumps(value, sort_keys=True))
                 (entry["phase"], entry["action"])
                 for entry in delivered_work["claim"]["checkpoint"]["authorizations"]
             ],
-            [("pre_external_mutation", "pull_request.update")],
+            [
+                ("pre_external_mutation", "repository.candidate.push"),
+                ("candidate_published", "repository.candidate.push"),
+                ("pre_external_mutation", "pull_request.update"),
+                ("pre_external_mutation", "repository.candidate.push"),
+                ("candidate_published", "repository.candidate.push"),
+            ],
         )
 
     def test_delegation_delivers_one_exact_ready_pull_request(self) -> None:

--- a/skills/atelier/references/delegation.md
+++ b/skills/atelier/references/delegation.md
@@ -65,6 +65,15 @@ match the still-open current native ticket before recording a receipt.
   blocked receipt atomically, records one unresolved planner decision, and retains
   mutation ownership. A later attempt still needs fresh exact PR authority before
   it can publish or restore PR metadata.
+- If installing that recovery advances canonical main beyond the sealed invocation
+  base, only this same terminal blocked recovery may finalize across the stale base.
+  The replacement must still be the final exact authorized push on the inherited
+  repository, remote, and ref, must assert no PR metadata, and must retain unresolved
+  obligations. The receipt records both base revisions as a durable obligation.
+  Checkpoints, ordinary blocked results, and delivery remain current-base-only. A
+  fresh claimant may advance the recovered candidate to current main only through
+  an exact push and `candidate_published` acknowledgement before restoring PR
+  metadata under fresh exact authority.
 - `requires_epic` is recorded as a blocked attempt for planner action. Atelier
   does not invoke `implement-epic` from delegated work.
 

--- a/skills/atelier/scripts/delegation.py
+++ b/skills/atelier/scripts/delegation.py
@@ -409,10 +409,20 @@ class DelegationCoordinator:
                 observation_not_before=observation_not_before,
                 now=now,
             )
-            _require_current_invocation_contract(invocation, state)
             if state.work["status"] != "active":
                 raise MailboxTransitionRejected(f"{work_id}: terminal result requires active work")
             claim = copy.deepcopy(_require_fence(state.work, fence))
+            stale_base_recovery = _stale_base_blocked_recovery(
+                invocation,
+                result,
+                claim,
+                current_base=state.current_policy.commit,
+            )
+            _require_current_invocation_contract(
+                invocation,
+                state,
+                allow_stale_base=stale_base_recovery,
+            )
             if claim["invocation_digest"] != _canonical_digest(invocation):
                 raise MailboxTransitionRejected(
                     "delegated invocation does not match its sealed digest"
@@ -421,6 +431,17 @@ class DelegationCoordinator:
                 raise MailboxTransitionRejected("terminal ticket observation is not current")
             _require_tracker_transition(result, state.observation)
             evidence = _attempt_evidence(result)
+            if stale_base_recovery:
+                evidence = AttemptEvidence(
+                    validation=evidence.validation,
+                    reviews=evidence.reviews,
+                    unresolved_obligations=(
+                        *evidence.unresolved_obligations,
+                        "Delegated invocation base "
+                        f"{invocation['repository']['base_sha']} is stale against "
+                        f"current canonical base {state.current_policy.commit}.",
+                    ),
+                )
             outcome = "delivered" if terminal == "ready_pr" else "blocked"
             body = (
                 "Delegated candidate delivered."
@@ -876,8 +897,62 @@ def _require_tracker_transition(result: Mapping[str, Any], observation: Mapping[
         )
 
 
+def _stale_base_blocked_recovery(
+    invocation: Mapping[str, Any],
+    result: Mapping[str, Any],
+    claim: Mapping[str, Any],
+    *,
+    current_base: str,
+) -> bool:
+    candidate = result.get("candidate")
+    current = claim.get("candidate")
+    ledger = claim["checkpoint"]["authorizations"]
+    if (
+        invocation["repository"]["base_sha"] == current_base
+        or result["terminal_state"] != "blocked"
+        or result["implementation_state"] != "published"
+        or not result["handoff"]["transferable"]
+        or not result["unresolved_obligations"]
+        or candidate is None
+        or current is None
+        or current["pull_request"] is None
+        or candidate["publication"] != {"kind": "ordinary", "pull_requests": []}
+        or not ledger
+    ):
+        return False
+    candidate_identity = (
+        candidate["repository"],
+        candidate["remote_url"],
+        candidate["remote_ref"],
+        candidate["base_sha"],
+        candidate["head_sha"],
+    )
+    current_identity = (
+        current["repository"],
+        current["remote_url"],
+        current["remote_ref"],
+        current["base_revision"],
+        current["head_revision"],
+    )
+    last = ledger[-1]
+    return (
+        candidate_identity != current_identity
+        and candidate["repository"] == invocation["repository"]["identity"]
+        and candidate["remote_url"] == invocation["repository"]["remote_url"]
+        and candidate["base_sha"] == invocation["repository"]["base_sha"]
+        and candidate["remote_ref"] != invocation["repository"]["base_ref"]
+        and last["phase"] == "pre_external_mutation"
+        and last["action"] == "repository.candidate.push"
+        and last["candidate_head"] == candidate["head_sha"]
+        and last["candidate_remote_ref"] == candidate["remote_ref"]
+    )
+
+
 def _require_current_invocation_contract(
-    invocation: Mapping[str, Any], state: Any
+    invocation: Mapping[str, Any],
+    state: Any,
+    *,
+    allow_stale_base: bool = False,
 ) -> None:
     policy = state.effective_policy
     current_acceptance = list(policy["acceptance"]["evidence"])
@@ -888,7 +963,10 @@ def _require_current_invocation_contract(
         raise MailboxTransitionRejected(
             "delegated invocation repository does not match the current project"
         )
-    if invocation["repository"]["base_sha"] != state.current_policy.commit:
+    if (
+        invocation["repository"]["base_sha"] != state.current_policy.commit
+        and not allow_stale_base
+    ):
         raise MailboxTransitionRejected(
             "delegated invocation base is stale against the current repository"
         )

--- a/skills/atelier/scripts/mailbox.py
+++ b/skills/atelier/scripts/mailbox.py
@@ -989,6 +989,17 @@ def _validate_claim(
         and ledger[-1]["candidate_head"] == candidate["head_revision"]
         and ledger[-1]["candidate_remote_ref"] == candidate["remote_ref"]
     )
+    latest_candidate_publication = next(
+        (entry for entry in reversed(ledger) if entry["phase"] == "candidate_published"),
+        None,
+    )
+    acknowledged_current_candidate = (
+        candidate is not None
+        and latest_candidate_publication is not None
+        and latest_candidate_publication["acknowledged_candidate_head"]
+        == candidate["head_revision"]
+        and latest_candidate_publication["candidate_remote_ref"] == candidate["remote_ref"]
+    )
 
     inherited_receipt_id = claim["inherited_receipt_id"]
     inherited_receipt = (
@@ -1012,6 +1023,10 @@ def _validate_claim(
                 not same_lineage(inherited_receipt["candidate"], candidate)
                 and not (
                     recovered_current_candidate
+                    and same_remote_lineage(inherited_receipt["candidate"], candidate)
+                )
+                and not (
+                    acknowledged_current_candidate
                     and same_remote_lineage(inherited_receipt["candidate"], candidate)
                 )
             )
@@ -1222,7 +1237,7 @@ def _validate_claim(
     acknowledged_same_lineage_advance = (
         inherited_candidate_source is not None
         and candidate is not None
-        and same_lineage(inherited_candidate_source, candidate)
+        and same_remote_lineage(inherited_candidate_source, candidate)
         and bool(publication_entries)
         and publication_entries[-1]["candidate_head"] == candidate["head_revision"]
         and publication_entries[-1]["candidate_remote_ref"] == candidate["remote_ref"]


### PR DESCRIPTION
## TL;DR

Atelier can now truthfully finalize the exact denied-publication blocked recovery after canonical main advances, while keeping every other stale-base path closed.

## Summary

- Permit only the exact terminal blocked recovery proven by the final authorized candidate push.
- Persist both the sealed invocation base and current canonical base in durable obligations.
- Keep stale checkpoints, ordinary blocked results, and delivery paths rejected.
- Cover fresh-clone release, current-main adoption, exact PR authorization, and ready-PR delivery.

## Tickets

Fixes #800